### PR TITLE
feat(revamp): Block E — Programs section on ProjectDetailsPage (closes #45)

### DIFF
--- a/client/src/components/project/ProjectProgramsSection.tsx
+++ b/client/src/components/project/ProjectProgramsSection.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Loader2, Sparkles, ExternalLink } from "lucide-react";
+import { api, type ApiProgram, type ApiProgramApplication } from "@/lib/api";
+
+type Row = ApiProgramApplication & { program?: ApiProgram };
+
+const statusVariant = (status: ApiProgramApplication["status"]) => {
+  switch (status) {
+    case "accepted":
+      return "default" as const;
+    case "rejected":
+    case "withdrawn":
+      return "outline" as const;
+    default:
+      return "secondary" as const;
+  }
+};
+
+/**
+ * Phase 1 revamp (#45): shows which programs this project has applied to,
+ * with status, on the project's Overview tab. Link is a real anchor so
+ * right-click-open-in-new-tab works (spec §3.1).
+ *
+ * Implementation: fetches applications + all programs in parallel, joins
+ * on programId. Small-scale data today; if the programs table grows, this
+ * becomes a dedicated per-project-with-program-metadata endpoint.
+ */
+export function ProjectProgramsSection({ projectId }: { projectId: string }) {
+  const [rows, setRows] = useState<Row[] | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    Promise.all([api.getApplicationsForProject(projectId), api.listPrograms()])
+      .then(([appsRes, progsRes]) => {
+        if (!active) return;
+        const byId = new Map<string, ApiProgram>();
+        for (const p of progsRes.data) byId.set(p.id, p);
+        const joined: Row[] = appsRes.data.map((a) => ({ ...a, program: byId.get(a.programId) }));
+        setRows(joined);
+      })
+      .catch(() => {
+        if (active) setRows([]);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [projectId]);
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg flex items-center gap-2">
+            <Sparkles className="w-5 h-5" aria-hidden="true" />
+            Programs
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            Loading…
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  // Don't render the section at all for projects with no applications. This is
+  // the minimal empty state per spec §5 Issue 10 — "section hidden OR a minimal
+  // 'No program applications yet' line."
+  if (!rows || rows.length === 0) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg flex items-center gap-2">
+          <Sparkles className="w-5 h-5" aria-hidden="true" />
+          Programs
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2">
+          {rows.map((r) => {
+            const slug = r.program?.slug;
+            const name = r.program?.name || r.programId;
+            return (
+              <li key={r.id} className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  {slug ? (
+                    <Link
+                      to={`/programs/${slug}`}
+                      className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-sm"
+                    >
+                      {name}
+                      <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+                    </Link>
+                  ) : (
+                    <span className="text-sm font-medium">{name}</span>
+                  )}
+                </div>
+                <Badge variant={statusVariant(r.status)}>{r.status}</Badge>
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/pages/ProjectDetailsPage.tsx
+++ b/client/src/pages/ProjectDetailsPage.tsx
@@ -46,6 +46,7 @@ import { SubmitM2DeliverablesModal } from "@/components/SubmitM2DeliverablesModa
 import { ProjectUpdatesTab } from "@/components/project/ProjectUpdatesTab";
 import { FundingSignalBadge } from "@/components/project/FundingSignalBadge";
 import { EditFundingSignalModal } from "@/components/project/EditFundingSignalModal";
+import { ProjectProgramsSection } from "@/components/project/ProjectProgramsSection";
 import type { ApiFundingSignal } from "@/lib/api";
 import { EditProjectDetailsModal } from "@/components/EditProjectDetailsModal";
 import { isAdmin as checkIsAdmin } from "@/lib/constants";
@@ -1091,6 +1092,9 @@ const ProjectDetailsPage = () => {
                     )}
                   </div>
                 )}
+
+                {/* Programs section — Phase 1 revamp (#45) */}
+                <ProjectProgramsSection projectId={project.id} />
 
                 {/* Final Deliverables */}
                 {project.finalSubmission && (


### PR DESCRIPTION
Block E of the Phase 1 revamp — single-issue block. Shows on a project's Overview which programs it has applied to, with status.

**Stacked on #55 (Block D).** Target base is `revamp/block-d-program-applications` while that PR is open. Once #55 merges, I'll rebase this branch onto `develop` and retarget the PR.

Closes #45.

## Block E journey slice (per spec §12)

*"My project page shows where I've applied."* Navigate to `/m2-program/plata-mia-15ac43` → Overview tab shows a Programs section listing "Dogfooding 2026 → submitted" with a real anchor link to `/programs/dogfooding-2026-berlin`.

## End of Block E = full preview journey lights up

Once this lands (and #53 / #54 which landed alongside), the mock-mode preview renders Plata Mia's complete Phase 1 journey end-to-end:

- `/programs/dogfooding-2026-berlin` — the Dogfooding program (Block A)
- `/m2-program/plata-mia-15ac43`:
  - Updates tab with two seeded updates (Block B)
  - Funding signal badge on Overview (Block C)
  - Programs section on Overview linking back to Dogfooding (this PR)

## Commit

### #45: Programs section

- `client/src/components/project/ProjectProgramsSection.tsx` (new) — fetches `api.getApplicationsForProject(projectId)` and `api.listPrograms()` in parallel, joins on `programId`, renders a small list card with program name (real `<Link>` anchor, inherits right-click-open-in-new-tab for free) and a status badge.
- `client/src/pages/ProjectDetailsPage.tsx` — mounts the section at the top of the Overview tab, above Final Deliverables.

## Empty state

The spec said *"section hidden OR a minimal 'No program applications yet' line"*. I picked **hidden** to avoid dead space on every project that isn't applying to anything. Easy to flip later if the team prefers the line.

## Test plan

Automated:
- [x] `cd client && npm run build` → clean.
- [x] No server changes → server tests unaffected.

Playwright (auto-verifiable in mock mode):
- [ ] On `/m2-program/plata-mia-15ac43`, the Overview tab shows a "Programs" card with "Dogfooding 2026" and a "submitted" badge.
- [ ] Clicking the "Dogfooding 2026" link navigates to `/programs/dogfooding-2026-berlin`.
- [ ] On `/m2-program/plata-mia-15ac43`, right-click → Open Link in New Tab on "Dogfooding 2026" works (anchor semantics).
- [ ] On `/m2-program/<a-project-with-no-applications>`, the Overview tab has no Programs section.

## Out of scope

- Withdrawing an application from the project side (Phase 2+).
- Per-program-type rendering of `applicationFields` on this list (it's a summary list; the Apply modal is where fields are entered).