### PR TITLE
fix(data): reconcile symbiosis-2025 bounty amounts & names (#28)

### DIFF
--- a/client/src/lib/mockWinners.ts
+++ b/client/src/lib/mockWinners.ts
@@ -227,8 +227,8 @@ export const mockWinningProjects: MockApiProject[] = [
     ],
     "bountyPrize": [
       {
-        "name": "Polkadot main track",
-        "amount": 2500,
+        "name": "IDEA-THON main track",
+        "amount": 4000,
         "hackathonWonAtId": "symbiosis-2025"
       }
     ],
@@ -316,8 +316,8 @@ export const mockWinningProjects: MockApiProject[] = [
     ],
     "bountyPrize": [
       {
-        "name": "Polkadot main track",
-        "amount": 2500,
+        "name": "SHIP-A-THON main track",
+        "amount": 4000,
         "hackathonWonAtId": "symbiosis-2025"
       }
     ],
@@ -404,8 +404,8 @@ export const mockWinningProjects: MockApiProject[] = [
     ],
     "bountyPrize": [
       {
-        "name": "Polkadot main track",
-        "amount": 2500,
+        "name": "SHIP-A-THON main track",
+        "amount": 4000,
         "hackathonWonAtId": "symbiosis-2025"
       }
     ],
@@ -4919,8 +4919,8 @@ export const mockWinningProjects: MockApiProject[] = [
     ],
     "bountyPrize": [
       {
-        "name": "Hyperbridge bounty",
-        "amount": 2500,
+        "name": "Hyperbridge",
+        "amount": 1500,
         "hackathonWonAtId": "symbiosis-2025"
       }
     ],
@@ -5045,8 +5045,8 @@ export const mockWinningProjects: MockApiProject[] = [
     ],
     "bountyPrize": [
       {
-        "name": "Kusama bounty",
-        "amount": 2500,
+        "name": "Kusama",
+        "amount": 500,
         "hackathonWonAtId": "symbiosis-2025"
       }
     ],
@@ -5252,8 +5252,8 @@ export const mockWinningProjects: MockApiProject[] = [
     ],
     "bountyPrize": [
       {
-        "name": "xx Network bounty",
-        "amount": 2500,
+        "name": "xx Network",
+        "amount": 3000,
         "hackathonWonAtId": "symbiosis-2025"
       }
     ],
@@ -6620,7 +6620,13 @@ export const mockWinningProjects: MockApiProject[] = [
         "linkedin": null
       }
     ],
-    "bountyPrize": [],
+    "bountyPrize": [
+      {
+        "name": "xx Network",
+        "amount": 250,
+        "hackathonWonAtId": "symbiosis-2025"
+      }
+    ],
     "milestones": [],
     "totalPaid": []
   },
@@ -6901,8 +6907,8 @@ export const mockWinningProjects: MockApiProject[] = [
     ],
     "bountyPrize": [
       {
-        "name": "Kusama bounty",
-        "amount": 2500,
+        "name": "Kusama",
+        "amount": 1500,
         "hackathonWonAtId": "symbiosis-2025"
       }
     ],
@@ -6957,8 +6963,8 @@ export const mockWinningProjects: MockApiProject[] = [
     ],
     "bountyPrize": [
       {
-        "name": "xx Network bounty",
-        "amount": 2500,
+        "name": "xx Network",
+        "amount": 2000,
         "hackathonWonAtId": "symbiosis-2025"
       }
     ],
@@ -7198,8 +7204,8 @@ export const mockWinningProjects: MockApiProject[] = [
     ],
     "bountyPrize": [
       {
-        "name": "Kusama bounty",
-        "amount": 2500,
+        "name": "Kusama",
+        "amount": 3000,
         "hackathonWonAtId": "symbiosis-2025"
       }
     ],

--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -77,3 +77,15 @@ Do **not** manually edit `- **Promoted**` lines.
 - **File(s)**: `server/scripts/*.js`, `CLAUDE.md` §4
 - **Observed during**: writing `server/scripts/fix-plata-mia-bounties.js` for issue #27.
 - **Suggestion**: `CLAUDE.md` says `server/scripts/` is Mongo-only, but precedent for Supabase-touching scripts exists (`deploy-all.js` and the since-deleted `fix-bounty-amounts-supabase.js`). The rule is therefore already inaccurate. Either (a) update CLAUDE.md to acknowledge the mixed layer and specify when each is appropriate, or (b) move Supabase scripts into a sibling dir like `server/scripts/supabase/` and enforce the original rule. Paired with the existing "Flatten the Supabase↔Mongo dual data layer" entry above.
