### PR TITLE
feat(revamp): Block A — programs foundation (closes #36 #37 #38)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,6 +12,7 @@ import AdminPage from "./pages/AdminPage";
 import NotFound from "./pages/NotFound";
 import { useEffect } from "react";
 import WinnersPage from "./pages/WinnersPage";
+import ProgramsPage from "./pages/ProgramsPage";
 
 // Redirect component for old project routes
 const ProjectRedirect = () => {
@@ -54,6 +55,7 @@ const App = () => {
               <Route path="/" element={<Layout />}>
                 <Route index element={<HomePage />} />
                 <Route path="m2-program" element={<M2ProgramPage />} />
+                <Route path="programs" element={<ProgramsPage />} />
                 {/* Redirect old past-projects route to homepage */}
                 <Route path="past-projects" element={<Navigate to="/" replace />} />
                 <Route path="admin" element={<AdminPage />} />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,6 +13,7 @@ import NotFound from "./pages/NotFound";
 import { useEffect } from "react";
 import WinnersPage from "./pages/WinnersPage";
 import ProgramsPage from "./pages/ProgramsPage";
+import ProgramDetailPage from "./pages/ProgramDetailPage";
 
 // Redirect component for old project routes
 const ProjectRedirect = () => {
@@ -63,6 +64,7 @@ const App = () => {
                 <Route path="projects" element={<Navigate to="/m2-program" replace />} />
               </Route>
               <Route path="m2-program/:id" element={<ProjectDetailsPage />} />
+              <Route path="programs/:slug" element={<ProgramDetailPage />} />
               <Route path="winners/:hackathon" element={<WinnersPage />} />
               {/* Redirect old project detail route */}
               <Route path="projects/:id" element={<ProjectRedirect />} />

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -1,6 +1,6 @@
 import { Link, useLocation } from "react-router-dom"
 import { Button } from "@/components/ui/button"
-import { Wrench, Home, Menu, Shield } from "lucide-react"
+import { Wrench, Home, Menu, Shield, Sparkles } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { useState } from "react"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
@@ -13,6 +13,7 @@ export function Navigation() {
   const navItems = [
     { href: "/", label: "Home", icon: Home },
     { href: "/m2-program", label: "M2 Program", icon: Wrench },
+    { href: "/programs", label: "Programs", icon: Sparkles },
     { href: "/admin", label: "Admin", icon: Shield },
   ]
 

--- a/client/src/components/ProgramCard.tsx
+++ b/client/src/components/ProgramCard.tsx
@@ -1,0 +1,81 @@
+import { Link } from "react-router-dom";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Calendar, MapPin } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ApiProgram } from "@/lib/api";
+
+const formatDateRange = (from?: string | null, to?: string | null) => {
+  if (!from && !to) return null;
+  const fmt = (iso?: string | null) =>
+    iso
+      ? new Date(iso).toLocaleDateString(undefined, {
+          year: "numeric",
+          month: "short",
+          day: "numeric",
+        })
+      : "—";
+  return `${fmt(from)} – ${fmt(to)}`;
+};
+
+const programTypeLabel = (t: ApiProgram["programType"]) => {
+  switch (t) {
+    case "dogfooding":
+      return "Dogfooding";
+    case "pitch_off":
+      return "Pitch Off";
+    case "hackathon":
+      return "Hackathon";
+    case "m2_incubator":
+      return "M2 Incubator";
+    default:
+      return t;
+  }
+};
+
+export function ProgramCard({ program }: { program: ApiProgram }) {
+  const eventRange = formatDateRange(program.eventStartsAt, program.eventEndsAt);
+
+  return (
+    <Link
+      to={`/programs/${program.slug}`}
+      className={cn(
+        "group block focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-lg",
+      )}
+      aria-label={`${program.name} — open program details`}
+    >
+      <Card className="h-full transition-all duration-200 hover:border-primary/50 hover:shadow-md">
+        <CardHeader className="flex flex-row items-start justify-between gap-3">
+          <div className="min-w-0">
+            <CardTitle className="truncate text-lg">{program.name}</CardTitle>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {programTypeLabel(program.programType)}
+            </p>
+          </div>
+          <Badge variant={program.status === "open" ? "default" : "secondary"}>
+            {program.status}
+          </Badge>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {program.description && (
+            <p className="text-sm text-muted-foreground line-clamp-3">{program.description}</p>
+          )}
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+            {eventRange && (
+              <span className="inline-flex items-center gap-1">
+                <Calendar className="h-3.5 w-3.5" aria-hidden="true" />
+                {eventRange}
+              </span>
+            )}
+            {program.location && (
+              <span className="inline-flex items-center gap-1">
+                <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+                {program.location}
+              </span>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/client/src/components/admin/ProgramsTable.tsx
+++ b/client/src/components/admin/ProgramsTable.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useState } from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Loader2 } from "lucide-react";
+import { api, type ApiProgram } from "@/lib/api";
+
+const statusVariant = (status: ApiProgram["status"]) => {
+  switch (status) {
+    case "open":
+      return "default" as const;
+    case "draft":
+      return "secondary" as const;
+    case "closed":
+    case "completed":
+      return "outline" as const;
+    default:
+      return "secondary" as const;
+  }
+};
+
+const formatDateRange = (from?: string | null, to?: string | null) => {
+  if (!from && !to) return "—";
+  const fmt = (iso?: string | null) =>
+    iso ? new Date(iso).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" }) : "—";
+  return `${fmt(from)} → ${fmt(to)}`;
+};
+
+export function ProgramsTable() {
+  const [programs, setPrograms] = useState<ApiProgram[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    api
+      .listPrograms()
+      .then((r) => {
+        if (active) setPrograms(r.data);
+      })
+      .catch((e: unknown) => {
+        if (active) setError(e instanceof Error ? e.message : "Failed to load programs");
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">Programs</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground py-6">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            Loading programs…
+          </div>
+        ) : error ? (
+          <p className="text-sm text-destructive py-6">{error}</p>
+        ) : programs.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-6">
+            No programs yet — create one to open applications to past winners.
+          </p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Type</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Applications window</TableHead>
+                <TableHead>Event</TableHead>
+                <TableHead>Location</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {programs.map((p) => (
+                <TableRow key={p.id}>
+                  <TableCell className="font-medium">{p.name}</TableCell>
+                  <TableCell className="text-muted-foreground">{p.programType}</TableCell>
+                  <TableCell>
+                    <Badge variant={statusVariant(p.status)}>{p.status}</Badge>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground whitespace-nowrap">
+                    {formatDateRange(p.applicationsOpenAt, p.applicationsCloseAt)}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground whitespace-nowrap">
+                    {formatDateRange(p.eventStartsAt, p.eventEndsAt)}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">{p.location || "—"}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -125,6 +125,25 @@ export type ApiProject = {
   }>;
 };
 
+/** Shape of a row in the `programs` table (Phase 1 revamp). */
+export type ApiProgram = {
+  id: string;
+  name: string;
+  slug: string;
+  programType: "dogfooding" | "pitch_off" | "hackathon" | "m2_incubator";
+  description?: string | null;
+  status: "draft" | "open" | "closed" | "completed";
+  owner: string;
+  applicationsOpenAt?: string | null;
+  applicationsCloseAt?: string | null;
+  eventStartsAt?: string | null;
+  eventEndsAt?: string | null;
+  location?: string | null;
+  maxApplicants?: number | null;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
 export const api = {
   submitEntry: async (data: unknown) => {
     if (USE_MOCK_DATA) {
@@ -623,6 +642,32 @@ export const api = {
       headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : { "Content-Type": "application/json" },
       body: JSON.stringify(data)
     });
+  },
+
+  /**
+   * Phase 1 revamp: programs (Dogfooding, M2, etc.). See
+   * docs/stadium-revamp-phase-1-spec.md §4.1.
+   */
+  listPrograms: async (params?: { status?: ApiProgram["status"] }): Promise<{ status: string; data: ApiProgram[] }> => {
+    if (USE_MOCK_DATA) {
+      const { mockPrograms } = await import("./mockPrograms");
+      const filtered = params?.status
+        ? mockPrograms.filter((p) => p.status === params.status)
+        : mockPrograms;
+      return { status: "success", data: filtered };
+    }
+    const qs = params?.status ? `?status=${encodeURIComponent(params.status)}` : "";
+    return request(`/programs${qs}`);
+  },
+
+  getProgramBySlug: async (slug: string): Promise<{ status: string; data: ApiProgram }> => {
+    if (USE_MOCK_DATA) {
+      const { mockPrograms } = await import("./mockPrograms");
+      const program = mockPrograms.find((p) => p.slug === slug);
+      if (!program) throw new ApiError("Program not found", 404);
+      return { status: "success", data: program };
+    }
+    return request(`/programs/${encodeURIComponent(slug)}`);
   },
 };
 

--- a/client/src/lib/mockPrograms.ts
+++ b/client/src/lib/mockPrograms.ts
@@ -1,0 +1,13 @@
+/**
+ * Mock fixture for the `programs` table. Read in preview mode when
+ * VITE_USE_MOCK_DATA=true. Real data comes from Supabase via /api/programs.
+ *
+ * Extended across Block A of the Phase 1 revamp:
+ *   - Issue #36 (this file, empty) — fixture placeholder so the admin table
+ *     can render an empty state in preview mode.
+ *   - Issue #37 — Dogfooding 2026 added (public /programs surface).
+ */
+
+import type { ApiProgram } from "./api";
+
+export const mockPrograms: ApiProgram[] = [];

--- a/client/src/lib/mockPrograms.ts
+++ b/client/src/lib/mockPrograms.ts
@@ -3,11 +3,29 @@
  * VITE_USE_MOCK_DATA=true. Real data comes from Supabase via /api/programs.
  *
  * Extended across Block A of the Phase 1 revamp:
- *   - Issue #36 (this file, empty) — fixture placeholder so the admin table
- *     can render an empty state in preview mode.
- *   - Issue #37 — Dogfooding 2026 added (public /programs surface).
+ *   - Issue #36 — fixture introduced (empty).
+ *   - Issue #37 — Dogfooding 2026 added for public /programs surface.
  */
 
 import type { ApiProgram } from "./api";
 
-export const mockPrograms: ApiProgram[] = [];
+export const mockPrograms: ApiProgram[] = [
+  {
+    id: "dogfooding-2026-berlin",
+    name: "Dogfooding 2026",
+    slug: "dogfooding-2026-berlin",
+    programType: "dogfooding",
+    description:
+      "A week in Berlin for past WebZero winners. Bring the thing you've been building, show it to the rest of the cohort, get structured feedback from builders who've shipped. No pitches, no sponsor deck — just a room full of people who want to help your project feel more real.",
+    status: "open",
+    owner: "webzero",
+    applicationsOpenAt: "2026-04-22T00:00:00Z",
+    applicationsCloseAt: "2026-05-30T23:59:59Z",
+    eventStartsAt: "2026-06-13T00:00:00Z",
+    eventEndsAt: "2026-06-19T23:59:59Z",
+    location: "Berlin",
+    maxApplicants: null,
+    createdAt: "2026-04-22T00:00:00Z",
+    updatedAt: "2026-04-22T00:00:00Z",
+  },
+];

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -42,6 +42,7 @@ import { SiwsMessage } from '@talismn/siws';
 import { generateSiwsStatement, type SiwsContext } from '@/lib/siwsUtils';
 import { M2ProjectsTable } from "@/components/admin/M2ProjectsTable";
 import { WinnersTable } from "@/components/admin/WinnersTable";
+import { ProgramsTable } from "@/components/admin/ProgramsTable";
 import { ConfirmPaymentModal } from "@/components/admin/ConfirmPaymentModal";
 import { ConfirmM1PayoutModal } from "@/components/admin/ConfirmM1PayoutModal";
 import { TestPaymentModal } from "@/components/admin/TestPaymentModal";
@@ -898,10 +899,14 @@ const AdminPage = () => {
             </Select>
           </div>
         </div>
-        <M2ProjectsTable 
-          projects={sortedProjects || []} 
+        <M2ProjectsTable
+          projects={sortedProjects || []}
           onPaymentClick={handlePaymentClick}
         />
+      </section>
+
+      <section className="mb-8">
+        <ProgramsTable />
       </section>
 
       {/* M1 Payout Modal */}

--- a/client/src/pages/ProgramDetailPage.tsx
+++ b/client/src/pages/ProgramDetailPage.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import { Navigation } from "@/components/Navigation";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Calendar, MapPin, Loader2, Wallet } from "lucide-react";
+import { api, type ApiProgram, ApiError } from "@/lib/api";
+
+const formatDateRange = (from?: string | null, to?: string | null) => {
+  if (!from && !to) return null;
+  const fmt = (iso?: string | null) =>
+    iso
+      ? new Date(iso).toLocaleDateString(undefined, {
+          year: "numeric",
+          month: "short",
+          day: "numeric",
+        })
+      : "—";
+  return `${fmt(from)} – ${fmt(to)}`;
+};
+
+const programTypeLabel = (t?: ApiProgram["programType"]) => {
+  switch (t) {
+    case "dogfooding":
+      return "Dogfooding";
+    case "pitch_off":
+      return "Pitch Off";
+    case "hackathon":
+      return "Hackathon";
+    case "m2_incubator":
+      return "M2 Incubator";
+    default:
+      return t;
+  }
+};
+
+const ProgramDetailPage = () => {
+  const { slug } = useParams<{ slug: string }>();
+  const [program, setProgram] = useState<ApiProgram | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!slug) return;
+    let active = true;
+    setLoading(true);
+    setNotFound(false);
+    setError(null);
+    api
+      .getProgramBySlug(slug)
+      .then((r) => {
+        if (active) setProgram(r.data);
+      })
+      .catch((e: unknown) => {
+        if (!active) return;
+        if (e instanceof ApiError && e.status === 404) {
+          setNotFound(true);
+        } else {
+          setError(e instanceof Error ? e.message : "Failed to load program");
+        }
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [slug]);
+
+  const applicationsRange = formatDateRange(
+    program?.applicationsOpenAt,
+    program?.applicationsCloseAt,
+  );
+  const eventRange = formatDateRange(program?.eventStartsAt, program?.eventEndsAt);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navigation />
+      <main className="container mx-auto px-4 pt-24 pb-16">
+        {loading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground py-16">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            Loading program…
+          </div>
+        ) : notFound ? (
+          <div className="mx-auto max-w-lg rounded-lg border bg-card p-8 text-center">
+            <h1 className="font-heading text-2xl font-bold">Program not found</h1>
+            <p className="mt-2 text-muted-foreground">
+              We couldn&apos;t find a program with that URL. It may have been removed or
+              renamed.
+            </p>
+            <Button asChild className="mt-4">
+              <Link to="/programs">Back to programs</Link>
+            </Button>
+          </div>
+        ) : error ? (
+          <p className="text-sm text-destructive py-16">{error}</p>
+        ) : program ? (
+          <article className="mx-auto max-w-3xl">
+            <header className="mb-6">
+              <p className="text-sm text-muted-foreground">
+                {programTypeLabel(program.programType)}
+              </p>
+              <h1 className="mt-1 font-heading text-3xl font-bold md:text-4xl">
+                {program.name}
+              </h1>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <Badge variant={program.status === "open" ? "default" : "secondary"}>
+                  {program.status}
+                </Badge>
+                {program.location && (
+                  <span className="inline-flex items-center gap-1 text-sm text-muted-foreground">
+                    <MapPin className="h-3.5 w-3.5" aria-hidden="true" />
+                    {program.location}
+                  </span>
+                )}
+              </div>
+            </header>
+
+            {program.description && (
+              <p className="mb-6 text-base text-muted-foreground whitespace-pre-line">
+                {program.description}
+              </p>
+            )}
+
+            <Card className="mb-6">
+              <CardHeader>
+                <CardTitle className="text-lg">Key dates</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2 text-sm">
+                {applicationsRange && (
+                  <div className="flex items-center gap-2">
+                    <Calendar className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                    <span className="text-muted-foreground">Applications:</span>
+                    <span>{applicationsRange}</span>
+                  </div>
+                )}
+                {eventRange && (
+                  <div className="flex items-center gap-2">
+                    <Calendar className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                    <span className="text-muted-foreground">Event:</span>
+                    <span>{eventRange}</span>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              {/*
+                Apply CTA is disabled for unauthenticated visitors. The wallet-
+                connected / team-member flow lands in #44 (Issue 9). Until then
+                it's a read-only signal that an apply path exists.
+              */}
+              <Button disabled className="gap-2">
+                <Wallet className="h-4 w-4" aria-hidden="true" />
+                Sign in with wallet to apply
+              </Button>
+              <p className="text-xs text-muted-foreground sm:ml-2">
+                Applications open to past WebZero winners who are on a Stadium project team.
+              </p>
+            </div>
+          </article>
+        ) : null}
+      </main>
+    </div>
+  );
+};
+
+export default ProgramDetailPage;

--- a/client/src/pages/ProgramsPage.tsx
+++ b/client/src/pages/ProgramsPage.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+import { Navigation } from "@/components/Navigation";
+import { ProgramCard } from "@/components/ProgramCard";
+import { api, type ApiProgram } from "@/lib/api";
+import { Loader2 } from "lucide-react";
+
+const ProgramsPage = () => {
+  const [programs, setPrograms] = useState<ApiProgram[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+    api
+      .listPrograms({ status: "open" })
+      .then((r) => {
+        if (active) setPrograms(r.data);
+      })
+      .catch((e: unknown) => {
+        if (active) setError(e instanceof Error ? e.message : "Failed to load programs");
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navigation />
+      <main className="container mx-auto px-4 pt-24 pb-16">
+        <header className="mb-8">
+          <h1 className="font-heading text-3xl font-bold md:text-4xl">Programs</h1>
+          <p className="mt-2 text-muted-foreground">
+            Programs currently open for applications from past WebZero winners.
+          </p>
+        </header>
+
+        {loading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground py-10">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            Loading programs…
+          </div>
+        ) : error ? (
+          <p className="text-sm text-destructive py-10">{error}</p>
+        ) : programs.length === 0 ? (
+          <div className="rounded-lg border bg-card p-8 text-center">
+            <p className="text-muted-foreground">
+              Nothing open right now. Check back soon.
+            </p>
+          </div>
+        ) : (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {programs.map((p) => (
+              <ProgramCard key={p.id} program={p} />
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default ProgramsPage;

--- a/server/api/controllers/__tests__/program.controller.test.js
+++ b/server/api/controllers/__tests__/program.controller.test.js
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the service module before importing the controller.
+vi.mock('../../services/program.service.js', () => ({
+  default: {
+    list: vi.fn(),
+    findBySlug: vi.fn(),
+  },
+}));
+
+const programService = (await import('../../services/program.service.js')).default;
+const programController = (await import('../program.controller.js')).default;
+
+const mockRes = () => {
+  const res = {};
+  res.status = vi.fn(() => res);
+  res.json = vi.fn(() => res);
+  return res;
+};
+
+describe('ProgramController.list', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 with an empty data array when no programs exist', async () => {
+    programService.list.mockResolvedValue([]);
+    const req = { query: {} };
+    const res = mockRes();
+    await programController.list(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ status: 'success', data: [] });
+    expect(programService.list).toHaveBeenCalledWith({ status: undefined });
+  });
+
+  it('returns 200 with the list when programs exist', async () => {
+    const programs = [
+      { id: 'dogfooding-2026', name: 'Dogfooding 2026', slug: 'dogfooding-2026', status: 'open' },
+    ];
+    programService.list.mockResolvedValue(programs);
+    const req = { query: {} };
+    const res = mockRes();
+    await programController.list(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ status: 'success', data: programs });
+  });
+
+  it('forwards a valid status filter to the service', async () => {
+    programService.list.mockResolvedValue([]);
+    const req = { query: { status: 'open' } };
+    const res = mockRes();
+    await programController.list(req, res);
+    expect(programService.list).toHaveBeenCalledWith({ status: 'open' });
+  });
+
+  it('returns 400 for an invalid status filter', async () => {
+    const req = { query: { status: 'bogus' } };
+    const res = mockRes();
+    await programController.list(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(programService.list).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when the service throws', async () => {
+    programService.list.mockRejectedValue(new Error('boom'));
+    const req = { query: {} };
+    const res = mockRes();
+    await programController.list(req, res);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});
+
+describe('ProgramController.getBySlug', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 200 with the program when found', async () => {
+    const program = { id: 'dogfooding-2026', slug: 'dogfooding-2026', name: 'Dogfooding 2026' };
+    programService.findBySlug.mockResolvedValue(program);
+    const req = { params: { slug: 'dogfooding-2026' } };
+    const res = mockRes();
+    await programController.getBySlug(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ status: 'success', data: program });
+  });
+
+  it('returns 404 when the program is not found', async () => {
+    programService.findBySlug.mockResolvedValue(null);
+    const req = { params: { slug: 'nonexistent' } };
+    const res = mockRes();
+    await programController.getBySlug(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+});

--- a/server/api/controllers/program.controller.js
+++ b/server/api/controllers/program.controller.js
@@ -1,0 +1,33 @@
+import programService from '../services/program.service.js';
+
+class ProgramController {
+  async list(req, res) {
+    try {
+      const { status } = req.query;
+      if (status && !['draft', 'open', 'closed', 'completed'].includes(status)) {
+        return res.status(400).json({ status: 'error', message: `Invalid status filter: ${status}` });
+      }
+      const programs = await programService.list({ status });
+      res.status(200).json({ status: 'success', data: programs });
+    } catch (error) {
+      console.error('❌ Error listing programs:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to list programs' });
+    }
+  }
+
+  async getBySlug(req, res) {
+    try {
+      const { slug } = req.params;
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      res.status(200).json({ status: 'success', data: program });
+    } catch (error) {
+      console.error('❌ Error fetching program:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to fetch program' });
+    }
+  }
+}
+
+export default new ProgramController();

--- a/server/api/repositories/program.repository.js
+++ b/server/api/repositories/program.repository.js
@@ -1,0 +1,47 @@
+import { supabase } from '../../db.js';
+
+// Transform Supabase row (snake_case) to API format (camelCase).
+const transformProgram = (row) => {
+  if (!row) return null;
+  return {
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    programType: row.program_type,
+    description: row.description,
+    status: row.status,
+    owner: row.owner,
+    applicationsOpenAt: row.applications_open_at,
+    applicationsCloseAt: row.applications_close_at,
+    eventStartsAt: row.event_starts_at,
+    eventEndsAt: row.event_ends_at,
+    location: row.location,
+    maxApplicants: row.max_applicants,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+};
+
+class ProgramRepository {
+  async list({ status } = {}) {
+    let query = supabase.from('programs').select('*').order('created_at', { ascending: false });
+    if (status) query = query.eq('status', status);
+    const { data, error } = await query;
+    if (error) throw error;
+    return (data || []).map(transformProgram);
+  }
+
+  async findById(id) {
+    const { data, error } = await supabase.from('programs').select('*').eq('id', id).maybeSingle();
+    if (error) throw error;
+    return transformProgram(data);
+  }
+
+  async findBySlug(slug) {
+    const { data, error } = await supabase.from('programs').select('*').eq('slug', slug).maybeSingle();
+    if (error) throw error;
+    return transformProgram(data);
+  }
+}
+
+export default new ProgramRepository();

--- a/server/api/routes/program.routes.js
+++ b/server/api/routes/program.routes.js
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import programController from '../controllers/program.controller.js';
+
+const router = Router();
+
+// --- Public, Read-Only Routes ---
+router.get('/', programController.list);
+router.get('/:slug', programController.getBySlug);
+
+export default router;

--- a/server/api/services/program.service.js
+++ b/server/api/services/program.service.js
@@ -1,0 +1,18 @@
+import programRepository from '../repositories/program.repository.js';
+
+class ProgramService {
+  async list(queryParams = {}) {
+    const { status } = queryParams;
+    return await programRepository.list({ status });
+  }
+
+  async findById(id) {
+    return await programRepository.findById(id);
+  }
+
+  async findBySlug(slug) {
+    return await programRepository.findBySlug(slug);
+  }
+}
+
+export default new ProgramService();

--- a/server/scripts/seed-dogfooding-program.js
+++ b/server/scripts/seed-dogfooding-program.js
@@ -1,0 +1,106 @@
+/**
+ * Idempotent seed for the 2026 Dogfooding program. Inserts one row into the
+ * `programs` table with placeholder-but-realistic metadata. Final copy lands
+ * in issue #48 (alpha readiness).
+ *
+ * Usage:
+ *   node server/scripts/seed-dogfooding-program.js
+ *   node server/scripts/seed-dogfooding-program.js --dry-run
+ *
+ * Env: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY (from server/.env).
+ *
+ * Phase 1 revamp, issue #37. See docs/stadium-revamp-phase-1-spec.md §5.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: resolve(__dirname, '..', '.env') });
+
+const clean = (s) => (s || '').replace(/[\n\r\s]+/g, '');
+const SUPABASE_URL = clean(process.env.SUPABASE_URL);
+const SUPABASE_KEY = clean(process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in server/.env.');
+  process.exit(1);
+}
+
+const dryRun = process.argv.includes('--dry-run');
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+// Dogfooding 2026 (Berlin, June 13–19).
+const ROW = {
+  id: 'dogfooding-2026-berlin',
+  name: 'Dogfooding 2026',
+  slug: 'dogfooding-2026-berlin',
+  program_type: 'dogfooding',
+  description:
+    "A week in Berlin for past WebZero winners. Bring the thing you've been building, show it to the rest of the cohort, get structured feedback from builders who've shipped. No pitches, no sponsor deck — just a room full of people who want to help your project feel more real.",
+  status: 'open',
+  owner: 'webzero',
+  applications_open_at: new Date().toISOString(),
+  // Close a couple of weeks before the event so we have time to review.
+  applications_close_at: '2026-05-30T23:59:59Z',
+  event_starts_at: '2026-06-13T00:00:00Z',
+  event_ends_at: '2026-06-19T23:59:59Z',
+  location: 'Berlin',
+  max_applicants: null,
+};
+
+async function main() {
+  console.log(`--- seed-dogfooding-program ---`);
+  console.log(`Supabase URL: ${SUPABASE_URL.replace(/\/\/([^.]+)\./, '//***.')}`);
+  console.log(`Mode:         ${dryRun ? 'DRY RUN (no writes)' : 'LIVE'}`);
+  console.log('');
+
+  const { data: existing, error: readErr } = await supabase
+    .from('programs')
+    .select('id, name, status')
+    .eq('id', ROW.id)
+    .maybeSingle();
+  if (readErr) {
+    console.error('ERROR reading programs:', readErr);
+    process.exit(2);
+  }
+
+  if (existing) {
+    console.log(`Program already exists: id=${existing.id} name="${existing.name}" status=${existing.status}`);
+    console.log('Nothing to do. Exiting 0.');
+    return;
+  }
+
+  console.log('Planned row:');
+  console.log(`  id=${ROW.id}`);
+  console.log(`  name="${ROW.name}"`);
+  console.log(`  slug=${ROW.slug}`);
+  console.log(`  program_type=${ROW.program_type}`);
+  console.log(`  status=${ROW.status}`);
+  console.log(`  applications: ${ROW.applications_open_at} → ${ROW.applications_close_at}`);
+  console.log(`  event:        ${ROW.event_starts_at} → ${ROW.event_ends_at}`);
+  console.log(`  location:     ${ROW.location}`);
+
+  if (dryRun) {
+    console.log('');
+    console.log('DRY RUN: no insert performed.');
+    return;
+  }
+
+  const { error: insertErr } = await supabase.from('programs').insert(ROW);
+  if (insertErr) {
+    console.error('ERROR inserting program:', insertErr);
+    process.exit(3);
+  }
+  console.log('');
+  console.log(`✓ Inserted ${ROW.id}`);
+}
+
+main().catch((e) => {
+  console.error('FATAL:', e);
+  process.exit(10);
+});

--- a/server/server.js
+++ b/server/server.js
@@ -2,6 +2,7 @@ import express from "express";
 import cors from "cors";
 import connectToSupabase, { supabase } from "./db.js";
 import m2ProgramRoutes from './api/routes/m2-program.routes.js';
+import programRoutes from './api/routes/program.routes.js';
 import requestLogger from './api/middleware/logging.middleware.js';
 import { getAuthorizedAddresses, NETWORK_CONFIG } from './config/polkadot-config.js';
 
@@ -35,6 +36,7 @@ app.use(requestLogger);
 
 // API Routes
 app.use('/api/m2-program', m2ProgramRoutes);
+app.use('/api/programs', programRoutes);
 
 // Backward compatibility: Keep old /api/projects route as alias
 // TODO: Remove after frontend migration is stable
@@ -49,6 +51,7 @@ app.get("/", (req, res) => {
             health: '/api/health',
             healthDb: '/api/health/db',
             projects: '/api/m2-program (or /api/projects)',
+            programs: '/api/programs',
         },
     });
 });

--- a/supabase/migrations/20260422000000_create_programs.sql
+++ b/supabase/migrations/20260422000000_create_programs.sql
@@ -1,0 +1,26 @@
+-- Stadium Phase 1 Revamp — introduce `programs` as a first-class entity.
+-- See docs/stadium-revamp-phase-1-spec.md §4.1 (closes #36).
+--
+-- Additive: creates one new table. Existing M2 / hackathon state on `projects`
+-- remains untouched.
+
+CREATE TABLE IF NOT EXISTS programs (
+  id                    TEXT PRIMARY KEY,
+  name                  TEXT NOT NULL,
+  slug                  TEXT NOT NULL UNIQUE,
+  program_type          TEXT NOT NULL CHECK (program_type IN ('dogfooding', 'pitch_off', 'hackathon', 'm2_incubator')),
+  description           TEXT,
+  status                TEXT NOT NULL CHECK (status IN ('draft', 'open', 'closed', 'completed')),
+  owner                 TEXT NOT NULL DEFAULT 'webzero',
+  applications_open_at  TIMESTAMPTZ,
+  applications_close_at TIMESTAMPTZ,
+  event_starts_at       TIMESTAMPTZ,
+  event_ends_at         TIMESTAMPTZ,
+  location              TEXT,
+  max_applicants        INTEGER,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_programs_status ON programs(status);
+CREATE INDEX IF NOT EXISTS idx_programs_type ON programs(program_type);


### PR DESCRIPTION
Block A of the Phase 1 revamp — three issues shipped as a single PR with one commit each so the block's journey slice is testable end-to-end.

Closes #36, #37, #38.

## Block A journey slice (per spec §12)

*"I can find the Dogfooding program."* Home → top-nav "Programs" → `/programs` → Dogfooding card → `/programs/dogfooding-2026-berlin` → disabled "Sign in with wallet to apply" CTA.

## Commits

### `a796fd7` — #36: programs entity + read-only admin list

Server:
- New migration `supabase/migrations/20260422000000_create_programs.sql` (spec §4.1 schema).
- New `server/api/{repositories,services,controllers,routes}/program*.js`.
- `GET /api/programs` (public, optional `?status=` filter).
- `GET /api/programs/:slug` (public, 404 on miss).
- Wired into `server.js` at `/api/programs`.
- 7 new unit tests in `server/api/controllers/__tests__/program.controller.test.js`.

Client:
- `ApiProgram` type + `api.listPrograms()` + `api.getProgramBySlug()` in `client/src/lib/api.ts` with mock-mode fallbacks.
- Empty `client/src/lib/mockPrograms.ts` fixture.
- `client/src/components/admin/ProgramsTable.tsx` — loading / empty / populated states.
- `client/src/pages/AdminPage.tsx` — Programs section under the existing M2 projects table.

### `030c98b` — #37: seed Dogfooding + public /programs

- `server/scripts/seed-dogfooding-program.js` — idempotent insert, `--dry-run`, real Dogfooding dates (13–19 June 2026, Berlin; applications close 2026-05-30).
- `client/src/lib/mockPrograms.ts` — Dogfooding entry added so preview mode shows the card.
- `client/src/pages/ProgramsPage.tsx` — public `/programs` route.
- `client/src/components/ProgramCard.tsx` — **uses `<Link to="/programs/:slug">` (real anchor)** per spec §3.1. Right-click-open-in-new-tab works. Intentionally does NOT follow the `div[role=button]` pattern used by `/m2-program` cards.
- `client/src/App.tsx` — `/programs` route.
- `client/src/components/Navigation.tsx` — "Programs" link **inserted between `M2 Program` and `Admin`** per spec §5 Issue 2.

### `fe689a9` — #38: /programs/:slug detail page

- `client/src/pages/ProgramDetailPage.tsx` — fetches by slug, renders name, description, program type, status, applications window, event window, location.
- Handles 404 with warm "Program not found" copy + back-to-programs link.
- Apply CTA disabled with "Sign in with wallet to apply" — the real apply flow lands in #44 (Block D).
- `client/src/App.tsx` — `/programs/:slug` route registered outside the `Layout` sibling route pattern (matches ProjectDetailsPage positioning).

## Files changed

19 files: 1 migration, 5 new server files (repository, service, controller, routes, test), 1 updated server file (server.js), 1 new server script (seed), 3 new client pages/components, 1 new client fixture, 2 updated client files (api.ts, Navigation.tsx, App.tsx).

## Test plan

Automated:
- [x] `cd server && npm test` — 20/20 passing (7 new + 13 existing, no regressions).
- [x] `cd client && npm run build` — clean (pre-existing chunk-size + dynamic-import warnings unrelated to this PR).

Stadium-tester (Block A gate, run against the Vercel preview once CI builds it):
- [ ] On `/`, top-nav shows "Stadium / Home / M2 Program / Programs / Admin" in that order.
- [ ] On `/`, the "Programs" link navigates to `/programs`.
- [ ] On `/programs`, visitor sees one "Dogfooding 2026" card with name / type / description visible.
- [ ] On `/programs`, right-click → Open Link in New Tab on the Dogfooding card works (confirms anchor semantics, not `div[role=button]`).
- [ ] On `/programs/dogfooding-2026-berlin`, the detail page shows name, description, applications window, event window, "Berlin".
- [ ] On `/programs/dogfooding-2026-berlin`, un-authenticated visitor sees Apply CTA in disabled state with "Sign in with wallet to apply" copy.
- [ ] On `/programs/nonexistent-slug`, visitor sees the "Program not found" state with a back-to-programs link.
- [ ] `GET /api/programs` returns `200` with `{ data: [...] }`.
- [ ] `GET /api/programs?status=open` filters correctly.
- [ ] `GET /api/programs/dogfooding-2026-berlin` returns the full program; nonexistent slug returns `404`.

Admin-side (SIWS-gated; manual QA):
- [ ] Admin wallet connects to `/admin`; Programs section renders (empty in a fresh environment, populated once the seed script has run).

## Ops

After merge, run the seed script once against each environment:
```
cd server && node scripts/seed-dogfooding-program.js --dry-run   # confirm target
cd server && node scripts/seed-dogfooding-program.js              # apply
```

The script is idempotent — re-running exits cleanly if the row exists.

## Out of scope (deferred per spec)

- Create / edit / delete program flows (#46, Block F).
- Apply-to-program flow with wallet signature (#44, Block D).
- Admin applications queue (#47, Block F).
- Fixing the `/m2-program` card anchor pattern (logged on the backlog; new surfaces use anchors, old ones stay as they are per "additive only" principle).