### PR TITLE
feat: store M2 program entitlement per project

### DIFF
--- a/client/src/components/admin/WinnersTable.tsx
+++ b/client/src/components/admin/WinnersTable.tsx
@@ -208,6 +208,18 @@ export function WinnersTable({ projects, onRefresh, connectedAddress }: WinnersT
     return project.bountyPrize.reduce((sum: number, b: BountyPrize) => sum + b.amount, 0);
   };
 
+  // Calculate total M2 entitlement (M1 + M2 grants)
+  const getM2Entitlement = (project: any) => {
+    const entitlement = project.m2Entitlement;
+    if (!entitlement) return 0;
+    return (entitlement.milestone1Amount || 0) + (entitlement.milestone2Amount || 0);
+  };
+
+  // Check if project is in M2 program
+  const isM2Project = (project: any) => {
+    return project.m2Status || project.m2Entitlement;
+  };
+
   // Open manage modal with project data
   const openManageModal = (project: any) => {
     const bounty = project.bountyPrize?.[0];
@@ -588,6 +600,11 @@ export function WinnersTable({ projects, onRefresh, connectedAddress }: WinnersT
                             {project.bountyPrize.map((b: BountyPrize, idx: number) => (
                               <div key={idx}>${b.amount.toLocaleString()}</div>
                             ))}
+                          </div>
+                        )}
+                        {isM2Project(project) && getM2Entitlement(project) > 0 && (
+                          <div className="text-xs text-green-600 font-medium">
+                            + ${getM2Entitlement(project).toLocaleString()} M2 grant
                           </div>
                         )}
                       </div>

--- a/server/api/repositories/project.repository.js
+++ b/server/api/repositories/project.repository.js
@@ -24,6 +24,11 @@ const transformProject = (row) => {
             eventStartedAt: row.hackathon_event_started_at
         },
         m2Status: row.m2_status,
+        m2Entitlement: (row.m2_milestone_1_amount !== null || row.m2_milestone_2_amount !== null) ? {
+            milestone1Amount: row.m2_milestone_1_amount,
+            milestone2Amount: row.m2_milestone_2_amount,
+            currency: row.m2_currency
+        } : undefined,
         m2Agreement: row.m2_status ? {
             mentorName: row.m2_mentor_name,
             agreedDate: row.m2_agreed_date,
@@ -106,6 +111,11 @@ const toSupabaseProject = (data) => {
 
     // M2 fields
     if (data.m2Status !== undefined) row.m2_status = data.m2Status;
+    if (data.m2Entitlement) {
+        if (data.m2Entitlement.milestone1Amount !== undefined) row.m2_milestone_1_amount = data.m2Entitlement.milestone1Amount;
+        if (data.m2Entitlement.milestone2Amount !== undefined) row.m2_milestone_2_amount = data.m2Entitlement.milestone2Amount;
+        if (data.m2Entitlement.currency !== undefined) row.m2_currency = data.m2Entitlement.currency;
+    }
     if (data.m2Agreement) {
         if (data.m2Agreement.mentorName !== undefined) row.m2_mentor_name = data.m2Agreement.mentorName;
         if (data.m2Agreement.agreedDate !== undefined) row.m2_agreed_date = data.m2Agreement.agreedDate;

--- a/supabase/migrations/20260415000000_add_m2_entitlement_fields.sql
+++ b/supabase/migrations/20260415000000_add_m2_entitlement_fields.sql
@@ -1,0 +1,10 @@
+-- Add M2 entitlement fields to projects table
+-- This stores the planned M2 program entitlement per project (M1 grant + M2 grant amounts)
+
+ALTER TABLE projects
+ADD COLUMN IF NOT EXISTS m2_milestone_1_amount NUMERIC,
+ADD COLUMN IF NOT EXISTS m2_milestone_2_amount NUMERIC,
+ADD COLUMN IF NOT EXISTS m2_currency TEXT CHECK (m2_currency IN ('USDC', 'DOT')) DEFAULT 'USDC';
+
+-- Add indexes for the new fields
+CREATE INDEX IF NOT EXISTS idx_projects_m2_entitlement ON projects(m2_milestone_1_amount, m2_milestone_2_amount);


### PR DESCRIPTION
## Summary
This PR adds schema support for storing M2 program entitlements per project and updates the WinnersTable to display them.

## Changes

### 1. Schema Migration (`supabase/migrations/20260415000000_add_m2_entitlement_fields.sql`)
- Added `m2_milestone_1_amount` (NUMERIC) - M1 grant amount
- Added `m2_milestone_2_amount` (NUMERIC) - M2 grant amount  
- Added `m2_currency` (TEXT) - currency for M2 payments (USDC/DOT)
- Added index for efficient queries

### 2. API Layer (`server/api/repositories/project.repository.js`)
- Updated `transformProject` to expose `m2Entitlement` object with `milestone1Amount`, `milestone2Amount`, `currency`
- Updated `toSupabaseProject` to handle writing m2Entitlement fields

### 3. UI Layer (`client/src/components/admin/WinnersTable.tsx`)
- Added `getM2Entitlement()` helper to calculate total M2 grant
- Added `isM2Project()` helper to check if project is in M2 program
- Updated Amount column to show "+ $X M2 grant" for M2 projects with entitlement values

## Acceptance Criteria Met
- [x] Schema stores planned M2 entitlement per project
- [x] Supabase migration adds the columns
- [x] `transformProject` exposes new fields in camelCase
- [x] WinnersTable Amount column renders bounty sum + M2 entitlement for M2 rows

## Out of Scope
- Backfilling historical entitlement values (separate data task)
- Changing bounty amount storage