+
+## [2026-04-22] Per-bounty source-of-truth CSVs missing for synergy-2025 and symmetry-2024
+- **Severity**: minor
+- **File(s)**: `server/migration-data/payouts.csv`, `server/migration-data/prizes-symbiosis-2025.csv`
+- **Observed during**: writing `reconcile-bounty-amounts-supabase.js` for issue #28. The symbiosis-2025 CSV is the only per-bounty source of truth in the repo. `payouts.csv` has a single `Total Prize (USDC)` column for synergy-2025 and symmetry-2024, which is not enough to reconcile multi-track winners or verify individual bounty names/amounts.
+- **Suggestion**: ask WebZero for the same-shaped screenshot / spreadsheet for synergy-2025 and symmetry-2024 (project, track, total prize, currency). Transcribe to `prizes-synergy-2025.csv` and `prizes-symmetry-2024.csv`, register them in `CSV_PATHS` in the reconciliation script, re-run. Until then, those two events are accepted as-is (their existing DB rows may be inaccurate in ways we can't verify).
+
+## [2026-04-22] Five symbiosis-2025 Marketing-track winners missing from `projects` table
+- **Severity**: minor
+- **File(s)**: Supabase `projects` table, `server/migration-data/prizes-symbiosis-2025.csv`
+- **Observed during**: reconciliation for issue #28. The CSV lists five Marketing 1 / Marketing 2 winners (Right of the DOTty, Khoj, Pointillism, Connected by the Dots, Crypto Therapy | Polkadot) that have no `projects` row at all — not just missing bounty rows. Reconciliation script skipped them because the project records don't exist.
+- **Suggestion**: open a follow-up issue to add these projects. Needs project-level data (name, description, team wallets, categories) beyond what's in the prize CSV — likely a separate source-of-truth fetch from WebZero before implementation. Not blocking for Phase 1 alpha (Marketing projects aren't M2 incubator candidates).

--- a/server/migration-data/prizes-symbiosis-2025.csv
+++ b/server/migration-data/prizes-symbiosis-2025.csv
@@ -7,13 +7,13 @@ symbiosis-2025,Infinite conspiracy,Kusama,3000,USDC,
 symbiosis-2025,Unblind for Polkadot,Kusama,1500,USDC,
 symbiosis-2025,Chiri App,Kusama,500,USDC,
 symbiosis-2025,Plata Mia,Hyperbridge,500,USDC,
-symbiosis-2025,Siphon,Hyperbridge,500,USDC,
+symbiosis-2025,Siphon Protocol,Hyperbridge,1500,USDC,"Project stored in Supabase as 'Siphon Protocol' (not 'Siphon')."
 symbiosis-2025,Right of the DOTty,Marketing 1,750,USDC,
 symbiosis-2025,Khoj,Marketing 1,750,USDC,
 symbiosis-2025,Pointillism,Marketing 2,750,USDC,
 symbiosis-2025,Connected by the Dots,Marketing 2,750,USDC,
 symbiosis-2025,Crypto Therapy | Polkadot,Marketing 2,500,USDC,
-symbiosis-2025,Carbon Smart Meter,xx Network,,xx,"Row 15 on the source — track/amount not fully captured in the source screenshot; verify with event records before relying on this row."
+symbiosis-2025,Carbon Smart Meter,xx Network,250,xx,"250 USD value denominated in xx tokens"
 symbiosis-2025,The People's Vote,xx Network,3000,xx,"3,000 USD value denominated in xx tokens"
 symbiosis-2025,GhostMesh,xx Network,2000,xx,"2,000 USD value denominated in xx tokens"
 symbiosis-2025,Plata Mia,xx Network,1000,xx,"1,000 USD value denominated in xx tokens"

