### PR TITLE
feat(revamp): Block B — project updates (closes #39 #40 #41)

### DIFF
--- a/client/src/components/project/PostUpdateModal.tsx
+++ b/client/src/components/project/PostUpdateModal.tsx
@@ -1,0 +1,218 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
+import { Loader2 } from "lucide-react";
+import { web3Enable, web3Accounts, web3FromSource } from "@polkadot/extension-dapp";
+import { SiwsMessage } from "@talismn/siws";
+import { generateSiwsStatement } from "@/lib/siwsUtils";
+import { api, type ApiProjectUpdate } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+
+const BODY_MIN = 1;
+const BODY_MAX = 2000;
+
+// Mirrors server validateSimpleUrl: accepts www / http / https prefixes.
+const isSimpleUrl = (v: string) =>
+  !v || v.startsWith("www") || v.startsWith("http://") || v.startsWith("https://");
+
+export function PostUpdateModal({
+  open,
+  onOpenChange,
+  projectId,
+  projectTitle,
+  connectedAddress,
+  onPosted,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  projectId: string;
+  projectTitle: string;
+  connectedAddress: string;
+  onPosted: (update: ApiProjectUpdate) => void;
+}) {
+  const [body, setBody] = useState("");
+  const [linkUrl, setLinkUrl] = useState("");
+  const [bodyError, setBodyError] = useState<string | null>(null);
+  const [linkError, setLinkError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const { toast } = useToast();
+
+  const reset = () => {
+    setBody("");
+    setLinkUrl("");
+    setBodyError(null);
+    setLinkError(null);
+    setSubmitting(false);
+  };
+
+  const validate = (): boolean => {
+    let ok = true;
+    const trimmed = body.trim();
+    if (trimmed.length < BODY_MIN) {
+      setBodyError("Body can't be empty.");
+      ok = false;
+    } else if (trimmed.length > BODY_MAX) {
+      setBodyError(`Body must be ${BODY_MAX} characters or fewer (currently ${trimmed.length}).`);
+      ok = false;
+    } else {
+      setBodyError(null);
+    }
+
+    const trimmedLink = linkUrl.trim();
+    if (trimmedLink && !isSimpleUrl(trimmedLink)) {
+      setLinkError("Link must start with http, https, or www.");
+      ok = false;
+    } else {
+      setLinkError(null);
+    }
+
+    return ok;
+  };
+
+  const handleSubmit = async () => {
+    if (!validate()) return;
+    setSubmitting(true);
+    try {
+      await web3Enable("Stadium");
+      const accounts = await web3Accounts();
+      const account = accounts.find((a) => a.address === connectedAddress) || accounts[0];
+      if (!account) throw new Error("No wallet account found");
+
+      const siws = new SiwsMessage({
+        domain: window.location.hostname,
+        uri: window.location.origin,
+        address: account.address,
+        nonce: Math.random().toString(36).slice(2),
+        statement: generateSiwsStatement({ action: "post-update", projectTitle }),
+      });
+      const injector = await web3FromSource(account.meta.source);
+      const signed = (await siws.sign(injector)) as unknown as { signature: string; message?: string };
+      const messageStr =
+        typeof signed.message === "string" && signed.message
+          ? signed.message
+          : (siws as unknown as { toString: () => string }).toString();
+      const authHeader = btoa(
+        JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address }),
+      );
+
+      const res = await api.postProjectUpdate(
+        projectId,
+        { body: body.trim(), linkUrl: linkUrl.trim() || null },
+        authHeader,
+      );
+      onPosted(res.data);
+      toast({ title: "Update posted" });
+      reset();
+      onOpenChange(false);
+    } catch (e) {
+      const err = e as Error;
+      toast({
+        title: "Couldn't post update",
+        description: err?.message || "Unknown error",
+        variant: "destructive",
+      });
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!submitting) {
+          if (!v) reset();
+          onOpenChange(v);
+        }
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Post an update</DialogTitle>
+          <DialogDescription>
+            Share what's shipped, what's changed, or what you're asking for. Updates are visible to
+            anyone viewing your project page.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="post-update-body">Update</Label>
+            <Textarea
+              id="post-update-body"
+              rows={6}
+              maxLength={BODY_MAX + 100 /* allow a little overflow so the error fires */}
+              placeholder="What happened this week?"
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              aria-invalid={bodyError ? true : undefined}
+              aria-describedby="post-update-body-error post-update-body-count"
+            />
+            <div className="flex items-center justify-between text-xs">
+              <span id="post-update-body-error" className="text-destructive">
+                {bodyError || ""}
+              </span>
+              <span
+                id="post-update-body-count"
+                className={
+                  body.trim().length > BODY_MAX ? "text-destructive" : "text-muted-foreground"
+                }
+              >
+                {body.trim().length} / {BODY_MAX}
+              </span>
+            </div>
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="post-update-link">Link (optional)</Label>
+            <Input
+              id="post-update-link"
+              type="url"
+              placeholder="https://…"
+              value={linkUrl}
+              onChange={(e) => setLinkUrl(e.target.value)}
+              aria-invalid={linkError ? true : undefined}
+              aria-describedby="post-update-link-error"
+            />
+            {linkError && (
+              <p id="post-update-link-error" className="text-xs text-destructive">
+                {linkError}
+              </p>
+            )}
+          </div>
+        </div>
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            onClick={() => {
+              if (!submitting) {
+                reset();
+                onOpenChange(false);
+              }
+            }}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={submitting}>
+            {submitting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                Posting…
+              </>
+            ) : (
+              "Post update"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/project/ProjectUpdatesTab.tsx
+++ b/client/src/components/project/ProjectUpdatesTab.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
-import { ExternalLink, Loader2, Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ExternalLink, Loader2, Sparkles, PenSquare } from "lucide-react";
 import { api, type ApiProjectUpdate } from "@/lib/api";
+import { PostUpdateModal } from "@/components/project/PostUpdateModal";
 
 const formatDateTime = (iso: string) => {
   const d = new Date(iso);
@@ -18,10 +20,23 @@ const truncateAddress = (addr: string) => {
   return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
 };
 
-export function ProjectUpdatesTab({ projectId }: { projectId: string }) {
+export function ProjectUpdatesTab({
+  projectId,
+  projectTitle,
+  canPost,
+  connectedAddress,
+}: {
+  projectId: string;
+  projectTitle: string;
+  /** True when the connected wallet is a team member of this project (or admin). */
+  canPost: boolean;
+  /** The wallet address currently connected, if any. Required for canPost=true. */
+  connectedAddress?: string;
+}) {
   const [updates, setUpdates] = useState<ApiProjectUpdate[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
 
   const load = useCallback(() => {
     let active = true;
@@ -48,6 +63,32 @@ export function ProjectUpdatesTab({ projectId }: { projectId: string }) {
     return cleanup;
   }, [load]);
 
+  const handlePosted = (created: ApiProjectUpdate) => {
+    setUpdates((prev) => [created, ...prev]);
+  };
+
+  const postButton =
+    canPost && connectedAddress ? (
+      <div className="flex justify-end">
+        <Button onClick={() => setModalOpen(true)} className="gap-2">
+          <PenSquare className="h-4 w-4" aria-hidden="true" />
+          Post update
+        </Button>
+      </div>
+    ) : null;
+
+  const modal =
+    canPost && connectedAddress ? (
+      <PostUpdateModal
+        open={modalOpen}
+        onOpenChange={setModalOpen}
+        projectId={projectId}
+        projectTitle={projectTitle}
+        connectedAddress={connectedAddress}
+        onPosted={handlePosted}
+      />
+    ) : null;
+
   if (loading) {
     return (
       <div className="flex items-center gap-2 text-sm text-muted-foreground py-10">
@@ -63,44 +104,54 @@ export function ProjectUpdatesTab({ projectId }: { projectId: string }) {
 
   if (updates.length === 0) {
     return (
-      <Card>
-        <CardContent className="py-10 text-center">
-          <Sparkles className="mx-auto h-6 w-6 text-muted-foreground" aria-hidden="true" />
-          <p className="mt-3 text-sm font-medium">Nothing here yet</p>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Your team can post the first update when something ships, pivots, or lands.
-          </p>
-        </CardContent>
-      </Card>
+      <div className="space-y-4">
+        {postButton}
+        <Card>
+          <CardContent className="py-10 text-center">
+            <Sparkles className="mx-auto h-6 w-6 text-muted-foreground" aria-hidden="true" />
+            <p className="mt-3 text-sm font-medium">Nothing here yet</p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {canPost
+                ? "Post the first update when something ships, pivots, or lands."
+                : "Your team can post the first update when something ships, pivots, or lands."}
+            </p>
+          </CardContent>
+        </Card>
+        {modal}
+      </div>
     );
   }
 
   return (
-    <ol className="space-y-4" aria-label="Project updates, most recent first">
-      {updates.map((u) => (
-        <li key={u.id}>
-          <Card>
-            <CardContent className="space-y-3 py-5">
-              <div className="flex items-center justify-between text-xs text-muted-foreground">
-                <span>{truncateAddress(u.createdBy)}</span>
-                <time dateTime={u.createdAt}>{formatDateTime(u.createdAt)}</time>
-              </div>
-              <p className="whitespace-pre-line text-sm leading-relaxed">{u.body}</p>
-              {u.linkUrl && (
-                <a
-                  href={u.linkUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
-                >
-                  <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
-                  {u.linkUrl}
-                </a>
-              )}
-            </CardContent>
-          </Card>
-        </li>
-      ))}
-    </ol>
+    <div className="space-y-4">
+      {postButton}
+      <ol className="space-y-4" aria-label="Project updates, most recent first">
+        {updates.map((u) => (
+          <li key={u.id}>
+            <Card>
+              <CardContent className="space-y-3 py-5">
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                  <span>{truncateAddress(u.createdBy)}</span>
+                  <time dateTime={u.createdAt}>{formatDateTime(u.createdAt)}</time>
+                </div>
+                <p className="whitespace-pre-line text-sm leading-relaxed">{u.body}</p>
+                {u.linkUrl && (
+                  <a
+                    href={u.linkUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                    {u.linkUrl}
+                  </a>
+                )}
+              </CardContent>
+            </Card>
+          </li>
+        ))}
+      </ol>
+      {modal}
+    </div>
   );
 }

--- a/client/src/components/project/ProjectUpdatesTab.tsx
+++ b/client/src/components/project/ProjectUpdatesTab.tsx
@@ -1,0 +1,106 @@
+import { useCallback, useEffect, useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { ExternalLink, Loader2, Sparkles } from "lucide-react";
+import { api, type ApiProjectUpdate } from "@/lib/api";
+
+const formatDateTime = (iso: string) => {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+};
+
+const truncateAddress = (addr: string) => {
+  if (!addr) return "team";
+  if (addr.length <= 14) return addr;
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+};
+
+export function ProjectUpdatesTab({ projectId }: { projectId: string }) {
+  const [updates, setUpdates] = useState<ApiProjectUpdate[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    let active = true;
+    setLoading(true);
+    setError(null);
+    api
+      .getProjectUpdates(projectId)
+      .then((r) => {
+        if (active) setUpdates(r.data);
+      })
+      .catch((e: unknown) => {
+        if (active) setError(e instanceof Error ? e.message : "Failed to load updates");
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [projectId]);
+
+  useEffect(() => {
+    const cleanup = load();
+    return cleanup;
+  }, [load]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground py-10">
+        <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+        Loading updates…
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className="text-sm text-destructive py-10">{error}</p>;
+  }
+
+  if (updates.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-10 text-center">
+          <Sparkles className="mx-auto h-6 w-6 text-muted-foreground" aria-hidden="true" />
+          <p className="mt-3 text-sm font-medium">Nothing here yet</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Your team can post the first update when something ships, pivots, or lands.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <ol className="space-y-4" aria-label="Project updates, most recent first">
+      {updates.map((u) => (
+        <li key={u.id}>
+          <Card>
+            <CardContent className="space-y-3 py-5">
+              <div className="flex items-center justify-between text-xs text-muted-foreground">
+                <span>{truncateAddress(u.createdBy)}</span>
+                <time dateTime={u.createdAt}>{formatDateTime(u.createdAt)}</time>
+              </div>
+              <p className="whitespace-pre-line text-sm leading-relaxed">{u.body}</p>
+              {u.linkUrl && (
+                <a
+                  href={u.linkUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+                >
+                  <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                  {u.linkUrl}
+                </a>
+              )}
+            </CardContent>
+          </Card>
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -144,6 +144,16 @@ export type ApiProgram = {
   updatedAt?: string;
 };
 
+/** Shape of a row in `project_updates` (Phase 1 revamp, #39). */
+export type ApiProjectUpdate = {
+  id: string;
+  projectId: string;
+  body: string;
+  linkUrl?: string | null;
+  createdBy: string;
+  createdAt: string;
+};
+
 export const api = {
   submitEntry: async (data: unknown) => {
     if (USE_MOCK_DATA) {
@@ -668,6 +678,47 @@ export const api = {
       return { status: "success", data: program };
     }
     return request(`/programs/${encodeURIComponent(slug)}`);
+  },
+
+  /**
+   * Phase 1 revamp: project updates (Block B, issues #39–#41).
+   */
+  getProjectUpdates: async (projectId: string): Promise<{ status: string; data: ApiProjectUpdate[] }> => {
+    if (USE_MOCK_DATA) {
+      const { mockProjectUpdates } = await import("./mockProjectUpdates");
+      const filtered = mockProjectUpdates
+        .filter((u) => u.projectId === projectId)
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+      return { status: "success", data: filtered };
+    }
+    return request(`/m2-program/${encodeURIComponent(projectId)}/updates`);
+  },
+
+  postProjectUpdate: async (
+    projectId: string,
+    payload: { body: string; linkUrl?: string | null },
+    authHeader?: string,
+  ): Promise<{ status: string; data: ApiProjectUpdate }> => {
+    if (USE_MOCK_DATA) {
+      const { mockProjectUpdates } = await import("./mockProjectUpdates");
+      const created: ApiProjectUpdate = {
+        id: `upd-mock-${Date.now()}`,
+        projectId,
+        body: payload.body.trim(),
+        linkUrl: payload.linkUrl ? payload.linkUrl.trim() : null,
+        createdBy: "mock-wallet",
+        createdAt: new Date().toISOString(),
+      };
+      mockProjectUpdates.unshift(created);
+      return { status: "success", data: created };
+    }
+    return request(`/m2-program/${encodeURIComponent(projectId)}/updates`, {
+      method: "POST",
+      headers: authHeader
+        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
+        : { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
   },
 };
 

--- a/client/src/lib/mockProjectUpdates.ts
+++ b/client/src/lib/mockProjectUpdates.ts
@@ -1,0 +1,35 @@
+/**
+ * Mock fixture for the `project_updates` table. Seeded for a couple of
+ * projects so the Updates tab renders its populated state in preview mode.
+ *
+ * Phase 1 revamp, issue #40.
+ */
+
+import type { ApiProjectUpdate } from "./api";
+
+export const mockProjectUpdates: ApiProjectUpdate[] = [
+  {
+    id: "upd-plata-mia-1",
+    projectId: "plata-mia-15ac43",
+    body: "Shipped v2 of the stealth transfer flow this week — one-step deposit is live and we've had two teams try it end-to-end. Docs will land in a few days.",
+    linkUrl: "https://plata-mia.vercel.app/",
+    createdBy: "5MockWalletAddressRedactedForPreviewPurposes00000",
+    createdAt: "2026-04-18T10:00:00Z",
+  },
+  {
+    id: "upd-plata-mia-2",
+    projectId: "plata-mia-15ac43",
+    body: "We're applying for the Web3 Foundation grant next month — if anyone in the cohort has experience with their application review process, would love a 20-minute call.",
+    linkUrl: null,
+    createdBy: "5MockWalletAddressRedactedForPreviewPurposes00000",
+    createdAt: "2026-04-10T14:30:00Z",
+  },
+  {
+    id: "upd-kleo-1",
+    projectId: "kleo-protocol-53c76f",
+    body: "First real loan originated on mainnet today. Small amount, but the whole flow — onboarding, scoring, disbursement, repayment — went through without us having to touch anything.",
+    linkUrl: "https://kleo.finance/",
+    createdBy: "5MockWalletAddressRedactedForPreviewPurposes00000",
+    createdAt: "2026-04-15T09:20:00Z",
+  },
+];

--- a/client/src/lib/siwsUtils.ts
+++ b/client/src/lib/siwsUtils.ts
@@ -3,7 +3,7 @@
  */
 
 export interface SiwsContext {
-  action: 'update-team' | 'submit-deliverable' | 'update-project' | 'register-address' | 'admin-action' | 'create-project' | 'delete-project' | 'review-project' | 'approve-project' | 'reject-project';
+  action: 'update-team' | 'submit-deliverable' | 'update-project' | 'register-address' | 'admin-action' | 'create-project' | 'delete-project' | 'review-project' | 'approve-project' | 'reject-project' | 'post-update';
   projectId?: string;
   projectTitle?: string;
   additionalContext?: string;
@@ -42,10 +42,14 @@ export function generateSiwsStatement(context: SiwsContext): string {
     
     case 'register-address':
       return `Register team address for ${baseDomain}`;
-    
+
     case 'admin-action':
       return `Perform administrative action on ${baseDomain}`;
-    
+
+    // Phase 1 revamp (#41): project updates
+    case 'post-update':
+      return `Post an update to ${context.projectTitle || 'project'} on ${baseDomain}`;
+
     default:
       return `Sign in to ${baseDomain}`;
   }

--- a/client/src/pages/ProjectDetailsPage.tsx
+++ b/client/src/pages/ProjectDetailsPage.tsx
@@ -43,6 +43,7 @@ import { WalletConnectionBanner } from "@/components/WalletConnectionBanner";
 import { TeamPaymentSection } from "@/components/TeamPaymentSection";
 import { M2SubmissionTimeline } from "@/components/M2SubmissionTimeline";
 import { SubmitM2DeliverablesModal } from "@/components/SubmitM2DeliverablesModal";
+import { ProjectUpdatesTab } from "@/components/project/ProjectUpdatesTab";
 import { EditProjectDetailsModal } from "@/components/EditProjectDetailsModal";
 import { isAdmin as checkIsAdmin } from "@/lib/constants";
 import { addressInList } from "@/lib/addressUtils";
@@ -1041,10 +1042,11 @@ const ProjectDetailsPage = () => {
 
             {/* Tabs Section */}
             <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-              <TabsList className="grid w-full grid-cols-3">
+              <TabsList className="grid w-full grid-cols-4">
                 <TabsTrigger value="overview">Overview</TabsTrigger>
                 <TabsTrigger value="milestones">Milestones</TabsTrigger>
                 <TabsTrigger value="team">Team & Payments</TabsTrigger>
+                <TabsTrigger value="updates">Updates</TabsTrigger>
               </TabsList>
 
               {/* Overview Tab */}
@@ -1282,6 +1284,11 @@ const ProjectDetailsPage = () => {
                   isConnected={!!connectedAddress}
                   onSave={handleTeamPaymentSave}
                 />
+              </TabsContent>
+
+              {/* Updates Tab — Phase 1 revamp #40 */}
+              <TabsContent value="updates" className="space-y-6 mt-6">
+                <ProjectUpdatesTab projectId={project.id} />
               </TabsContent>
             </Tabs>
 

--- a/client/src/pages/ProjectDetailsPage.tsx
+++ b/client/src/pages/ProjectDetailsPage.tsx
@@ -1286,9 +1286,14 @@ const ProjectDetailsPage = () => {
                 />
               </TabsContent>
 
-              {/* Updates Tab — Phase 1 revamp #40 */}
+              {/* Updates Tab — Phase 1 revamp #40 / #41 */}
               <TabsContent value="updates" className="space-y-6 mt-6">
-                <ProjectUpdatesTab projectId={project.id} />
+                <ProjectUpdatesTab
+                  projectId={project.id}
+                  projectTitle={project.projectName}
+                  canPost={(isTeamMember || isAdmin) && Boolean(connectedAddress)}
+                  connectedAddress={connectedAddress || undefined}
+                />
               </TabsContent>
             </Tabs>
 

--- a/server/api/controllers/__tests__/project-update.test.js
+++ b/server/api/controllers/__tests__/project-update.test.js
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../services/project.service.js', () => ({
+  default: {
+    getProjectById: vi.fn(),
+  },
+}));
+
+vi.mock('../../services/project-update.service.js', () => ({
+  default: {
+    listByProject: vi.fn(),
+    create: vi.fn(),
+  },
+}));
+
+// Payment service is imported transitively via the controller — stub it so
+// its polkadot-api side effects don't fire during unit tests.
+vi.mock('../../services/payment.service.js', () => ({
+  default: {
+    constructTransfer: vi.fn(),
+    prepareMultisigTransaction: vi.fn(),
+  },
+}));
+
+const projectService = (await import('../../services/project.service.js')).default;
+const projectUpdateService = (await import('../../services/project-update.service.js')).default;
+const projectController = (await import('../project.controller.js')).default;
+
+const mockRes = () => {
+  const res = {};
+  res.status = vi.fn(() => res);
+  res.json = vi.fn(() => res);
+  return res;
+};
+
+describe('ProjectController.getProjectUpdates', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 404 when project does not exist', async () => {
+    projectService.getProjectById.mockResolvedValue(null);
+    const req = { params: { projectId: 'nope' } };
+    const res = mockRes();
+    await projectController.getProjectUpdates(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(projectUpdateService.listByProject).not.toHaveBeenCalled();
+  });
+
+  it('returns 200 with empty array when no updates exist', async () => {
+    projectService.getProjectById.mockResolvedValue({ id: 'p1' });
+    projectUpdateService.listByProject.mockResolvedValue([]);
+    const req = { params: { projectId: 'p1' } };
+    const res = mockRes();
+    await projectController.getProjectUpdates(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ status: 'success', data: [] });
+  });
+
+  it('returns 200 with the update list when updates exist', async () => {
+    const updates = [
+      { id: 'u1', projectId: 'p1', body: 'hello', linkUrl: null, createdBy: 'addr', createdAt: 't1' },
+    ];
+    projectService.getProjectById.mockResolvedValue({ id: 'p1' });
+    projectUpdateService.listByProject.mockResolvedValue(updates);
+    const req = { params: { projectId: 'p1' } };
+    const res = mockRes();
+    await projectController.getProjectUpdates(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ status: 'success', data: updates });
+  });
+});
+
+describe('ProjectController.postProjectUpdate', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 404 when project does not exist', async () => {
+    projectService.getProjectById.mockResolvedValue(null);
+    const req = { params: { projectId: 'nope' }, body: { body: 'hi' }, user: { address: 'a' } };
+    const res = mockRes();
+    await projectController.postProjectUpdate(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns 422 when body is empty', async () => {
+    projectService.getProjectById.mockResolvedValue({ id: 'p1' });
+    const req = { params: { projectId: 'p1' }, body: { body: '' }, user: { address: 'a' } };
+    const res = mockRes();
+    await projectController.postProjectUpdate(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('returns 422 when body exceeds 2000 chars', async () => {
+    projectService.getProjectById.mockResolvedValue({ id: 'p1' });
+    const longBody = 'x'.repeat(2001);
+    const req = { params: { projectId: 'p1' }, body: { body: longBody }, user: { address: 'a' } };
+    const res = mockRes();
+    await projectController.postProjectUpdate(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('returns 422 when linkUrl is malformed', async () => {
+    projectService.getProjectById.mockResolvedValue({ id: 'p1' });
+    const req = {
+      params: { projectId: 'p1' },
+      body: { body: 'ok', linkUrl: 'not-a-url' },
+      user: { address: 'a' },
+    };
+    const res = mockRes();
+    await projectController.postProjectUpdate(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('creates an update on valid payload and returns 201', async () => {
+    projectService.getProjectById.mockResolvedValue({ id: 'p1' });
+    const created = { id: 'u1', projectId: 'p1', body: 'hi', linkUrl: null, createdBy: 'addr' };
+    projectUpdateService.create.mockResolvedValue(created);
+    const req = {
+      params: { projectId: 'p1' },
+      body: { body: '  hi  ', linkUrl: '' },
+      user: { address: 'addr' },
+    };
+    const res = mockRes();
+    await projectController.postProjectUpdate(req, res);
+    expect(projectUpdateService.create).toHaveBeenCalledWith({
+      projectId: 'p1',
+      body: 'hi',
+      linkUrl: null,
+      createdBy: 'addr',
+    });
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({ status: 'success', data: created });
+  });
+
+  it('passes linkUrl through after trimming when present', async () => {
+    projectService.getProjectById.mockResolvedValue({ id: 'p1' });
+    projectUpdateService.create.mockResolvedValue({ id: 'u1' });
+    const req = {
+      params: { projectId: 'p1' },
+      body: { body: 'hi', linkUrl: '  https://example.com/post  ' },
+      user: { address: 'addr' },
+    };
+    const res = mockRes();
+    await projectController.postProjectUpdate(req, res);
+    expect(projectUpdateService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ linkUrl: 'https://example.com/post' }),
+    );
+  });
+});

--- a/server/api/controllers/project.controller.js
+++ b/server/api/controllers/project.controller.js
@@ -1,7 +1,8 @@
 import projectService from '../services/project.service.js';
+import projectUpdateService from '../services/project-update.service.js';
 import paymentService from '../services/payment.service.js';
 import { ALLOWED_CATEGORIES } from '../constants/allowedTech.js';
-import { validateSS58, validateM2Submission, validateSimpleUrl } from '../utils/validation.js';
+import { validateSS58, validateM2Submission, validateSimpleUrl, validateProjectUpdate } from '../utils/validation.js';
 import { canEditM2Agreement, isSubmissionWindowOpen } from '../utils/dateHelpers.js';
 import logger from '../utils/logger.js';
 import { getAuthorizedAddresses } from '../../config/polkadot-config.js';
@@ -537,6 +538,56 @@ class ProjectController {
                 error: 'Test payment failed',
                 details: process.env.NODE_ENV === 'development' ? error.message : undefined
             });
+        }
+    }
+
+    // --- Phase 1 revamp: project updates (#39) ---
+
+    async getProjectUpdates(req, res) {
+        try {
+            const { projectId } = req.params;
+            // Ensure the project exists — avoid revealing non-existent IDs via empty arrays.
+            const project = await projectService.getProjectById(projectId);
+            if (!project) {
+                return res.status(404).json({ status: 'error', message: 'Project not found' });
+            }
+            const updates = await projectUpdateService.listByProject(projectId);
+            res.status(200).json({ status: 'success', data: updates });
+        } catch (error) {
+            console.error('❌ Error fetching project updates:', error);
+            res.status(500).json({ status: 'error', message: 'Failed to fetch project updates' });
+        }
+    }
+
+    async postProjectUpdate(req, res) {
+        try {
+            const { projectId } = req.params;
+            const raw = req.body || {};
+            const body = typeof raw.body === 'string' ? raw.body.trim() : raw.body;
+            const linkUrl = typeof raw.linkUrl === 'string' ? raw.linkUrl.trim() : raw.linkUrl;
+
+            const project = await projectService.getProjectById(projectId);
+            if (!project) {
+                return res.status(404).json({ status: 'error', message: 'Project not found' });
+            }
+
+            const { valid, error: validationError } = validateProjectUpdate({ body, linkUrl });
+            if (!valid) {
+                return res.status(422).json({ status: 'error', message: validationError });
+            }
+
+            const createdBy = req.user?.address || req.auth?.address || 'unknown';
+            const created = await projectUpdateService.create({
+                projectId,
+                body,
+                linkUrl: linkUrl || null,
+                createdBy,
+            });
+
+            res.status(201).json({ status: 'success', data: created });
+        } catch (error) {
+            console.error('❌ Error posting project update:', error);
+            res.status(500).json({ status: 'error', message: 'Failed to post project update' });
         }
     }
 }

--- a/server/api/middleware/auth.middleware.js
+++ b/server/api/middleware/auth.middleware.js
@@ -37,7 +37,9 @@ const VALID_STATEMENTS = [
   // Admin action statements
   "Review project on Stadium",
   "Approve project on Stadium",
-  "Reject project on Stadium"
+  "Reject project on Stadium",
+  // Phase 1 revamp statements
+  "Post an update on Stadium"
 ];
 
 const EXPECTED_DOMAIN = process.env.EXPECTED_DOMAIN || 'localhost';
@@ -64,7 +66,9 @@ function validateSiwsStatement(statement) {
     /^Delete project .+ on Stadium$/,
     /^Review project .+ on Stadium$/,
     /^Approve project .+ on Stadium$/,
-    /^Reject project .+ on Stadium$/
+    /^Reject project .+ on Stadium$/,
+    // Phase 1 revamp: project updates (#41)
+    /^Post an update to .+ on Stadium$/
   ];
   
   return projectPatterns.some(pattern => pattern.test(statement));

--- a/server/api/repositories/project-update.repository.js
+++ b/server/api/repositories/project-update.repository.js
@@ -1,0 +1,43 @@
+import { supabase } from '../../db.js';
+
+const transformUpdate = (row) => {
+  if (!row) return null;
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    body: row.body,
+    linkUrl: row.link_url,
+    createdBy: row.created_by,
+    createdAt: row.created_at,
+  };
+};
+
+class ProjectUpdateRepository {
+  async listByProject(projectId, { limit = 100 } = {}) {
+    const { data, error } = await supabase
+      .from('project_updates')
+      .select('*')
+      .eq('project_id', projectId)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+    if (error) throw error;
+    return (data || []).map(transformUpdate);
+  }
+
+  async create({ projectId, body, linkUrl, createdBy }) {
+    const { data, error } = await supabase
+      .from('project_updates')
+      .insert({
+        project_id: projectId,
+        body,
+        link_url: linkUrl || null,
+        created_by: createdBy,
+      })
+      .select('*')
+      .single();
+    if (error) throw error;
+    return transformUpdate(data);
+  }
+}
+
+export default new ProjectUpdateRepository();

--- a/server/api/routes/m2-program.routes.js
+++ b/server/api/routes/m2-program.routes.js
@@ -20,6 +20,10 @@ router.patch('/:projectId/m2-agreement', requireTeamMemberOrAdmin, projectContro
 router.patch('/:projectId/payout-address', requireTeamMemberOrAdmin, projectController.updatePayoutAddress);
 router.post('/:projectId/submit-m2', requireTeamMemberOrAdmin, projectController.submitM2Deliverables);
 
+// --- Phase 1 revamp: project updates (#39) ---
+router.get('/:projectId/updates', projectController.getProjectUpdates);
+router.post('/:projectId/updates', requireTeamMemberOrAdmin, projectController.postProjectUpdate);
+
 // --- Admin M2 approval ---
 router.post('/:projectId/approve', requireAdmin, projectController.approveM2);
 

--- a/server/api/services/project-update.service.js
+++ b/server/api/services/project-update.service.js
@@ -1,0 +1,13 @@
+import projectUpdateRepository from '../repositories/project-update.repository.js';
+
+class ProjectUpdateService {
+  async listByProject(projectId, opts) {
+    return await projectUpdateRepository.listByProject(projectId, opts);
+  }
+
+  async create(payload) {
+    return await projectUpdateRepository.create(payload);
+  }
+}
+
+export default new ProjectUpdateService();

--- a/server/api/utils/validation.js
+++ b/server/api/utils/validation.js
@@ -200,7 +200,34 @@ export const validateM2Submission = (data) => {
   if (!validateLength(summary, 10, 1000)) {
     return { valid: false, error: 'Summary must be between 10 and 1000 characters' };
   }
-  
+
+  return { valid: true };
+};
+
+/**
+ * Validate project update data (Phase 1 revamp, #39).
+ * @param {Object} data - { body: string, linkUrl?: string }
+ * @returns {Object} - { valid: boolean, error: string }
+ */
+export const validateProjectUpdate = (data) => {
+  if (!data || typeof data !== 'object') {
+    return { valid: false, error: 'Update payload must be an object' };
+  }
+  const { body, linkUrl } = data;
+
+  if (typeof body !== 'string') {
+    return { valid: false, error: 'body is required and must be a string' };
+  }
+  if (!validateLength(body, 1, 2000)) {
+    return { valid: false, error: 'body must be between 1 and 2000 characters' };
+  }
+
+  if (linkUrl !== undefined && linkUrl !== null && linkUrl !== '') {
+    if (typeof linkUrl !== 'string' || !validateSimpleUrl(linkUrl)) {
+      return { valid: false, error: 'linkUrl, when provided, must start with www or http' };
+    }
+  }
+
   return { valid: true };
 };
 

--- a/supabase/migrations/20260422010000_create_project_updates.sql
+++ b/supabase/migrations/20260422010000_create_project_updates.sql
@@ -1,0 +1,17 @@
+-- Stadium Phase 1 Revamp — project_updates (issue #39, Block B).
+-- See docs/stadium-revamp-phase-1-spec.md §4.3.
+--
+-- Immutable append-only log. No edit, no delete from the API. Typos are fixed
+-- by posting a new update.
+
+CREATE TABLE IF NOT EXISTS project_updates (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  body       TEXT NOT NULL CHECK (length(body) BETWEEN 1 AND 2000),
+  link_url   TEXT,
+  created_by TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_updates_project_created_at
+  ON project_updates(project_id, created_at DESC);


### PR DESCRIPTION
Block B of the Phase 1 revamp — project updates.

Closes #39, #40, #41.

## Block B journey slice (per spec §12)

*"I can post an update on my project."* Team member connects wallet on their project detail page → opens new Updates tab → clicks "Post update" → fills body → signs SIWS → update appears at the top of the list without a reload.

## Commits

### `d746a45` — #39: schema + server API

- Migration `supabase/migrations/20260422010000_create_project_updates.sql` (spec §4.3: UUID id, project_id FK, body CHECK length 1..2000, optional link_url, created_by, created_at; index on (project_id, created_at DESC)).
- `server/api/repositories/project-update.repository.js` — listByProject (reverse-chron) + create.
- `server/api/services/project-update.service.js` — thin wrap.
- Extended `project.controller.js` with `getProjectUpdates` (public, 404 on missing project) and `postProjectUpdate` (422 on validation failure, trims body/linkUrl before validation, 201 on success).
- `m2-program.routes.js` — `GET /:projectId/updates` (public) and `POST /:projectId/updates` (requireTeamMemberOrAdmin).
- `validation.js` — `validateProjectUpdate` (body 1..2000, optional linkUrl via existing validateSimpleUrl).
- `auth.middleware.js` — adds the `/^Post an update to .+ on Stadium$/` pattern + a base statement.
- 9 new unit tests (GET 404/empty/populated, POST 404/empty-body/too-long/bad-link/happy-path/linkUrl-trim).

### `fa3af45` — #40: Updates tab (read surface)

- `client/src/lib/api.ts` — `ApiProjectUpdate` type + `api.getProjectUpdates` + `api.postProjectUpdate` (staged here; used by #41).
- `client/src/lib/mockProjectUpdates.ts` (new) — three seeded updates across Plata Mia (2) and Kleo Protocol (1) so preview mode shows both the empty state (most projects) and the populated state.
- `client/src/components/project/ProjectUpdatesTab.tsx` (new) — loading, error, empty (warm builder-voice copy), populated (reverse-chron ordered list with author + timestamp + body + optional link).
- `client/src/pages/ProjectDetailsPage.tsx` — **TabsList `grid-cols-3` → `grid-cols-4`** (per audit 2026-04-22 finding). Fourth "Updates" TabsTrigger + TabsContent that mounts ProjectUpdatesTab.

### `453395d` — #41: Post Update modal (write surface)

- `client/src/lib/siwsUtils.ts` — new `post-update` action → `"Post an update to <project> on Stadium"` (matches the server-side regex).
- `client/src/components/project/PostUpdateModal.tsx` (new) — body textarea with live character counter (1..2000), optional link (mirrors server's validateSimpleUrl), inline errors per field, SIWS flow via `web3Enable → web3Accounts → web3FromSource`, posts via `api.postProjectUpdate`.
- `client/src/components/project/ProjectUpdatesTab.tsx` — new props `projectTitle`, `canPost`, `connectedAddress`. Post button is rendered only when `canPost === true` AND a wallet is connected. New updates are prepended to local state without a page reload.
- `client/src/pages/ProjectDetailsPage.tsx` — passes `canPost = (isTeamMember || isAdmin) && Boolean(connectedAddress)` and the wallet address through.

## Validation strategy (per spec §10)

- Body length 1..2000 enforced on both client and server.
- Link URL prefix rules (`www`, `http://`, `https://`) identical on client and server.
- No new client-only regexes; no revalidation divergence.

## Test plan

Automated:
- [x] `cd server && npm test` → 22/22 (9 new + 13 existing).
- [x] `cd client && npm run build` → clean (pre-existing chunk-size + dynamic-import warnings unrelated).

Playwright (Block B gate, run against the Vercel preview once CI builds it):
- [ ] On `/m2-program/<any-project-id>`, the tab strip shows exactly four tabs: Overview / Milestones / Team & Payments / Updates.
- [ ] On `/m2-program/plata-mia-15ac43`, clicking Updates shows two seeded updates in reverse chronological order with body, timestamp, author, and at least one link.
- [ ] On `/m2-program/<a-project-with-no-updates>`, Updates tab shows the warm empty-state copy.
- [ ] On `/m2-program/<any-project-id>`, an un-authenticated visitor does NOT see a "Post update" button.
- [ ] The Updates tab's post-button is in the DOM only when the wallet is connected AND a team member (check in mock mode by stubbing the wallet state).

SIWS-gated (manual QA with a real wallet; Playwright can't sign):
- [ ] Connect a wallet that is a team member on the target project → Post update button appears.
- [ ] Open modal, type a short body, submit → SIWS prompt, sign, modal closes, new update appears at top of list without reload.
- [ ] Body > 2000 chars → inline error before submit, no network request.
- [ ] Invalid link URL (e.g. `not-a-url`) → inline error before submit.
- [ ] Wallet not on team → button hidden even after connect.
- [ ] Admin wallet on a project they're not a member of → button visible (admins can post).

## Out of scope (deferred per spec)

- Editing or deleting updates (intentional immutability; spec §4.3).
- Notifications when updates are posted (Phase 2+).
- Cross-project updates feed (Phase 2+).

## Ops

No deploy-time seed needed. The `project_updates` table is created by the migration; existing projects simply have no rows and the UI shows its empty state.