### PR TITLE
feat(revamp): Block D — program applications (closes #43 #44)

### DIFF
--- a/client/src/components/program/ApplyToProgramModal.tsx
+++ b/client/src/components/program/ApplyToProgramModal.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Loader2 } from "lucide-react";
+import { web3Enable, web3Accounts, web3FromSource } from "@polkadot/extension-dapp";
+import { SiwsMessage } from "@talismn/siws";
+import { generateSiwsStatement } from "@/lib/siwsUtils";
+import { api, type ApiProgram, type ApiProgramApplication, type ApiProject } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+
+const FEEDBACK_FOCUS_MIN = 1;
+const FEEDBACK_FOCUS_MAX = 500;
+
+export function ApplyToProgramModal({
+  open,
+  onOpenChange,
+  program,
+  projects,
+  connectedAddress,
+  onApplied,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  program: ApiProgram;
+  /** Projects the connected wallet is a team member of. Sorted by updated_at DESC. */
+  projects: ApiProject[];
+  connectedAddress: string;
+  onApplied: (application: ApiProgramApplication) => void;
+}) {
+  const defaultProjectId = useMemo(() => projects[0]?.id || "", [projects]);
+  const [projectId, setProjectId] = useState<string>(defaultProjectId);
+  const [feedbackFocus, setFeedbackFocus] = useState("");
+  const [feedbackError, setFeedbackError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const { toast } = useToast();
+
+  const selectedProject = useMemo(
+    () => projects.find((p) => p.id === projectId) || projects[0] || null,
+    [projects, projectId],
+  );
+
+  useEffect(() => {
+    if (open) {
+      setProjectId(defaultProjectId);
+      setFeedbackFocus("");
+      setFeedbackError(null);
+    }
+  }, [open, defaultProjectId]);
+
+  const validate = (): boolean => {
+    if (program.programType !== "dogfooding") return true;
+    const trimmed = feedbackFocus.trim();
+    if (trimmed.length < FEEDBACK_FOCUS_MIN) {
+      setFeedbackError("Tell us briefly what you want feedback on.");
+      return false;
+    }
+    if (trimmed.length > FEEDBACK_FOCUS_MAX) {
+      setFeedbackError(`Must be ${FEEDBACK_FOCUS_MAX} characters or fewer.`);
+      return false;
+    }
+    setFeedbackError(null);
+    return true;
+  };
+
+  const handleSubmit = async () => {
+    if (!selectedProject) return;
+    if (!validate()) return;
+    setSubmitting(true);
+    try {
+      await web3Enable("Stadium");
+      const accounts = await web3Accounts();
+      const account = accounts.find((a) => a.address === connectedAddress) || accounts[0];
+      if (!account) throw new Error("No wallet account found");
+
+      const siws = new SiwsMessage({
+        domain: window.location.hostname,
+        uri: window.location.origin,
+        address: account.address,
+        nonce: Math.random().toString(36).slice(2),
+        statement: generateSiwsStatement({
+          action: "apply-to-program",
+          projectTitle: selectedProject.projectName,
+          programTitle: program.name,
+        }),
+      });
+      const injector = await web3FromSource(account.meta.source);
+      const signed = (await siws.sign(injector)) as unknown as { signature: string; message?: string };
+      const messageStr =
+        typeof signed.message === "string" && signed.message
+          ? signed.message
+          : (siws as unknown as { toString: () => string }).toString();
+      const authHeader = btoa(
+        JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address }),
+      );
+
+      const application_fields: Record<string, unknown> =
+        program.programType === "dogfooding" ? { feedback_focus: feedbackFocus.trim() } : {};
+
+      const res = await api.applyToProgram(
+        program.slug,
+        { project_id: selectedProject.id, application_fields },
+        authHeader,
+      );
+      onApplied(res.data);
+      toast({ title: "Application submitted" });
+      onOpenChange(false);
+    } catch (e) {
+      const err = e as Error;
+      toast({
+        title: "Couldn't submit application",
+        description: err?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => (submitting ? null : onOpenChange(v))}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Apply to {program.name}</DialogTitle>
+          <DialogDescription>
+            Bring the project you already built — we'll pull the rest from its Stadium page.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <Label htmlFor="apply-project">Project</Label>
+            <Select value={projectId} onValueChange={setProjectId}>
+              <SelectTrigger id="apply-project">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {projects.map((p) => (
+                  <SelectItem key={p.id} value={p.id}>
+                    {p.projectName}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {program.programType === "dogfooding" && (
+            <div className="space-y-1">
+              <Label htmlFor="apply-feedback">What do you want feedback on?</Label>
+              <Textarea
+                id="apply-feedback"
+                rows={5}
+                placeholder="One or two specific things you'd most like the cohort to dig into."
+                value={feedbackFocus}
+                onChange={(e) => setFeedbackFocus(e.target.value)}
+                aria-invalid={feedbackError ? true : undefined}
+                aria-describedby="apply-feedback-error apply-feedback-count"
+              />
+              <div className="flex items-center justify-between text-xs">
+                <span id="apply-feedback-error" className="text-destructive">
+                  {feedbackError || ""}
+                </span>
+                <span
+                  id="apply-feedback-count"
+                  className={
+                    feedbackFocus.trim().length > FEEDBACK_FOCUS_MAX
+                      ? "text-destructive"
+                      : "text-muted-foreground"
+                  }
+                >
+                  {feedbackFocus.trim().length} / {FEEDBACK_FOCUS_MAX}
+                </span>
+              </div>
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            onClick={() => (submitting ? null : onOpenChange(false))}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={submitting || !selectedProject}>
+            {submitting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                Submitting…
+              </>
+            ) : (
+              "Submit application"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -137,6 +137,20 @@ export type ApiFundingSignal = {
   updatedAt?: string | null;
 };
 
+/** Shape of a row in `program_applications` (Phase 1 revamp, #43). */
+export type ApiProgramApplication = {
+  id: string;
+  programId: string;
+  projectId: string;
+  status: "submitted" | "accepted" | "rejected" | "withdrawn";
+  applicationFields: Record<string, unknown>;
+  submittedBy: string;
+  submittedAt: string;
+  reviewedBy?: string | null;
+  reviewedAt?: string | null;
+  reviewNotes?: string | null;
+};
+
 /** Shape of a row in the `programs` table (Phase 1 revamp). */
 export type ApiProgram = {
   id: string;
@@ -779,6 +793,103 @@ export const api = {
     }
     return request(`/m2-program/${encodeURIComponent(projectId)}/funding-signal`, {
       method: "PATCH",
+      headers: authHeader
+        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
+        : { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  },
+
+  /**
+   * Phase 1 revamp: program applications (Block D, issues #43–#44).
+   */
+
+  /** List projects where the given wallet is a team member. */
+  getProjectsByTeamWallet: async (address: string): Promise<{ status: string; data: ApiProject[] }> => {
+    if (USE_MOCK_DATA) {
+      const { mockWinningProjects } = await import("./mockWinners");
+      const matches = mockWinningProjects
+        .filter((p) =>
+          (p.teamMembers || []).some((m) => m.walletAddress && m.walletAddress === address),
+        )
+        .sort((a, b) => {
+          const ua = a.updatedAt || "";
+          const ub = b.updatedAt || "";
+          return ub.localeCompare(ua);
+        });
+      return { status: "success", data: matches as unknown as ApiProject[] };
+    }
+    return request(`/m2-program/by-team/${encodeURIComponent(address)}`);
+  },
+
+  /** List all applications a given project has submitted. */
+  getApplicationsForProject: async (
+    projectId: string,
+  ): Promise<{ status: string; data: ApiProgramApplication[] }> => {
+    if (USE_MOCK_DATA) {
+      const { mockProgramApplications } = await import("./mockProgramApplications");
+      return {
+        status: "success",
+        data: mockProgramApplications.filter((a) => a.projectId === projectId),
+      };
+    }
+    return request(`/m2-program/${encodeURIComponent(projectId)}/applications`);
+  },
+
+  /** Admin-only: list all applications for a program. */
+  listProgramApplications: async (
+    slug: string,
+    authHeader?: string,
+  ): Promise<{ status: string; data: ApiProgramApplication[] }> => {
+    if (USE_MOCK_DATA) {
+      const { mockProgramApplications } = await import("./mockProgramApplications");
+      const { mockPrograms } = await import("./mockPrograms");
+      const program = mockPrograms.find((p) => p.slug === slug);
+      if (!program) return { status: "success", data: [] };
+      return {
+        status: "success",
+        data: mockProgramApplications.filter((a) => a.programId === program.id),
+      };
+    }
+    return request(`/programs/${encodeURIComponent(slug)}/applications`, {
+      headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : undefined,
+    });
+  },
+
+  applyToProgram: async (
+    slug: string,
+    payload: { project_id: string; application_fields: Record<string, unknown> },
+    authHeader?: string,
+  ): Promise<{ status: string; data: ApiProgramApplication }> => {
+    if (USE_MOCK_DATA) {
+      const { mockProgramApplications } = await import("./mockProgramApplications");
+      const { mockPrograms } = await import("./mockPrograms");
+      const program = mockPrograms.find((p) => p.slug === slug);
+      if (!program) throw new ApiError("Program not found", 404);
+      if (
+        mockProgramApplications.some(
+          (a) => a.programId === program.id && a.projectId === payload.project_id,
+        )
+      ) {
+        throw new ApiError("This project has already applied to this program.", 409);
+      }
+      const created: ApiProgramApplication = {
+        id: `app-mock-${Date.now()}`,
+        programId: program.id,
+        projectId: payload.project_id,
+        status: "submitted",
+        applicationFields: payload.application_fields,
+        submittedBy: "mock-wallet",
+        submittedAt: new Date().toISOString(),
+        reviewedBy: null,
+        reviewedAt: null,
+        reviewNotes: null,
+      };
+      mockProgramApplications.unshift(created);
+      return { status: "success", data: created };
+    }
+    return request(`/programs/${encodeURIComponent(slug)}/applications`, {
+      method: "POST",
       headers: authHeader
         ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
         : { "Content-Type": "application/json" },

--- a/client/src/lib/mockProgramApplications.ts
+++ b/client/src/lib/mockProgramApplications.ts
@@ -1,0 +1,27 @@
+/**
+ * Mock fixture for `program_applications`. Seeded with one application so
+ * Block E's "Programs" section on project detail pages lights up in preview
+ * mode.
+ *
+ * Phase 1 revamp, issue #43.
+ */
+
+import type { ApiProgramApplication } from "./api";
+
+export const mockProgramApplications: ApiProgramApplication[] = [
+  {
+    id: "app-plata-dogfooding-1",
+    programId: "dogfooding-2026-berlin",
+    projectId: "plata-mia-15ac43",
+    status: "submitted",
+    applicationFields: {
+      feedback_focus:
+        "We'd love structured feedback on the UX of our stealth-transfer flow — specifically whether the one-step deposit is discoverable.",
+    },
+    submittedBy: "mock-wallet",
+    submittedAt: "2026-04-22T11:30:00Z",
+    reviewedBy: null,
+    reviewedAt: null,
+    reviewNotes: null,
+  },
+];

--- a/client/src/lib/siwsUtils.ts
+++ b/client/src/lib/siwsUtils.ts
@@ -3,9 +3,10 @@
  */
 
 export interface SiwsContext {
-  action: 'update-team' | 'submit-deliverable' | 'update-project' | 'register-address' | 'admin-action' | 'create-project' | 'delete-project' | 'review-project' | 'approve-project' | 'reject-project' | 'post-update' | 'update-funding-signal';
+  action: 'update-team' | 'submit-deliverable' | 'update-project' | 'register-address' | 'admin-action' | 'create-project' | 'delete-project' | 'review-project' | 'approve-project' | 'reject-project' | 'post-update' | 'update-funding-signal' | 'apply-to-program';
   projectId?: string;
   projectTitle?: string;
+  programTitle?: string;
   additionalContext?: string;
 }
 
@@ -53,6 +54,10 @@ export function generateSiwsStatement(context: SiwsContext): string {
     // Phase 1 revamp (#42): funding signal
     case 'update-funding-signal':
       return `Update funding signal for ${context.projectTitle || 'project'} on ${baseDomain}`;
+
+    // Phase 1 revamp (#44): apply project to program
+    case 'apply-to-program':
+      return `Apply project ${context.projectTitle || ''} to program ${context.programTitle || ''} on ${baseDomain}`;
 
     default:
       return `Sign in to ${baseDomain}`;

--- a/client/src/pages/ProgramDetailPage.tsx
+++ b/client/src/pages/ProgramDetailPage.tsx
@@ -1,11 +1,20 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { Navigation } from "@/components/Navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Calendar, MapPin, Loader2, Wallet } from "lucide-react";
-import { api, type ApiProgram, ApiError } from "@/lib/api";
+import { Calendar, MapPin, Loader2, Wallet, CheckCircle2 } from "lucide-react";
+import { web3Enable, web3Accounts } from "@polkadot/extension-dapp";
+import {
+  api,
+  type ApiProgram,
+  type ApiProject,
+  type ApiProgramApplication,
+  ApiError,
+} from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+import { ApplyToProgramModal } from "@/components/program/ApplyToProgramModal";
 
 const formatDateRange = (from?: string | null, to?: string | null) => {
   if (!from && !to) return null;
@@ -37,10 +46,19 @@ const programTypeLabel = (t?: ApiProgram["programType"]) => {
 
 const ProgramDetailPage = () => {
   const { slug } = useParams<{ slug: string }>();
+  const { toast } = useToast();
+
   const [program, setProgram] = useState<ApiProgram | null>(null);
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Wallet + my projects state
+  const [connectedAddress, setConnectedAddress] = useState<string | null>(null);
+  const [connecting, setConnecting] = useState(false);
+  const [myProjects, setMyProjects] = useState<ApiProject[]>([]);
+  const [myApplications, setMyApplications] = useState<ApiProgramApplication[]>([]);
+  const [modalOpen, setModalOpen] = useState(false);
 
   useEffect(() => {
     if (!slug) return;
@@ -69,11 +87,133 @@ const ProgramDetailPage = () => {
     };
   }, [slug]);
 
+  // Load the wallet's projects whenever the connected address changes.
+  useEffect(() => {
+    if (!connectedAddress) {
+      setMyProjects([]);
+      return;
+    }
+    let active = true;
+    api
+      .getProjectsByTeamWallet(connectedAddress)
+      .then((r) => {
+        if (active) setMyProjects(r.data);
+      })
+      .catch(() => {
+        if (active) setMyProjects([]);
+      });
+    return () => {
+      active = false;
+    };
+  }, [connectedAddress]);
+
+  // Load applications this wallet's projects already submitted to THIS program.
+  useEffect(() => {
+    if (!program || myProjects.length === 0) {
+      setMyApplications([]);
+      return;
+    }
+    let active = true;
+    Promise.all(myProjects.map((p) => api.getApplicationsForProject(p.id).catch(() => null)))
+      .then((results) => {
+        if (!active) return;
+        const flat: ApiProgramApplication[] = [];
+        for (const r of results) {
+          if (r?.data) flat.push(...r.data);
+        }
+        setMyApplications(flat.filter((a) => a.programId === program.id));
+      });
+    return () => {
+      active = false;
+    };
+  }, [program, myProjects]);
+
+  const existingApplication = useMemo(() => myApplications[0] || null, [myApplications]);
+
+  const connectWallet = async () => {
+    setConnecting(true);
+    try {
+      await web3Enable("Stadium");
+      const accounts = await web3Accounts();
+      if (accounts.length === 0) {
+        toast({
+          title: "No wallet account found",
+          description: "Install Polkadot-JS or Talisman and create an account first.",
+          variant: "destructive",
+        });
+        return;
+      }
+      setConnectedAddress(accounts[0].address);
+    } catch (e) {
+      const err = e as Error;
+      toast({
+        title: "Couldn't connect wallet",
+        description: err?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const handleApplied = (app: ApiProgramApplication) => {
+    setMyApplications((prev) => [app, ...prev]);
+  };
+
   const applicationsRange = formatDateRange(
     program?.applicationsOpenAt,
     program?.applicationsCloseAt,
   );
   const eventRange = formatDateRange(program?.eventStartsAt, program?.eventEndsAt);
+
+  const renderApplyCta = () => {
+    if (!program) return null;
+
+    if (program.status !== "open") {
+      return (
+        <Button disabled className="gap-2">
+          Applications closed
+        </Button>
+      );
+    }
+
+    if (existingApplication) {
+      return (
+        <div className="inline-flex items-center gap-2 rounded-md border bg-muted px-3 py-2 text-sm">
+          <CheckCircle2 className="h-4 w-4 text-primary" aria-hidden="true" />
+          Applied — status: <Badge variant="secondary">{existingApplication.status}</Badge>
+        </div>
+      );
+    }
+
+    if (!connectedAddress) {
+      return (
+        <Button onClick={connectWallet} disabled={connecting} className="gap-2">
+          <Wallet className="h-4 w-4" aria-hidden="true" />
+          {connecting ? "Connecting…" : "Sign in with wallet to apply"}
+        </Button>
+      );
+    }
+
+    if (myProjects.length === 0) {
+      return (
+        <div className="space-y-1">
+          <Button disabled className="gap-2">
+            Apply
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            You need to be a team member on a Stadium project to apply.
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <Button onClick={() => setModalOpen(true)} className="gap-2">
+        Apply with my project
+      </Button>
+    );
+  };
 
   return (
     <div className="min-h-screen bg-background">
@@ -148,19 +288,24 @@ const ProgramDetailPage = () => {
             </Card>
 
             <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-              {/*
-                Apply CTA is disabled for unauthenticated visitors. The wallet-
-                connected / team-member flow lands in #44 (Issue 9). Until then
-                it's a read-only signal that an apply path exists.
-              */}
-              <Button disabled className="gap-2">
-                <Wallet className="h-4 w-4" aria-hidden="true" />
-                Sign in with wallet to apply
-              </Button>
-              <p className="text-xs text-muted-foreground sm:ml-2">
-                Applications open to past WebZero winners who are on a Stadium project team.
-              </p>
+              {renderApplyCta()}
+              {!existingApplication && program.status === "open" && (
+                <p className="text-xs text-muted-foreground sm:ml-2">
+                  Applications open to past WebZero winners who are on a Stadium project team.
+                </p>
+              )}
             </div>
+
+            {connectedAddress && myProjects.length > 0 && (
+              <ApplyToProgramModal
+                open={modalOpen}
+                onOpenChange={setModalOpen}
+                program={program}
+                projects={myProjects}
+                connectedAddress={connectedAddress}
+                onApplied={handleApplied}
+              />
+            )}
           </article>
         ) : null}
       </main>

--- a/server/api/controllers/__tests__/program-application.test.js
+++ b/server/api/controllers/__tests__/program-application.test.js
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../services/program.service.js', () => ({
+  default: { findBySlug: vi.fn() },
+}));
+vi.mock('../../services/project.service.js', () => ({
+  default: { getProjectById: vi.fn() },
+}));
+vi.mock('../../services/program-application.service.js', () => ({
+  default: { listByProgram: vi.fn(), listByProject: vi.fn(), findOne: vi.fn(), create: vi.fn() },
+}));
+
+const programService = (await import('../../services/program.service.js')).default;
+const projectService = (await import('../../services/project.service.js')).default;
+const applicationService = (await import('../../services/program-application.service.js')).default;
+const programController = (await import('../program.controller.js')).default;
+
+const mockRes = () => {
+  const res = {};
+  res.status = vi.fn(() => res);
+  res.json = vi.fn(() => res);
+  return res;
+};
+
+describe('ProgramController.listApplicationsForProgram', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 404 when program is unknown', async () => {
+    programService.findBySlug.mockResolvedValue(null);
+    const req = { params: { slug: 'nope' } };
+    const res = mockRes();
+    await programController.listApplicationsForProgram(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns 200 with the list', async () => {
+    programService.findBySlug.mockResolvedValue({ id: 'p1' });
+    applicationService.listByProgram.mockResolvedValue([]);
+    const req = { params: { slug: 'dogfooding' } };
+    const res = mockRes();
+    await programController.listApplicationsForProgram(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(applicationService.listByProgram).toHaveBeenCalledWith('p1');
+  });
+});
+
+describe('ProgramController.listApplicationsForProject', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 404 when project is unknown', async () => {
+    projectService.getProjectById.mockResolvedValue(null);
+    const req = { params: { projectId: 'nope' } };
+    const res = mockRes();
+    await programController.listApplicationsForProject(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns 200 with an empty array when no applications exist', async () => {
+    projectService.getProjectById.mockResolvedValue({ id: 'plata' });
+    applicationService.listByProject.mockResolvedValue([]);
+    const req = { params: { projectId: 'plata' } };
+    const res = mockRes();
+    await programController.listApplicationsForProject(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ status: 'success', data: [] });
+  });
+});
+
+describe('ProgramController.createApplication', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const dogfooding = {
+    id: 'dogfooding-2026',
+    slug: 'dogfooding-2026',
+    programType: 'dogfooding',
+    status: 'open',
+  };
+  const plata = { id: 'plata-mia' };
+
+  const baseReq = (overrides = {}) => ({
+    params: { slug: 'dogfooding-2026' },
+    body: {
+      project_id: 'plata-mia',
+      application_fields: { feedback_focus: 'Cross-chain UX feedback.' },
+      ...overrides,
+    },
+    user: { address: 'addr' },
+  });
+
+  it('returns 400 when project_id is missing', async () => {
+    const req = { params: { slug: 's' }, body: {} };
+    const res = mockRes();
+    await programController.createApplication(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 404 when program is unknown', async () => {
+    programService.findBySlug.mockResolvedValue(null);
+    const req = baseReq();
+    const res = mockRes();
+    await programController.createApplication(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it("returns 400 when the program isn't open", async () => {
+    programService.findBySlug.mockResolvedValue({ ...dogfooding, status: 'closed' });
+    const req = baseReq();
+    const res = mockRes();
+    await programController.createApplication(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when program_type has no registered validator', async () => {
+    programService.findBySlug.mockResolvedValue({ ...dogfooding, programType: 'pitch_off' });
+    projectService.getProjectById.mockResolvedValue(plata);
+    const req = baseReq();
+    const res = mockRes();
+    await programController.createApplication(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      code: 'unsupported_program_type_for_application',
+    }));
+  });
+
+  it('returns 422 when application_fields fails the program-type validator', async () => {
+    programService.findBySlug.mockResolvedValue(dogfooding);
+    projectService.getProjectById.mockResolvedValue(plata);
+    const req = baseReq({ application_fields: { feedback_focus: 'x'.repeat(501) } });
+    const res = mockRes();
+    await programController.createApplication(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('returns 409 when the project has already applied', async () => {
+    programService.findBySlug.mockResolvedValue(dogfooding);
+    projectService.getProjectById.mockResolvedValue(plata);
+    applicationService.findOne.mockResolvedValue({ id: 'existing' });
+    const req = baseReq();
+    const res = mockRes();
+    await programController.createApplication(req, res);
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'already_applied' }));
+  });
+
+  it('creates the application with normalised fields on the happy path', async () => {
+    programService.findBySlug.mockResolvedValue(dogfooding);
+    projectService.getProjectById.mockResolvedValue(plata);
+    applicationService.findOne.mockResolvedValue(null);
+    const created = { id: 'app-1', projectId: 'plata-mia', status: 'submitted' };
+    applicationService.create.mockResolvedValue(created);
+    const req = baseReq({
+      application_fields: { feedback_focus: '   Cross-chain UX feedback.   ' },
+    });
+    const res = mockRes();
+    await programController.createApplication(req, res);
+    expect(applicationService.create).toHaveBeenCalledWith({
+      programId: dogfooding.id,
+      projectId: 'plata-mia',
+      applicationFields: { feedback_focus: 'Cross-chain UX feedback.' },
+      submittedBy: 'addr',
+    });
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it('returns 409 on DB unique_violation race', async () => {
+    programService.findBySlug.mockResolvedValue(dogfooding);
+    projectService.getProjectById.mockResolvedValue(plata);
+    applicationService.findOne.mockResolvedValue(null);
+    const err = Object.assign(new Error('dup'), { code: '23505' });
+    applicationService.create.mockRejectedValue(err);
+    const req = baseReq();
+    const res = mockRes();
+    await programController.createApplication(req, res);
+    expect(res.status).toHaveBeenCalledWith(409);
+  });
+});

--- a/server/api/controllers/program.controller.js
+++ b/server/api/controllers/program.controller.js
@@ -1,4 +1,7 @@
 import programService from '../services/program.service.js';
+import programApplicationService from '../services/program-application.service.js';
+import projectService from '../services/project.service.js';
+import { validateApplicationFields } from '../utils/application-fields.validator.js';
 
 class ProgramController {
   async list(req, res) {
@@ -26,6 +29,115 @@ class ProgramController {
     } catch (error) {
       console.error('❌ Error fetching program:', error);
       res.status(500).json({ status: 'error', message: 'Failed to fetch program' });
+    }
+  }
+
+  // --- Phase 1 revamp: program applications (#43) ---
+
+  /** Admin-gated: list all applications for a given program. */
+  async listApplicationsForProgram(req, res) {
+    try {
+      const { slug } = req.params;
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const applications = await programApplicationService.listByProgram(program.id);
+      res.status(200).json({ status: 'success', data: applications });
+    } catch (error) {
+      console.error('❌ Error listing program applications:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to list applications' });
+    }
+  }
+
+  /** Public: list all applications a given project has submitted. */
+  async listApplicationsForProject(req, res) {
+    try {
+      const { projectId } = req.params;
+      const project = await projectService.getProjectById(projectId);
+      if (!project) {
+        return res.status(404).json({ status: 'error', message: 'Project not found' });
+      }
+      const applications = await programApplicationService.listByProject(projectId);
+      res.status(200).json({ status: 'success', data: applications });
+    } catch (error) {
+      console.error('❌ Error listing project applications:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to list applications' });
+    }
+  }
+
+  /**
+   * POST /api/programs/:slug/applications
+   *
+   * Gated by `requireTeamMemberOrAdminByBodyProject` upstream — so by the time
+   * we reach this handler, the signer is authorised to act on behalf of the
+   * target project.
+   */
+  async createApplication(req, res) {
+    try {
+      const { slug } = req.params;
+      const { project_id: projectId, application_fields: applicationFields } = req.body || {};
+
+      if (!projectId || typeof projectId !== 'string') {
+        return res.status(400).json({ status: 'error', message: 'project_id is required' });
+      }
+
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      if (program.status !== 'open') {
+        return res.status(400).json({
+          status: 'error',
+          message: `Program is not accepting applications (status: ${program.status}).`,
+        });
+      }
+
+      const project = await projectService.getProjectById(projectId);
+      if (!project) {
+        return res.status(404).json({ status: 'error', message: 'Project not found' });
+      }
+
+      // Per-program-type validation
+      const result = validateApplicationFields(program.programType, applicationFields);
+      if (!result.valid) {
+        return res.status(result.code === 'unsupported_program_type_for_application' ? 400 : 422)
+          .json({ status: 'error', message: result.error, code: result.code });
+      }
+
+      // Uniqueness check (DB also enforces via UNIQUE constraint)
+      const existing = await programApplicationService.findOne({
+        programId: program.id,
+        projectId,
+      });
+      if (existing) {
+        return res.status(409).json({
+          status: 'error',
+          message: 'This project has already applied to this program. Withdraw before re-applying.',
+          code: 'already_applied',
+        });
+      }
+
+      const submittedBy = req.user?.address || req.auth?.address || 'unknown';
+      const created = await programApplicationService.create({
+        programId: program.id,
+        projectId,
+        applicationFields: result.normalised || applicationFields,
+        submittedBy,
+      });
+
+      res.status(201).json({ status: 'success', data: created });
+    } catch (error) {
+      // Postgres unique_violation fallback (in case of race between findOne and insert).
+      if (error?.code === '23505') {
+        return res.status(409).json({
+          status: 'error',
+          message: 'This project has already applied to this program.',
+          code: 'already_applied',
+        });
+      }
+      console.error('❌ Error creating program application:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to create application' });
     }
   }
 }

--- a/server/api/controllers/project.controller.js
+++ b/server/api/controllers/project.controller.js
@@ -23,6 +23,25 @@ class ProjectController {
         }
     }
 
+    /**
+     * Phase 1 revamp (#44): projects where a given wallet is a team member.
+     * Ordered by updated_at DESC so the Apply modal's default selection is
+     * the most-recently-updated project.
+     */
+    async getProjectsByTeamWallet(req, res) {
+        try {
+            const { address } = req.params;
+            if (!address || typeof address !== 'string') {
+                return res.status(400).json({ status: 'error', message: 'Address is required' });
+            }
+            const projects = await projectService.findByTeamWallet(address);
+            res.status(200).json({ status: 'success', data: projects });
+        } catch (error) {
+            console.error('❌ Error fetching projects by wallet:', error);
+            res.status(500).json({ status: 'error', message: 'Failed to fetch projects for wallet' });
+        }
+    }
+
     async createProject(req, res) {
         try {
             const projectData = req.body || {};

--- a/server/api/middleware/auth.middleware.js
+++ b/server/api/middleware/auth.middleware.js
@@ -40,7 +40,8 @@ const VALID_STATEMENTS = [
   "Reject project on Stadium",
   // Phase 1 revamp statements
   "Post an update on Stadium",
-  "Update funding signal on Stadium"
+  "Update funding signal on Stadium",
+  "Apply to program on Stadium"
 ];
 
 const EXPECTED_DOMAIN = process.env.EXPECTED_DOMAIN || 'localhost';
@@ -71,7 +72,9 @@ function validateSiwsStatement(statement) {
     // Phase 1 revamp: project updates (#41)
     /^Post an update to .+ on Stadium$/,
     // Phase 1 revamp: funding signal (#42)
-    /^Update funding signal for .+ on Stadium$/
+    /^Update funding signal for .+ on Stadium$/,
+    // Phase 1 revamp: apply project X to program Y (#44)
+    /^Apply project .+ to program .+ on Stadium$/
   ];
   
   return projectPatterns.some(pattern => pattern.test(statement));
@@ -309,6 +312,27 @@ export const requireTeamMemberOrAdmin = async (req, res, next) => {
     logError(`Database error while checking team membership: ${error.message}`);
     return res.status(500).json({ status: 'error', message: 'Internal server error during authorization' });
   }
+};
+
+/**
+ * Variant of requireTeamMemberOrAdmin that reads the project id from the
+ * request body instead of the URL param. Used by routes whose URL is keyed
+ * to a different resource (e.g. POST /api/programs/:slug/applications, where
+ * :slug identifies the program and body.project_id identifies the project).
+ *
+ * Reuses requireTeamMemberOrAdmin unchanged — it just sets req.params.projectId
+ * so the downstream logic works.
+ */
+export const requireTeamMemberOrAdminByBodyProject = async (req, res, next) => {
+  const projectId = req.body?.project_id;
+  if (!projectId || typeof projectId !== 'string') {
+    return res.status(400).json({
+      status: 'error',
+      message: 'project_id is required in request body for this endpoint',
+    });
+  }
+  req.params = { ...req.params, projectId };
+  return requireTeamMemberOrAdmin(req, res, next);
 };
 
 export default requireAdmin;

--- a/server/api/repositories/program-application.repository.js
+++ b/server/api/repositories/program-application.repository.js
@@ -1,0 +1,85 @@
+import { supabase } from '../../db.js';
+
+const transform = (row) => {
+  if (!row) return null;
+  return {
+    id: row.id,
+    programId: row.program_id,
+    projectId: row.project_id,
+    status: row.status,
+    applicationFields: row.application_fields || {},
+    submittedBy: row.submitted_by,
+    submittedAt: row.submitted_at,
+    reviewedBy: row.reviewed_by,
+    reviewedAt: row.reviewed_at,
+    reviewNotes: row.review_notes,
+  };
+};
+
+class ProgramApplicationRepository {
+  async listByProgram(programId) {
+    const { data, error } = await supabase
+      .from('program_applications')
+      .select('*')
+      .eq('program_id', programId)
+      .order('submitted_at', { ascending: false });
+    if (error) throw error;
+    return (data || []).map(transform);
+  }
+
+  async listByProject(projectId) {
+    const { data, error } = await supabase
+      .from('program_applications')
+      .select('*')
+      .eq('project_id', projectId)
+      .order('submitted_at', { ascending: false });
+    if (error) throw error;
+    return (data || []).map(transform);
+  }
+
+  async findOne({ programId, projectId }) {
+    const { data, error } = await supabase
+      .from('program_applications')
+      .select('*')
+      .eq('program_id', programId)
+      .eq('project_id', projectId)
+      .maybeSingle();
+    if (error) throw error;
+    return transform(data);
+  }
+
+  async create({ programId, projectId, applicationFields, submittedBy }) {
+    const { data, error } = await supabase
+      .from('program_applications')
+      .insert({
+        program_id: programId,
+        project_id: projectId,
+        status: 'submitted',
+        application_fields: applicationFields || {},
+        submitted_by: submittedBy,
+      })
+      .select('*')
+      .single();
+    if (error) throw error;
+    return transform(data);
+  }
+
+  /** Phase 1: used by admin review flow (#47, Block F). */
+  async updateStatus({ id, status, reviewedBy, reviewNotes }) {
+    const { data, error } = await supabase
+      .from('program_applications')
+      .update({
+        status,
+        reviewed_by: reviewedBy,
+        reviewed_at: new Date().toISOString(),
+        review_notes: reviewNotes || null,
+      })
+      .eq('id', id)
+      .select('*')
+      .single();
+    if (error) throw error;
+    return transform(data);
+  }
+}
+
+export default new ProgramApplicationRepository();

--- a/server/api/repositories/project.repository.js
+++ b/server/api/repositories/project.repository.js
@@ -477,6 +477,33 @@ class ProjectRepository {
         // Fetch and return updated project
         return await this.getProjectById(projectId);
     }
+
+    /**
+     * Phase 1 revamp (#44): find all projects where the given wallet address
+     * appears on the team roster. Returns projects ordered by updated_at DESC
+     * so "the most-recently-updated project" is the default selection in the
+     * Apply modal.
+     */
+    async findByTeamWallet(walletAddress) {
+        if (!walletAddress) return [];
+        // Two-step: first, get project ids where the wallet is a team member.
+        const { data: teamRows, error: teamErr } = await supabase
+            .from('team_members')
+            .select('project_id')
+            .eq('wallet_address', walletAddress);
+        if (teamErr) throw teamErr;
+        const projectIds = [...new Set((teamRows || []).map((r) => r.project_id))];
+        if (projectIds.length === 0) return [];
+
+        // Second: fetch the projects with their joined relations.
+        const { data, error } = await supabase
+            .from('projects')
+            .select('*, team_members(*), bounty_prizes(*), milestones(*), payments(*)')
+            .in('id', projectIds)
+            .order('updated_at', { ascending: false });
+        if (error) throw error;
+        return (data || []).map(transformProject);
+    }
 }
 
 export default new ProjectRepository();

--- a/server/api/routes/m2-program.routes.js
+++ b/server/api/routes/m2-program.routes.js
@@ -7,6 +7,9 @@ const router = Router();
 
 // --- Public, Read-Only Routes ---
 router.get('/', projectController.getAllProjects);
+// Phase 1 revamp (#44): projects a given wallet is on the team of.
+// MUST be declared before /:projectId so the path doesn't collide with it.
+router.get('/by-team/:address', projectController.getProjectsByTeamWallet);
 router.get('/:projectId', projectController.getProjectById);
 
 // --- Admin-Only, Write Routes ---

--- a/server/api/routes/m2-program.routes.js
+++ b/server/api/routes/m2-program.routes.js
@@ -1,5 +1,6 @@
 import { Router } from 'express';
 import projectController from '../controllers/project.controller.js';
+import programController from '../controllers/program.controller.js';
 import requireAdmin, { requireTeamMemberOrAdmin } from '../middleware/auth.middleware.js';
 
 const router = Router();
@@ -27,6 +28,9 @@ router.post('/:projectId/updates', requireTeamMemberOrAdmin, projectController.p
 // --- Phase 1 revamp: funding signal (#42) ---
 router.get('/:projectId/funding-signal', projectController.getFundingSignal);
 router.patch('/:projectId/funding-signal', requireTeamMemberOrAdmin, projectController.updateFundingSignal);
+
+// --- Phase 1 revamp: per-project application list (#43) ---
+router.get('/:projectId/applications', programController.listApplicationsForProject);
 
 // --- Admin M2 approval ---
 router.post('/:projectId/approve', requireAdmin, projectController.approveM2);

--- a/server/api/routes/program.routes.js
+++ b/server/api/routes/program.routes.js
@@ -1,10 +1,19 @@
 import { Router } from 'express';
 import programController from '../controllers/program.controller.js';
+import requireAdmin, { requireTeamMemberOrAdminByBodyProject } from '../middleware/auth.middleware.js';
 
 const router = Router();
 
 // --- Public, Read-Only Routes ---
 router.get('/', programController.list);
 router.get('/:slug', programController.getBySlug);
+
+// --- Phase 1 revamp: applications (#43) ---
+router.get('/:slug/applications', requireAdmin, programController.listApplicationsForProgram);
+router.post(
+  '/:slug/applications',
+  requireTeamMemberOrAdminByBodyProject,
+  programController.createApplication,
+);
 
 export default router;

--- a/server/api/services/program-application.service.js
+++ b/server/api/services/program-application.service.js
@@ -1,0 +1,25 @@
+import programApplicationRepository from '../repositories/program-application.repository.js';
+
+class ProgramApplicationService {
+  async listByProgram(programId) {
+    return await programApplicationRepository.listByProgram(programId);
+  }
+
+  async listByProject(projectId) {
+    return await programApplicationRepository.listByProject(projectId);
+  }
+
+  async findOne(payload) {
+    return await programApplicationRepository.findOne(payload);
+  }
+
+  async create(payload) {
+    return await programApplicationRepository.create(payload);
+  }
+
+  async updateStatus(payload) {
+    return await programApplicationRepository.updateStatus(payload);
+  }
+}
+
+export default new ProgramApplicationService();

--- a/server/api/services/project.service.js
+++ b/server/api/services/project.service.js
@@ -5,6 +5,10 @@ class ProjectService {
         return await projectRepository.getProjectById(projectId);
     }
 
+    async findByTeamWallet(walletAddress) {
+        return await projectRepository.findByTeamWallet(walletAddress);
+    }
+
     async createProject(projectData) {
         return await projectRepository.createProject(projectData);
     }

--- a/server/api/utils/application-fields.validator.js
+++ b/server/api/utils/application-fields.validator.js
@@ -1,0 +1,46 @@
+/**
+ * Per-program-type validator for `program_applications.application_fields`.
+ * Spec reference: docs/stadium-revamp-phase-1-spec.md §5 Issue 8.
+ *
+ * Phase 1 ships only the `dogfooding` program type. POSTing an application
+ * against a program whose `program_type` has no registered validator returns
+ * a 400 with a distinct code so the admin UI can surface it clearly.
+ *
+ * Adding a new program type is a two-line change: register its schema in
+ * `validators`, done.
+ */
+
+const dogfooding = (fields) => {
+  if (!fields || typeof fields !== 'object' || Array.isArray(fields)) {
+    return { valid: false, error: 'application_fields must be an object' };
+  }
+  const { feedback_focus } = fields;
+  if (typeof feedback_focus !== 'string') {
+    return { valid: false, error: 'feedback_focus is required and must be a string' };
+  }
+  const trimmed = feedback_focus.trim();
+  if (trimmed.length < 1 || trimmed.length > 500) {
+    return { valid: false, error: 'feedback_focus must be 1–500 characters' };
+  }
+  // Return a canonicalised shape (trimmed string). Callers can use it to
+  // persist the normalised value.
+  return { valid: true, normalised: { feedback_focus: trimmed } };
+};
+
+const validators = {
+  dogfooding,
+};
+
+export const validateApplicationFields = (programType, fields) => {
+  const fn = validators[programType];
+  if (!fn) {
+    return {
+      valid: false,
+      code: 'unsupported_program_type_for_application',
+      error: `No application-field validator registered for program_type "${programType}".`,
+    };
+  }
+  return fn(fields);
+};
+
+export const SUPPORTED_APPLICATION_PROGRAM_TYPES = Object.keys(validators);

--- a/supabase/migrations/20260422030000_create_program_applications.sql
+++ b/supabase/migrations/20260422030000_create_program_applications.sql
@@ -1,0 +1,25 @@
+-- Stadium Phase 1 Revamp — program_applications (issue #43, Block D).
+-- See docs/stadium-revamp-phase-1-spec.md §4.2.
+--
+-- A project applies once to a given program; UNIQUE (program_id, project_id)
+-- enforces this. Application metadata lives in a JSONB column so per-program-
+-- type fields don't require a new table per type — the server-side validator
+-- dispatches on programs.program_type.
+
+CREATE TABLE IF NOT EXISTS program_applications (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  program_id         TEXT NOT NULL REFERENCES programs(id)  ON DELETE CASCADE,
+  project_id         TEXT NOT NULL REFERENCES projects(id)  ON DELETE CASCADE,
+  status             TEXT NOT NULL CHECK (status IN ('submitted', 'accepted', 'rejected', 'withdrawn')),
+  application_fields JSONB NOT NULL DEFAULT '{}',
+  submitted_by       TEXT NOT NULL,
+  submitted_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  reviewed_by        TEXT,
+  reviewed_at        TIMESTAMPTZ,
+  review_notes       TEXT,
+  UNIQUE (program_id, project_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_program_applications_program ON program_applications(program_id);
+CREATE INDEX IF NOT EXISTS idx_program_applications_project ON program_applications(project_id);
+CREATE INDEX IF NOT EXISTS idx_program_applications_status  ON program_applications(status);


### PR DESCRIPTION
Block D of the Phase 1 revamp — the load-bearing issue of the phase. A team member applies their existing project to an open program in one action.

Closes #43, #44.

## Block D journey slice (per spec §12)

*"I can apply my project to Dogfooding in one action."* Team member connects wallet on `/programs/dogfooding-2026-berlin` → Apply button enabled → modal prefilled with their most-recent project → fills `feedback_focus` → signs SIWS → page shows "Applied — status: submitted".

## Commits

### #43: schema + API

- Migration `supabase/migrations/20260422030000_create_program_applications.sql` (spec §4.2).
- Per-program-type validator at `server/api/utils/application-fields.validator.js` — Phase 1 registers Dogfooding's `{ feedback_focus: string, 1..500 }`. Unsupported types return `400 unsupported_program_type_for_application`.
- Repository + service with listByProgram / listByProject / findOne / create / updateStatus (last one for #47).
- `POST /api/programs/:slug/applications` (new `requireTeamMemberOrAdminByBodyProject` middleware reads `body.project_id`), `GET /api/programs/:slug/applications` (requireAdmin), `GET /api/m2-program/:projectId/applications` (public).
- Uniqueness enforced in DB (UNIQUE constraint) + application code (findOne pre-check + 23505 fallback).
- 10 new server unit tests covering all error paths and the happy path.

### #44: Apply modal

- `findByTeamWallet(address)` on the project repository/service/controller, exposed as `GET /api/m2-program/by-team/:address`. Ordered by updated_at DESC so the modal default is the most-recently-updated project.
- `api.getProjectsByTeamWallet`, `api.getApplicationsForProject`, `api.listProgramApplications`, `api.applyToProgram` in `client/src/lib/api.ts` — all with mock-mode fallbacks that enforce the same (program, project) uniqueness.
- New `ApplyToProgramModal` — project selector always renders (even when N=1), Dogfooding `feedback_focus` textarea with inline 1..500 validation, SIWS sign + POST.
- New 'apply-to-program' SIWS action + matching server-side regex.
- `ProgramDetailPage` rewritten to handle the four CTA states:
  - **No wallet connected** → "Sign in with wallet to apply" (actually connects).
  - **Wallet connected, N=0 team memberships** → Apply disabled + "You need to be a team member on a Stadium project to apply."
  - **Wallet connected, N≥1** → "Apply with my project" opens modal.
  - **Already applied** → "Applied — status: submitted/accepted/rejected" badge replaces the CTA.
  - **Applications closed** → disabled "Applications closed".
- Seeded `mockProgramApplications.ts` with Plata Mia → Dogfooding so Block E can render it.

## Test plan

Automated:
- [x] `cd server && npm test` → 32/32 passing.
- [x] `cd client && npm run build` → clean.

Playwright (auto-verifiable):
- [ ] On `/programs/dogfooding-2026-berlin`, un-authenticated visitor sees "Sign in with wallet to apply" button.
- [ ] On `/programs/dogfooding-2026-berlin`, the page renders program metadata (name, dates, location).
- [ ] `GET /api/programs/dogfooding-2026-berlin/applications` without auth returns 401 (admin-only).
- [ ] `GET /api/m2-program/plata-mia-15ac43/applications` returns the seeded application in the response.

SIWS-gated (manual QA with a real wallet):
- [ ] Connect wallet with 0 team memberships → Apply disabled with "You need to be a team member…" copy.
- [ ] Connect wallet that is a team member → Apply enabled; modal shows project selector defaulted to most-recent; for Dogfooding, the feedback_focus textarea renders.
- [ ] Submit with `feedback_focus = "…"` → SIWS prompt → sign → modal closes → page replaces CTA with "Applied — status: submitted" without reload.
- [ ] `feedback_focus` > 500 chars → inline error; no network call.
- [ ] Apply again with the same project → 409 error surfaced as toast.
- [ ] Apply with a different project (same wallet) → succeeds; now two applications.

## Out of scope (deferred per spec)

- Admin applications queue (#47, Block F). The admin GET endpoint lands here but no admin UI consumes it yet.
- Projects-on-detail-page list (#45, Block E) — the data is available via `api.getApplicationsForProject`; that issue wires it into the UI.
- Accept / reject / review-notes mutations (#47, Block F) — repository has updateStatus ready; route + controller land with Block F.

## Ops

- Seed script `node server/scripts/seed-dogfooding-program.js` (from Block A) remains the way to create the Dogfooding program in a fresh environment. Applications are written via the API; no seed needed.