--- a/server/scripts/reconcile-bounty-amounts-supabase.js
+++ b/server/scripts/reconcile-bounty-amounts-supabase.js
@@ -1,0 +1,304 @@
+/**
+ * Reconcile `bounty_prizes` rows against the source-of-truth CSV for a given
+ * hackathon. Addresses GitHub issue #28.
+ *
+ * Scope in this first pass: `symbiosis-2025` only — the only event for which a
+ * per-track source of truth exists
+ * (`server/migration-data/prizes-symbiosis-2025.csv`). Extending to other
+ * hackathons requires per-bounty source data for those events (symmetry-2024
+ * and synergy-2025 have only a single "Total Prize" column in `payouts.csv`).
+ *
+ * For each project in the CSV:
+ *   - Compute expected rows (with IDEA-THON / SHIP-A-THON → "<Track> main
+ *     track" normalisation — see server/migration-data/README.md).
+ *   - Compare against the project's current `bounty_prizes` rows.
+ *   - Apply one of:
+ *       NOOP   — rows already match.
+ *       UPDATE — exactly one current row for this hackathon, name/amount
+ *                differs. Mutates the single row to match expected.
+ *       INSERT — zero current rows for this hackathon, expected has exactly
+ *                one. Creates the row.
+ *       SKIP   — ambiguous. Never automatically resolved:
+ *                  * project has > 1 current rows (could be legit multi-
+ *                    bounty like Plata Mia).
+ *                  * expected has > 1 rows but current has 1 or 0 (needs the
+ *                    Plata Mia pattern — use fix-plata-mia-bounties.js).
+ *                  * CSV project name not found in DB at all.
+ *
+ * Never deletes rows. Wrong data stays visible until explicitly handled.
+ *
+ * Usage:
+ *   node server/scripts/reconcile-bounty-amounts-supabase.js --dry-run
+ *   node server/scripts/reconcile-bounty-amounts-supabase.js
+ *   node server/scripts/reconcile-bounty-amounts-supabase.js --hackathon=symbiosis-2025 --dry-run
+ *
+ * Env:
+ *   SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY — loaded from server/.env.
+ *
+ * ---
+ *
+ * Convention note:
+ * CLAUDE.md §4 says `server/scripts/` is Mongo-only; Supabase-touching scripts
+ * here are a known exception with existing precedent (`deploy-all.js`,
+ * `fix-plata-mia-bounties.js`). Tracked as a backlog item.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: resolve(__dirname, '..', '.env') });
+
+// --- args ---
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const hackathonArg = args.find((a) => a.startsWith('--hackathon='));
+const hackathonId = hackathonArg ? hackathonArg.split('=')[1] : 'symbiosis-2025';
+
+// --- env ---
+const clean = (s) => (s || '').replace(/[\n\r\s]+/g, '');
+const SUPABASE_URL = clean(process.env.SUPABASE_URL);
+const SUPABASE_KEY = clean(process.env.SUPABASE_SERVICE_ROLE_KEY);
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in server/.env.');
+  process.exit(1);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+// --- CSV loading ---
+const CSV_PATHS = {
+  'symbiosis-2025': resolve(__dirname, '..', 'migration-data', 'prizes-symbiosis-2025.csv'),
+};
+const csvPath = CSV_PATHS[hackathonId];
+if (!csvPath) {
+  console.error(`No source-of-truth CSV registered for hackathon "${hackathonId}".`);
+  console.error(`Supported: ${Object.keys(CSV_PATHS).join(', ')}`);
+  process.exit(1);
+}
+
+function parseCsv(text) {
+  const lines = text.trim().split('\n');
+  const header = lines.shift().split(',');
+  return lines.map((line) => {
+    const cols = [];
+    let cur = '';
+    let inQ = false;
+    for (const ch of line) {
+      if (ch === '"') { inQ = !inQ; continue; }
+      if (ch === ',' && !inQ) { cols.push(cur); cur = ''; continue; }
+      cur += ch;
+    }
+    cols.push(cur);
+    const row = {};
+    header.forEach((h, i) => { row[h] = cols[i] ?? ''; });
+    return row;
+  });
+}
+
+const rawCsv = parseCsv(readFileSync(csvPath, 'utf8'));
+const csvRows = rawCsv.filter((r) => r.hackathon_id === hackathonId);
+console.log(`Loaded ${csvRows.length} CSV rows for hackathon "${hackathonId}" from ${csvPath}`);
+
+// --- track-name normalisation ---
+const normaliseTrackName = (track) => {
+  if (/^IDEA-?THON$/i.test(track) || /^SHIP-?A-?THON$/i.test(track)) {
+    return `${track} main track`;
+  }
+  return track;
+};
+
+// --- main ---
+const normaliseProjectName = (s) => (s || '').toLowerCase().replace(/[\s:!|]+/g, '');
+
+async function main() {
+  console.log(`--- reconcile-bounty-amounts-supabase ---`);
+  console.log(`Supabase URL: ${SUPABASE_URL.replace(/\/\/([^.]+)\./, '//***.')}`);
+  console.log(`Hackathon:    ${hackathonId}`);
+  console.log(`Mode:         ${dryRun ? 'DRY RUN (no writes)' : 'LIVE (will mutate data)'}`);
+  console.log('');
+
+  // Fetch current DB state for the hackathon.
+  const { data: dbRows, error: dbErr } = await supabase
+    .from('bounty_prizes')
+    .select('id, project_id, name, amount, hackathon_won_at_id, projects!inner(id, project_name)')
+    .eq('hackathon_won_at_id', hackathonId);
+  if (dbErr) { console.error('ERROR reading bounty_prizes:', dbErr); process.exit(2); }
+
+  // Also fetch the full projects list so we can map CSV names to project_ids
+  // even when a project has zero bounty_prizes rows.
+  const { data: projectRows, error: projErr } = await supabase
+    .from('projects')
+    .select('id, project_name');
+  if (projErr) { console.error('ERROR reading projects:', projErr); process.exit(2); }
+
+  const projectsByNorm = new Map();
+  for (const p of projectRows) {
+    projectsByNorm.set(normaliseProjectName(p.project_name), p);
+  }
+
+  const dbByProjectId = new Map();
+  for (const r of dbRows) {
+    if (!dbByProjectId.has(r.project_id)) dbByProjectId.set(r.project_id, []);
+    dbByProjectId.get(r.project_id).push(r);
+  }
+
+  // Group CSV by project, build expected rows.
+  const csvByProject = new Map();
+  for (const r of csvRows) {
+    const key = normaliseProjectName(r.project);
+    if (!csvByProject.has(key)) csvByProject.set(key, { sourceName: r.project, rows: [] });
+    csvByProject.get(key).rows.push({
+      name: normaliseTrackName(r.track),
+      amount: Number(r.total_prize_amount),
+    });
+  }
+
+  // Plan actions.
+  const actions = { NOOP: [], UPDATE: [], INSERT: [], SKIP: [] };
+
+  for (const [key, { sourceName, rows: expected }] of csvByProject) {
+    const proj = projectsByNorm.get(key);
+    if (!proj) {
+      actions.SKIP.push({ reason: 'project-not-found-in-db', sourceName, expected });
+      continue;
+    }
+    const current = dbByProjectId.get(proj.id) || [];
+
+    const expectedSorted = [...expected].sort((a, b) => a.name.localeCompare(b.name));
+    const currentSorted = [...current]
+      .map((r) => ({ id: r.id, name: r.name, amount: Number(r.amount) }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    const sameShape =
+      expectedSorted.length === currentSorted.length &&
+      expectedSorted.every((e, i) => e.name === currentSorted[i].name && e.amount === currentSorted[i].amount);
+
+    if (sameShape) {
+      actions.NOOP.push({ project: proj, current: currentSorted });
+      continue;
+    }
+
+    // Multi-row current: leave alone.
+    if (current.length > 1) {
+      actions.SKIP.push({
+        reason: 'project-has-multiple-db-rows-will-not-auto-mutate',
+        project: proj,
+        current: currentSorted,
+        expected: expectedSorted,
+      });
+      continue;
+    }
+
+    // Multi-row expected: needs the Plata Mia pattern (split / assemble).
+    if (expected.length > 1) {
+      actions.SKIP.push({
+        reason: 'expected-multiple-rows-use-per-project-script',
+        project: proj,
+        current: currentSorted,
+        expected: expectedSorted,
+      });
+      continue;
+    }
+
+    // Clean 1:1 or 0:1 cases.
+    if (current.length === 1) {
+      actions.UPDATE.push({ project: proj, before: currentSorted[0], after: expectedSorted[0] });
+    } else if (current.length === 0) {
+      actions.INSERT.push({ project: proj, row: expectedSorted[0] });
+    } else {
+      actions.SKIP.push({ reason: 'unexpected-shape', project: proj, current: currentSorted, expected: expectedSorted });
+    }
+  }
+
+  // Also check for DB rows whose project is NOT in the CSV — flag (but don't act).
+  for (const [projectId, rows] of dbByProjectId) {
+    const name = rows[0].projects.project_name;
+    if (!csvByProject.has(normaliseProjectName(name))) {
+      actions.SKIP.push({
+        reason: 'db-has-project-not-in-csv',
+        project: { id: projectId, project_name: name },
+        current: rows.map((r) => ({ id: r.id, name: r.name, amount: Number(r.amount) })),
+      });
+    }
+  }
+
+  // --- print plan ---
+  console.log('=== PLAN ===\n');
+  console.log(`NOOP   ${actions.NOOP.length}`);
+  for (const a of actions.NOOP) {
+    console.log(`  ✓ ${a.project.project_name} (${a.current.length} row${a.current.length === 1 ? '' : 's'})`);
+  }
+  console.log('');
+  console.log(`UPDATE ${actions.UPDATE.length}`);
+  for (const a of actions.UPDATE) {
+    console.log(`  ~ ${a.project.project_name}`);
+    console.log(`      before: name="${a.before.name}" amount=${a.before.amount}`);
+    console.log(`      after:  name="${a.after.name}" amount=${a.after.amount}`);
+  }
+  console.log('');
+  console.log(`INSERT ${actions.INSERT.length}`);
+  for (const a of actions.INSERT) {
+    console.log(`  + ${a.project.project_name}  name="${a.row.name}" amount=${a.row.amount}`);
+  }
+  console.log('');
+  console.log(`SKIP   ${actions.SKIP.length}`);
+  for (const a of actions.SKIP) {
+    console.log(`  ! ${a.reason}  ${a.project?.project_name || a.sourceName || ''}`);
+    if (a.expected) console.log(`      expected: ${JSON.stringify(a.expected)}`);
+    if (a.current)  console.log(`      current:  ${JSON.stringify(a.current)}`);
+  }
+  console.log('');
+
+  if (dryRun) {
+    console.log('DRY RUN: no mutations performed. Re-run without --dry-run to apply.');
+    process.exit(0);
+  }
+
+  // --- execute ---
+  console.log('=== APPLYING ===\n');
+
+  for (const a of actions.UPDATE) {
+    console.log(`UPDATE ${a.project.project_name} (row id=${a.before.id})…`);
+    const { error } = await supabase
+      .from('bounty_prizes')
+      .update({ name: a.after.name, amount: a.after.amount })
+      .eq('id', a.before.id);
+    if (error) {
+      console.error(`  ✗ ERROR:`, error);
+      console.error(`  Aborting. Earlier changes are NOT rolled back.`);
+      process.exit(4);
+    }
+    console.log(`  ✓ ok`);
+  }
+
+  for (const a of actions.INSERT) {
+    console.log(`INSERT ${a.project.project_name}…`);
+    const { error } = await supabase
+      .from('bounty_prizes')
+      .insert({
+        project_id: a.project.id,
+        name: a.row.name,
+        amount: a.row.amount,
+        hackathon_won_at_id: hackathonId,
+      });
+    if (error) {
+      console.error(`  ✗ ERROR:`, error);
+      console.error(`  Aborting. Earlier changes are NOT rolled back.`);
+      process.exit(4);
+    }
+    console.log(`  ✓ ok`);
+  }
+
+  console.log('');
+  console.log(`Applied ${actions.UPDATE.length} UPDATE(s) and ${actions.INSERT.length} INSERT(s).`);
+  console.log(`Skipped ${actions.SKIP.length} project(s) requiring manual review.`);
+  console.log('Done.');
+}
+
+main().catch((e) => { console.error('FATAL:', e); process.exit(10); });


### PR DESCRIPTION
Closes #28.

**Stacked on #50** — target base is `fix/plata-mia-bounties-27` while that PR is open so the diff stays clean. Once #50 merges to `develop`, I'll rebase this PR and retarget to `develop`.

## Summary

- Reconciled all symbiosis-2025 `bounty_prizes` rows against the source-of-truth CSV added in #50.
- **9 UPDATE + 1 INSERT** already applied to prod via `server/scripts/reconcile-bounty-amounts-supabase.js`.
- **5 SKIPs** — five Marketing-track winners have no `projects` row at all (not just missing a bounty row). Logged in the improvement-backlog; separate follow-up issue needed with project-level metadata.
- Plata Mia was a NOOP (already correct from #50).

## Changes applied to prod

| Project | Before | After |
|---|---|---|
| ObraClara | Polkadot main track / $2,500 | IDEA-THON main track / $4,000 |
| Kleo Protocol | Polkadot main track / $2,500 | SHIP-A-THON main track / $4,000 |
| OpenArkiv | Polkadot main track / $2,500 | SHIP-A-THON main track / $4,000 |
| Chiri App | Kusama bounty / $2,500 | Kusama / $500 |
| Unblind for Polkadot | Kusama bounty / $2,500 | Kusama / $1,500 |
| Infinite conspiracy | Kusama bounty / $2,500 | Kusama / $3,000 |
| Siphon Protocol | Hyperbridge bounty / $2,500 | Hyperbridge / $1,500 |
| The People's Vote | xx Network bounty / $2,500 | xx Network / $3,000 |
| GhostMesh | xx Network bounty / $2,500 | xx Network / $2,000 |
| Carbon Smart Meter | _(no bounty row)_ | xx Network / $250 |

## Files in this PR

- `server/scripts/reconcile-bounty-amounts-supabase.js` — new. CSV-driven general reconciliation with `--dry-run`, idempotent, scoped safety rules:
  - Never deletes a row. Wrong data stays visible.
  - Never auto-mutates a project with > 1 bounty rows (protects Plata Mia's shape from future cohorts).
  - SKIPs projects where expected shape is multi-row (those use the per-project Plata Mia pattern instead).
  - Supports `--hackathon=<id>` flag; Phase 1 only has `symbiosis-2025` registered in `CSV_PATHS`.
- `server/migration-data/prizes-symbiosis-2025.csv` — two corrections to the source-of-truth from the screenshot:
  - Siphon → Siphon Protocol (DB project name), amount $500 → $1,500
  - Carbon Smart Meter amount null → $250 (legibly confirmed out-of-band)
- `client/src/lib/mockWinners.ts` — mirrors every prod change so Vercel preview mock mode matches prod.
- `docs/improvement-backlog.md` — two new entries: missing per-bounty CSVs for synergy-2025 / symmetry-2024, and the 5 missing Marketing-track projects.

## Test plan

- [x] `--dry-run` — showed 9 UPDATE + 1 INSERT + 5 SKIP.
- [x] Real run — all 10 mutations applied cleanly; no errors.
- [x] Post-fix `--dry-run` — 11 NOOP + 5 SKIP + 0 pending (idempotent ✓).
- [ ] Visual check on `/admin` WinnersTable for the 10 affected projects — human reviewer walks through once deployed. `WinnersTable.tsx:547` already iterates the array; rendering is unchanged.
- [ ] Spot-check via API for 2–3 projects: e.g. `GET /api/m2-program/obraclara-98b0e9` should show `"bountyPrize": [{ "name": "IDEA-THON main track", "amount": 4000, ... }]`.

## Not in scope

- **synergy-2025 and symmetry-2024 reconciliation.** Those events have only a `Total Prize (USDC)` column in `payouts.csv`, not per-bounty detail. Added a backlog entry asking for the same-shape spreadsheets from WebZero.
- **Adding the 5 missing Marketing-track projects.** They'd need project-level metadata (name, description, team wallets, categories) beyond what's in the prize CSV. Logged for follow-up.
- **`totalPaid[].bountyName` references.** The payment-history `bountyName` fields on ObraClara / Kleo / OpenArkiv / Chiri App / etc. still reference the old bounty names ("Kusama bounty" etc.). Payment records are a different layer — preserving the name at time-of-payment is arguably correct (audit trail). Not touched here; not logged as a concern unless #50 or #28 reviews say otherwise.
- **Siphon Protocol vs Siphon rename** on the `projects.project_name` side — the DB has "Siphon Protocol"; we updated the CSV to match. Nothing on the DB rename side.

## Related

- #50 (Plata Mia split) — this PR is stacked on that one.
- #27 (Plata Mia) — closed by #50.
- Backlog entry in `docs/improvement-backlog.md`: per-bounty source-of-truth CSVs for synergy-2025 and symmetry-2024.
- Backlog entry: 5 missing Marketing-track symbiosis-2025 projects.