### PR TITLE
feat(revamp): Block F — admin program management (closes #46 #47)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -14,6 +14,7 @@ import { useEffect } from "react";
 import WinnersPage from "./pages/WinnersPage";
 import ProgramsPage from "./pages/ProgramsPage";
 import ProgramDetailPage from "./pages/ProgramDetailPage";
+import AdminProgramPage from "./pages/AdminProgramPage";
 
 // Redirect component for old project routes
 const ProjectRedirect = () => {
@@ -65,6 +66,7 @@ const App = () => {
               </Route>
               <Route path="m2-program/:id" element={<ProjectDetailsPage />} />
               <Route path="programs/:slug" element={<ProgramDetailPage />} />
+              <Route path="admin/programs/:slug" element={<AdminProgramPage />} />
               <Route path="winners/:hackathon" element={<WinnersPage />} />
               {/* Redirect old project detail route */}
               <Route path="projects/:id" element={<ProjectRedirect />} />

--- a/client/src/components/admin/ApplicationCard.tsx
+++ b/client/src/components/admin/ApplicationCard.tsx
@@ -1,0 +1,166 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { CheckCircle2, XCircle, ExternalLink, Loader2 } from "lucide-react";
+import { web3Enable, web3Accounts, web3FromSource } from "@polkadot/extension-dapp";
+import { SiwsMessage } from "@talismn/siws";
+import { generateSiwsStatement } from "@/lib/siwsUtils";
+import { api, type ApiProgramApplication } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+
+const statusVariant = (status: ApiProgramApplication["status"]) => {
+  switch (status) {
+    case "accepted":
+      return "default" as const;
+    case "rejected":
+    case "withdrawn":
+      return "outline" as const;
+    default:
+      return "secondary" as const;
+  }
+};
+
+const truncateAddress = (addr?: string | null) => {
+  if (!addr) return "—";
+  if (addr.length <= 14) return addr;
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+};
+
+export function ApplicationCard({
+  application,
+  programSlug,
+  connectedAddress,
+  onUpdated,
+}: {
+  application: ApiProgramApplication;
+  programSlug: string;
+  connectedAddress: string;
+  onUpdated: (next: ApiProgramApplication) => void;
+}) {
+  const [working, setWorking] = useState<"accept" | "reject" | null>(null);
+  const { toast } = useToast();
+
+  const doUpdate = async (next: ApiProgramApplication["status"]) => {
+    setWorking(next === "accepted" ? "accept" : "reject");
+    try {
+      await web3Enable("Stadium");
+      const accounts = await web3Accounts();
+      const account = accounts.find((a) => a.address === connectedAddress) || accounts[0];
+      if (!account) throw new Error("No wallet account found");
+
+      const siws = new SiwsMessage({
+        domain: window.location.hostname,
+        uri: window.location.origin,
+        address: account.address,
+        nonce: Math.random().toString(36).slice(2),
+        statement: generateSiwsStatement({ action: "review-application" }),
+      });
+      const injector = await web3FromSource(account.meta.source);
+      const signed = (await siws.sign(injector)) as unknown as { signature: string; message?: string };
+      const messageStr =
+        typeof signed.message === "string" && signed.message
+          ? signed.message
+          : (siws as unknown as { toString: () => string }).toString();
+      const authHeader = btoa(
+        JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address }),
+      );
+
+      const res = await api.updateApplicationStatus(
+        programSlug,
+        application.id,
+        { status: next },
+        authHeader,
+      );
+      onUpdated(res.data);
+      toast({ title: `Application ${next}` });
+    } catch (e) {
+      const err = e as Error;
+      toast({
+        title: "Couldn't update application",
+        description: err?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setWorking(null);
+    }
+  };
+
+  const focus =
+    typeof application.applicationFields?.feedback_focus === "string"
+      ? (application.applicationFields.feedback_focus as string)
+      : null;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between gap-3">
+        <div className="min-w-0">
+          <Link
+            to={`/m2-program/${application.projectId}`}
+            className="inline-flex items-center gap-1 text-sm font-semibold text-primary hover:underline"
+          >
+            {application.projectId}
+            <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+          </Link>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Submitted by {truncateAddress(application.submittedBy)} ·{" "}
+            {new Date(application.submittedAt).toLocaleDateString()}
+          </p>
+        </div>
+        <Badge variant={statusVariant(application.status)}>{application.status}</Badge>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {focus && (
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Feedback focus
+            </p>
+            <p className="mt-1 whitespace-pre-line text-sm">{focus}</p>
+          </div>
+        )}
+        {application.reviewNotes && (
+          <div>
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Review notes
+            </p>
+            <p className="mt-1 whitespace-pre-line text-sm text-muted-foreground">
+              {application.reviewNotes}
+            </p>
+          </div>
+        )}
+        {application.status === "submitted" && (
+          <div className="flex flex-wrap gap-2 pt-1">
+            <Button
+              size="sm"
+              onClick={() => doUpdate("accepted")}
+              disabled={working !== null}
+              className="gap-2"
+            >
+              {working === "accept" ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+              ) : (
+                <CheckCircle2 className="h-3.5 w-3.5" aria-hidden="true" />
+              )}
+              Accept
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => doUpdate("rejected")}
+              disabled={working !== null}
+              className="gap-2"
+            >
+              {working === "reject" ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+              ) : (
+                <XCircle className="h-3.5 w-3.5" aria-hidden="true" />
+              )}
+              Reject
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/components/admin/ProgramFormModal.tsx
+++ b/client/src/components/admin/ProgramFormModal.tsx
@@ -1,0 +1,401 @@
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Loader2 } from "lucide-react";
+import { web3Enable, web3Accounts, web3FromSource } from "@polkadot/extension-dapp";
+import { SiwsMessage } from "@talismn/siws";
+import { generateSiwsStatement } from "@/lib/siwsUtils";
+import { api, type ApiProgram } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+
+const PROGRAM_TYPES: Array<{ value: ApiProgram["programType"]; label: string }> = [
+  { value: "dogfooding", label: "Dogfooding" },
+  { value: "pitch_off", label: "Pitch Off" },
+  { value: "hackathon", label: "Hackathon" },
+  { value: "m2_incubator", label: "M2 Incubator" },
+];
+
+const STATUSES: Array<{ value: ApiProgram["status"]; label: string }> = [
+  { value: "draft", label: "Draft" },
+  { value: "open", label: "Open" },
+  { value: "closed", label: "Closed" },
+  { value: "completed", label: "Completed" },
+];
+
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const slugify = (name: string) =>
+  name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 100);
+
+/** Convert ISO datetime → local-datetime-input value (yyyy-MM-ddThh:mm). */
+const isoToLocal = (iso?: string | null) => {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(
+    d.getMinutes(),
+  )}`;
+};
+const localToIso = (v: string) => (v ? new Date(v).toISOString() : null);
+
+export function ProgramFormModal({
+  open,
+  onOpenChange,
+  program,
+  connectedAddress,
+  onSaved,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  /** When provided, the modal is in edit mode for this program. Otherwise create mode. */
+  program: ApiProgram | null;
+  connectedAddress: string;
+  onSaved: (program: ApiProgram) => void;
+}) {
+  const editing = Boolean(program);
+
+  const [name, setName] = useState("");
+  const [slug, setSlug] = useState("");
+  const [slugEdited, setSlugEdited] = useState(false);
+  const [programType, setProgramType] = useState<ApiProgram["programType"]>("dogfooding");
+  const [status, setStatus] = useState<ApiProgram["status"]>("draft");
+  const [description, setDescription] = useState("");
+  const [location, setLocation] = useState("");
+  const [maxApplicants, setMaxApplicants] = useState("");
+  const [applicationsOpenAt, setApplicationsOpenAt] = useState("");
+  const [applicationsCloseAt, setApplicationsCloseAt] = useState("");
+  const [eventStartsAt, setEventStartsAt] = useState("");
+  const [eventEndsAt, setEventEndsAt] = useState("");
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (!open) return;
+    if (program) {
+      setName(program.name);
+      setSlug(program.slug);
+      setSlugEdited(true);
+      setProgramType(program.programType);
+      setStatus(program.status);
+      setDescription(program.description || "");
+      setLocation(program.location || "");
+      setMaxApplicants(program.maxApplicants ? String(program.maxApplicants) : "");
+      setApplicationsOpenAt(isoToLocal(program.applicationsOpenAt));
+      setApplicationsCloseAt(isoToLocal(program.applicationsCloseAt));
+      setEventStartsAt(isoToLocal(program.eventStartsAt));
+      setEventEndsAt(isoToLocal(program.eventEndsAt));
+    } else {
+      setName("");
+      setSlug("");
+      setSlugEdited(false);
+      setProgramType("dogfooding");
+      setStatus("draft");
+      setDescription("");
+      setLocation("");
+      setMaxApplicants("");
+      setApplicationsOpenAt("");
+      setApplicationsCloseAt("");
+      setEventStartsAt("");
+      setEventEndsAt("");
+    }
+    setErrors({});
+  }, [open, program]);
+
+  useEffect(() => {
+    if (!slugEdited) setSlug(slugify(name));
+  }, [name, slugEdited]);
+
+  const validate = (): boolean => {
+    const e: Record<string, string> = {};
+    if (!name.trim()) e.name = "Name is required.";
+    if (name.length > 200) e.name = "Name must be 200 characters or fewer.";
+    if (!SLUG_RE.test(slug) || slug.length > 100) {
+      e.slug = "Slug must be lowercase letters, numbers, and hyphens.";
+    }
+    if (maxApplicants) {
+      const n = Number(maxApplicants);
+      if (!Number.isInteger(n) || n < 1) e.maxApplicants = "Must be a positive integer.";
+    }
+    if (applicationsOpenAt && applicationsCloseAt) {
+      if (new Date(applicationsOpenAt).getTime() >= new Date(applicationsCloseAt).getTime()) {
+        e.applicationsCloseAt = "Close date must be after open date.";
+      }
+    }
+    if (eventStartsAt && eventEndsAt) {
+      if (new Date(eventStartsAt).getTime() > new Date(eventEndsAt).getTime()) {
+        e.eventEndsAt = "End date must be on or after start date.";
+      }
+    }
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  };
+
+  const handleSubmit = async () => {
+    if (!validate()) return;
+    setSubmitting(true);
+    try {
+      await web3Enable("Stadium");
+      const accounts = await web3Accounts();
+      const account = accounts.find((a) => a.address === connectedAddress) || accounts[0];
+      if (!account) throw new Error("No wallet account found");
+
+      const siws = new SiwsMessage({
+        domain: window.location.hostname,
+        uri: window.location.origin,
+        address: account.address,
+        nonce: Math.random().toString(36).slice(2),
+        statement: generateSiwsStatement({
+          action: editing ? "update-program" : "create-program",
+        }),
+      });
+      const injector = await web3FromSource(account.meta.source);
+      const signed = (await siws.sign(injector)) as unknown as { signature: string; message?: string };
+      const messageStr =
+        typeof signed.message === "string" && signed.message
+          ? signed.message
+          : (siws as unknown as { toString: () => string }).toString();
+      const authHeader = btoa(
+        JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address }),
+      );
+
+      const payload: Partial<ApiProgram> & {
+        name: string;
+        slug: string;
+        programType: ApiProgram["programType"];
+        status: ApiProgram["status"];
+      } = {
+        name: name.trim(),
+        slug: slug.trim(),
+        programType,
+        status,
+        description: description.trim() || null,
+        location: location.trim() || null,
+        maxApplicants: maxApplicants ? Number(maxApplicants) : null,
+        applicationsOpenAt: localToIso(applicationsOpenAt),
+        applicationsCloseAt: localToIso(applicationsCloseAt),
+        eventStartsAt: localToIso(eventStartsAt),
+        eventEndsAt: localToIso(eventEndsAt),
+      };
+
+      const res = editing
+        ? await api.updateProgram(program!.slug, payload, authHeader)
+        : await api.createProgram(payload, authHeader);
+      onSaved(res.data);
+      toast({ title: editing ? "Program updated" : "Program created" });
+      onOpenChange(false);
+    } catch (e) {
+      const err = e as Error & { status?: number };
+      toast({
+        title: editing ? "Couldn't update program" : "Couldn't create program",
+        description: err?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => (submitting ? null : onOpenChange(v))}>
+      <DialogContent className="sm:max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>{editing ? "Edit program" : "Create program"}</DialogTitle>
+          <DialogDescription>
+            {editing
+              ? "Update the program metadata."
+              : "Set up a new program. Applications open once the status is Open."}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="sm:col-span-2 space-y-1">
+            <Label htmlFor="pf-name">Name</Label>
+            <Input
+              id="pf-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              aria-invalid={errors.name ? true : undefined}
+            />
+            {errors.name && <p className="text-xs text-destructive">{errors.name}</p>}
+          </div>
+
+          <div className="sm:col-span-2 space-y-1">
+            <Label htmlFor="pf-slug">Slug</Label>
+            <Input
+              id="pf-slug"
+              value={slug}
+              onChange={(e) => {
+                setSlug(e.target.value);
+                setSlugEdited(true);
+              }}
+              aria-invalid={errors.slug ? true : undefined}
+              disabled={editing}
+            />
+            {errors.slug && <p className="text-xs text-destructive">{errors.slug}</p>}
+            {editing && (
+              <p className="text-xs text-muted-foreground">
+                Slug can't be changed after creation in this flow.
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="pf-type">Type</Label>
+            <Select
+              value={programType}
+              onValueChange={(v) => setProgramType(v as ApiProgram["programType"])}
+            >
+              <SelectTrigger id="pf-type">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PROGRAM_TYPES.map((t) => (
+                  <SelectItem key={t.value} value={t.value}>
+                    {t.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="pf-status">Status</Label>
+            <Select value={status} onValueChange={(v) => setStatus(v as ApiProgram["status"])}>
+              <SelectTrigger id="pf-status">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {STATUSES.map((s) => (
+                  <SelectItem key={s.value} value={s.value}>
+                    {s.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="sm:col-span-2 space-y-1">
+            <Label htmlFor="pf-description">Description</Label>
+            <Textarea
+              id="pf-description"
+              rows={3}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="pf-applications-open">Applications open at</Label>
+            <Input
+              id="pf-applications-open"
+              type="datetime-local"
+              value={applicationsOpenAt}
+              onChange={(e) => setApplicationsOpenAt(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="pf-applications-close">Applications close at</Label>
+            <Input
+              id="pf-applications-close"
+              type="datetime-local"
+              value={applicationsCloseAt}
+              onChange={(e) => setApplicationsCloseAt(e.target.value)}
+              aria-invalid={errors.applicationsCloseAt ? true : undefined}
+            />
+            {errors.applicationsCloseAt && (
+              <p className="text-xs text-destructive">{errors.applicationsCloseAt}</p>
+            )}
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="pf-event-starts">Event starts at</Label>
+            <Input
+              id="pf-event-starts"
+              type="datetime-local"
+              value={eventStartsAt}
+              onChange={(e) => setEventStartsAt(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="pf-event-ends">Event ends at</Label>
+            <Input
+              id="pf-event-ends"
+              type="datetime-local"
+              value={eventEndsAt}
+              onChange={(e) => setEventEndsAt(e.target.value)}
+              aria-invalid={errors.eventEndsAt ? true : undefined}
+            />
+            {errors.eventEndsAt && <p className="text-xs text-destructive">{errors.eventEndsAt}</p>}
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="pf-location">Location</Label>
+            <Input
+              id="pf-location"
+              value={location}
+              onChange={(e) => setLocation(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="pf-max">Max applicants (optional)</Label>
+            <Input
+              id="pf-max"
+              type="number"
+              min={1}
+              value={maxApplicants}
+              onChange={(e) => setMaxApplicants(e.target.value)}
+              aria-invalid={errors.maxApplicants ? true : undefined}
+            />
+            {errors.maxApplicants && (
+              <p className="text-xs text-destructive">{errors.maxApplicants}</p>
+            )}
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={submitting}>
+            {submitting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                Saving…
+              </>
+            ) : editing ? (
+              "Save"
+            ) : (
+              "Create program"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/admin/ProgramsTable.tsx
+++ b/client/src/components/admin/ProgramsTable.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   Table,
   TableBody,
@@ -9,8 +10,10 @@ import {
 } from "@/components/ui/table";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Edit, Loader2, Plus } from "lucide-react";
 import { api, type ApiProgram } from "@/lib/api";
+import { ProgramFormModal } from "@/components/admin/ProgramFormModal";
 
 const statusVariant = (status: ApiProgram["status"]) => {
   switch (status) {
@@ -33,13 +36,17 @@ const formatDateRange = (from?: string | null, to?: string | null) => {
   return `${fmt(from)} → ${fmt(to)}`;
 };
 
-export function ProgramsTable() {
+export function ProgramsTable({ connectedAddress }: { connectedAddress?: string } = {}) {
+  const navigate = useNavigate();
   const [programs, setPrograms] = useState<ApiProgram[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<ApiProgram | null>(null);
 
   useEffect(() => {
     let active = true;
+    setLoading(true);
     api
       .listPrograms()
       .then((r) => {
@@ -56,10 +63,33 @@ export function ProgramsTable() {
     };
   }, []);
 
+  const handleSaved = (p: ApiProgram) => {
+    setPrograms((prev) => {
+      const idx = prev.findIndex((x) => x.id === p.id);
+      if (idx === -1) return [p, ...prev];
+      const next = [...prev];
+      next[idx] = p;
+      return next;
+    });
+  };
+
   return (
     <Card>
-      <CardHeader>
+      <CardHeader className="flex flex-row items-center justify-between">
         <CardTitle className="text-lg">Programs</CardTitle>
+        {connectedAddress && (
+          <Button
+            size="sm"
+            onClick={() => {
+              setEditing(null);
+              setFormOpen(true);
+            }}
+            className="gap-2"
+          >
+            <Plus className="h-4 w-4" aria-hidden="true" />
+            Create program
+          </Button>
+        )}
       </CardHeader>
       <CardContent>
         {loading ? (
@@ -83,11 +113,16 @@ export function ProgramsTable() {
                 <TableHead>Applications window</TableHead>
                 <TableHead>Event</TableHead>
                 <TableHead>Location</TableHead>
+                <TableHead className="w-[120px]" aria-label="Actions" />
               </TableRow>
             </TableHeader>
             <TableBody>
               {programs.map((p) => (
-                <TableRow key={p.id}>
+                <TableRow
+                  key={p.id}
+                  className="cursor-pointer hover:bg-muted/50"
+                  onClick={() => navigate(`/admin/programs/${p.slug}`)}
+                >
                   <TableCell className="font-medium">{p.name}</TableCell>
                   <TableCell className="text-muted-foreground">{p.programType}</TableCell>
                   <TableCell>
@@ -100,12 +135,38 @@ export function ProgramsTable() {
                     {formatDateRange(p.eventStartsAt, p.eventEndsAt)}
                   </TableCell>
                   <TableCell className="text-muted-foreground">{p.location || "—"}</TableCell>
+                  <TableCell>
+                    {connectedAddress && (
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setEditing(p);
+                          setFormOpen(true);
+                        }}
+                        className="gap-2"
+                      >
+                        <Edit className="h-3.5 w-3.5" aria-hidden="true" />
+                        Edit
+                      </Button>
+                    )}
+                  </TableCell>
                 </TableRow>
               ))}
             </TableBody>
           </Table>
         )}
       </CardContent>
+      {connectedAddress && (
+        <ProgramFormModal
+          open={formOpen}
+          onOpenChange={setFormOpen}
+          program={editing}
+          connectedAddress={connectedAddress}
+          onSaved={handleSaved}
+        />
+      )}
     </Card>
   );
 }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -919,6 +919,35 @@ export const api = {
     });
   },
 
+  updateApplicationStatus: async (
+    slug: string,
+    applicationId: string,
+    patch: { status: ApiProgramApplication["status"]; reviewNotes?: string | null },
+    authHeader?: string,
+  ): Promise<{ status: string; data: ApiProgramApplication }> => {
+    if (USE_MOCK_DATA) {
+      const { mockProgramApplications } = await import("./mockProgramApplications");
+      const idx = mockProgramApplications.findIndex((a) => a.id === applicationId);
+      if (idx === -1) throw new ApiError("Application not found", 404);
+      const updated: ApiProgramApplication = {
+        ...mockProgramApplications[idx],
+        status: patch.status,
+        reviewedBy: "mock-admin",
+        reviewedAt: new Date().toISOString(),
+        reviewNotes: patch.reviewNotes ?? null,
+      };
+      mockProgramApplications[idx] = updated;
+      return { status: "success", data: updated };
+    }
+    return request(`/programs/${encodeURIComponent(slug)}/applications/${encodeURIComponent(applicationId)}`, {
+      method: "PATCH",
+      headers: authHeader
+        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
+        : { "Content-Type": "application/json" },
+      body: JSON.stringify(patch),
+    });
+  },
+
   applyToProgram: async (
     slug: string,
     payload: { project_id: string; application_fields: Record<string, unknown> },

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -801,6 +801,69 @@ export const api = {
   },
 
   /**
+   * Phase 1 revamp: admin program management (Block F, issue #46).
+   */
+  createProgram: async (
+    payload: Partial<ApiProgram> & { name: string; slug: string; programType: ApiProgram["programType"]; status: ApiProgram["status"] },
+    authHeader?: string,
+  ): Promise<{ status: string; data: ApiProgram }> => {
+    if (USE_MOCK_DATA) {
+      const { mockPrograms } = await import("./mockPrograms");
+      if (mockPrograms.some((p) => p.slug === payload.slug)) {
+        throw new ApiError("A program with that slug already exists.", 409);
+      }
+      const created: ApiProgram = {
+        id: payload.id || `mock-${Date.now()}`,
+        owner: "webzero",
+        description: payload.description ?? null,
+        applicationsOpenAt: payload.applicationsOpenAt ?? null,
+        applicationsCloseAt: payload.applicationsCloseAt ?? null,
+        eventStartsAt: payload.eventStartsAt ?? null,
+        eventEndsAt: payload.eventEndsAt ?? null,
+        location: payload.location ?? null,
+        maxApplicants: payload.maxApplicants ?? null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        ...payload,
+      };
+      mockPrograms.unshift(created);
+      return { status: "success", data: created };
+    }
+    return request(`/programs`, {
+      method: "POST",
+      headers: authHeader
+        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
+        : { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  },
+
+  updateProgram: async (
+    slug: string,
+    patch: Partial<ApiProgram>,
+    authHeader?: string,
+  ): Promise<{ status: string; data: ApiProgram }> => {
+    if (USE_MOCK_DATA) {
+      const { mockPrograms } = await import("./mockPrograms");
+      const idx = mockPrograms.findIndex((p) => p.slug === slug);
+      if (idx === -1) throw new ApiError("Program not found", 404);
+      if (patch.slug && patch.slug !== slug && mockPrograms.some((p) => p.slug === patch.slug)) {
+        throw new ApiError("A program with that slug already exists.", 409);
+      }
+      const merged = { ...mockPrograms[idx], ...patch, updatedAt: new Date().toISOString() };
+      mockPrograms[idx] = merged;
+      return { status: "success", data: merged };
+    }
+    return request(`/programs/${encodeURIComponent(slug)}`, {
+      method: "PATCH",
+      headers: authHeader
+        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
+        : { "Content-Type": "application/json" },
+      body: JSON.stringify(patch),
+    });
+  },
+
+  /**
    * Phase 1 revamp: program applications (Block D, issues #43–#44).
    */
 

--- a/client/src/lib/siwsUtils.ts
+++ b/client/src/lib/siwsUtils.ts
@@ -3,7 +3,7 @@
  */
 
 export interface SiwsContext {
-  action: 'update-team' | 'submit-deliverable' | 'update-project' | 'register-address' | 'admin-action' | 'create-project' | 'delete-project' | 'review-project' | 'approve-project' | 'reject-project' | 'post-update' | 'update-funding-signal' | 'apply-to-program';
+  action: 'update-team' | 'submit-deliverable' | 'update-project' | 'register-address' | 'admin-action' | 'create-project' | 'delete-project' | 'review-project' | 'approve-project' | 'reject-project' | 'post-update' | 'update-funding-signal' | 'apply-to-program' | 'create-program' | 'update-program' | 'review-application';
   projectId?: string;
   projectTitle?: string;
   programTitle?: string;
@@ -58,6 +58,14 @@ export function generateSiwsStatement(context: SiwsContext): string {
     // Phase 1 revamp (#44): apply project to program
     case 'apply-to-program':
       return `Apply project ${context.projectTitle || ''} to program ${context.programTitle || ''} on ${baseDomain}`;
+
+    // Phase 1 revamp (#46/#47): admin program management
+    case 'create-program':
+      return `Create program on ${baseDomain}`;
+    case 'update-program':
+      return `Update program on ${baseDomain}`;
+    case 'review-application':
+      return `Review application on ${baseDomain}`;
 
     default:
       return `Sign in to ${baseDomain}`;

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -906,7 +906,7 @@ const AdminPage = () => {
       </section>
 
       <section className="mb-8">
-        <ProgramsTable />
+        <ProgramsTable connectedAddress={walletState.selectedAccount?.address} />
       </section>
 
       {/* M1 Payout Modal */}

--- a/client/src/pages/AdminProgramPage.tsx
+++ b/client/src/pages/AdminProgramPage.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useState } from "react";
+import { useParams, Link } from "react-router-dom";
+import { Navigation } from "@/components/Navigation";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { ArrowLeft, Loader2 } from "lucide-react";
+import { web3Enable, web3Accounts, web3FromSource } from "@polkadot/extension-dapp";
+import { SiwsMessage } from "@talismn/siws";
+import { generateSiwsStatement } from "@/lib/siwsUtils";
+import {
+  api,
+  type ApiProgram,
+  type ApiProgramApplication,
+  ApiError,
+} from "@/lib/api";
+import { isAdmin as checkIsAdmin } from "@/lib/constants";
+import { ApplicationCard } from "@/components/admin/ApplicationCard";
+import { useToast } from "@/hooks/use-toast";
+
+const FILTERS: Array<{ value: ApiProgramApplication["status"] | "all"; label: string }> = [
+  { value: "submitted", label: "Submitted" },
+  { value: "accepted", label: "Accepted" },
+  { value: "rejected", label: "Rejected" },
+  { value: "withdrawn", label: "Withdrawn" },
+  { value: "all", label: "All" },
+];
+
+const AdminProgramPage = () => {
+  const { slug } = useParams<{ slug: string }>();
+  const { toast } = useToast();
+
+  const [program, setProgram] = useState<ApiProgram | null>(null);
+  const [applications, setApplications] = useState<ApiProgramApplication[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+  const [filter, setFilter] = useState<ApiProgramApplication["status"] | "all">("submitted");
+
+  const [connectedAddress, setConnectedAddress] = useState<string | null>(null);
+  const [isAdminWallet, setIsAdminWallet] = useState(false);
+  const [connecting, setConnecting] = useState(false);
+
+  useEffect(() => {
+    // Try to restore session address if admin
+    try {
+      const raw = sessionStorage.getItem("admin_session_account");
+      if (raw) {
+        const acc = JSON.parse(raw);
+        if (checkIsAdmin(acc.address)) {
+          setConnectedAddress(acc.address);
+          setIsAdminWallet(true);
+        }
+      }
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!slug) return;
+    let active = true;
+    setLoading(true);
+    setNotFound(false);
+    api
+      .getProgramBySlug(slug)
+      .then((r) => {
+        if (active) setProgram(r.data);
+      })
+      .catch((e: unknown) => {
+        if (!active) return;
+        if (e instanceof ApiError && e.status === 404) setNotFound(true);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [slug]);
+
+  const loadApplications = async () => {
+    if (!slug || !isAdminWallet || !connectedAddress) return;
+    try {
+      // Build the SIWS auth header; listProgramApplications is admin-gated.
+      await web3Enable("Stadium");
+      const accounts = await web3Accounts();
+      const account = accounts.find((a) => a.address === connectedAddress) || accounts[0];
+      if (!account) return;
+      const siws = new SiwsMessage({
+        domain: window.location.hostname,
+        uri: window.location.origin,
+        address: account.address,
+        nonce: Math.random().toString(36).slice(2),
+        statement: generateSiwsStatement({ action: "admin-action" }),
+      });
+      const injector = await web3FromSource(account.meta.source);
+      const signed = (await siws.sign(injector)) as unknown as { signature: string; message?: string };
+      const messageStr =
+        typeof signed.message === "string" && signed.message
+          ? signed.message
+          : (siws as unknown as { toString: () => string }).toString();
+      const authHeader = btoa(
+        JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address }),
+      );
+      const res = await api.listProgramApplications(slug, authHeader);
+      setApplications(res.data);
+    } catch (e) {
+      const err = e as Error;
+      toast({
+        title: "Couldn't load applications",
+        description: err?.message || "Unknown error",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const connectWallet = async () => {
+    setConnecting(true);
+    try {
+      await web3Enable("Stadium");
+      const accounts = await web3Accounts();
+      const admin = accounts.find((a) => checkIsAdmin(a.address));
+      if (!admin) {
+        toast({
+          title: "Admin account not found in wallet",
+          description: "Connect a wallet whose address is in ADMIN_WALLETS.",
+          variant: "destructive",
+        });
+        return;
+      }
+      setConnectedAddress(admin.address);
+      setIsAdminWallet(true);
+      sessionStorage.setItem(
+        "admin_session_account",
+        JSON.stringify({ address: admin.address, meta: admin.meta }),
+      );
+    } catch (e) {
+      const err = e as Error;
+      toast({
+        title: "Couldn't connect wallet",
+        description: err?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setConnecting(false);
+    }
+  };
+
+  const filtered =
+    filter === "all" ? applications : applications.filter((a) => a.status === filter);
+
+  const handleUpdated = (next: ApiProgramApplication) => {
+    setApplications((prev) => prev.map((a) => (a.id === next.id ? next : a)));
+  };
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navigation />
+      <main className="container mx-auto px-4 pt-24 pb-16">
+        <Button variant="ghost" asChild className="mb-4 gap-2">
+          <Link to="/admin">
+            <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+            Back to admin
+          </Link>
+        </Button>
+
+        {loading ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground py-16">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            Loading program…
+          </div>
+        ) : notFound ? (
+          <div className="mx-auto max-w-lg rounded-lg border bg-card p-8 text-center">
+            <h1 className="font-heading text-2xl font-bold">Program not found</h1>
+            <Button asChild className="mt-4">
+              <Link to="/admin">Back to admin</Link>
+            </Button>
+          </div>
+        ) : program ? (
+          <>
+            <header className="mb-6">
+              <p className="text-sm text-muted-foreground">{program.programType}</p>
+              <h1 className="mt-1 font-heading text-3xl font-bold md:text-4xl">{program.name}</h1>
+              <div className="mt-3 flex flex-wrap items-center gap-2">
+                <Badge variant={program.status === "open" ? "default" : "secondary"}>
+                  {program.status}
+                </Badge>
+                {program.location && (
+                  <span className="text-sm text-muted-foreground">{program.location}</span>
+                )}
+              </div>
+            </header>
+
+            {!isAdminWallet ? (
+              <div className="rounded-lg border bg-card p-6 text-center">
+                <p className="text-sm">
+                  Admin wallet required to review applications.
+                </p>
+                <Button onClick={connectWallet} disabled={connecting} className="mt-3 gap-2">
+                  {connecting ? "Connecting…" : "Connect admin wallet"}
+                </Button>
+              </div>
+            ) : (
+              <>
+                <div className="mb-4 flex items-center justify-between gap-3">
+                  <div className="flex flex-wrap gap-1">
+                    {FILTERS.map((f) => (
+                      <Button
+                        key={f.value}
+                        variant={filter === f.value ? "default" : "outline"}
+                        size="sm"
+                        onClick={() => setFilter(f.value)}
+                      >
+                        {f.label}
+                      </Button>
+                    ))}
+                  </div>
+                  <Button size="sm" variant="ghost" onClick={loadApplications}>
+                    Load / refresh
+                  </Button>
+                </div>
+
+                {applications.length === 0 ? (
+                  <p className="text-sm text-muted-foreground py-6">
+                    Click <em>Load / refresh</em> to fetch applications (SIWS-signed admin fetch).
+                  </p>
+                ) : filtered.length === 0 ? (
+                  <p className="text-sm text-muted-foreground py-6">
+                    No applications match the current filter.
+                  </p>
+                ) : (
+                  <div className="space-y-3">
+                    {filtered.map((a) => (
+                      <ApplicationCard
+                        key={a.id}
+                        application={a}
+                        programSlug={program.slug}
+                        connectedAddress={connectedAddress!}
+                        onUpdated={handleUpdated}
+                      />
+                    ))}
+                  </div>
+                )}
+              </>
+            )}
+          </>
+        ) : null}
+      </main>
+    </div>
+  );
+};
+
+export default AdminProgramPage;

--- a/server/api/controllers/__tests__/program-admin.test.js
+++ b/server/api/controllers/__tests__/program-admin.test.js
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../services/program.service.js', () => ({
+  default: {
+    findBySlug: vi.fn(),
+    create: vi.fn(),
+    updateBySlug: vi.fn(),
+  },
+}));
+vi.mock('../../services/project.service.js', () => ({
+  default: { getProjectById: vi.fn() },
+}));
+vi.mock('../../services/program-application.service.js', () => ({
+  default: {
+    listByProgram: vi.fn(),
+    listByProject: vi.fn(),
+    findOne: vi.fn(),
+    create: vi.fn(),
+  },
+}));
+
+const programService = (await import('../../services/program.service.js')).default;
+const programController = (await import('../program.controller.js')).default;
+
+const mockRes = () => {
+  const res = {};
+  res.status = vi.fn(() => res);
+  res.json = vi.fn(() => res);
+  return res;
+};
+
+const validPayload = {
+  name: 'Dogfooding 2026',
+  slug: 'dogfooding-2026',
+  programType: 'dogfooding',
+  status: 'draft',
+  description: 'A week in Berlin.',
+  applicationsOpenAt: '2026-04-22T00:00:00Z',
+  applicationsCloseAt: '2026-05-30T23:59:59Z',
+  eventStartsAt: '2026-06-13T00:00:00Z',
+  eventEndsAt: '2026-06-19T23:59:59Z',
+  location: 'Berlin',
+};
+
+describe('ProgramController.createProgram', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 422 when name is missing', async () => {
+    const req = { body: { ...validPayload, name: '' } };
+    const res = mockRes();
+    await programController.createProgram(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('returns 422 for non-kebab slug', async () => {
+    const req = { body: { ...validPayload, slug: 'Not Valid Slug' } };
+    const res = mockRes();
+    await programController.createProgram(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('returns 422 for invalid programType', async () => {
+    const req = { body: { ...validPayload, programType: 'bogus' } };
+    const res = mockRes();
+    await programController.createProgram(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('returns 422 when applications window is inverted', async () => {
+    const req = {
+      body: {
+        ...validPayload,
+        applicationsOpenAt: '2026-06-01T00:00:00Z',
+        applicationsCloseAt: '2026-05-01T00:00:00Z',
+      },
+    };
+    const res = mockRes();
+    await programController.createProgram(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('returns 409 on slug pre-check conflict', async () => {
+    programService.findBySlug.mockResolvedValue({ id: 'existing' });
+    const req = { body: validPayload };
+    const res = mockRes();
+    await programController.createProgram(req, res);
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'slug_conflict' }));
+  });
+
+  it('returns 409 on DB unique_violation race', async () => {
+    programService.findBySlug.mockResolvedValue(null);
+    const err = Object.assign(new Error('dup'), { code: '23505' });
+    programService.create.mockRejectedValue(err);
+    const req = { body: validPayload };
+    const res = mockRes();
+    await programController.createProgram(req, res);
+    expect(res.status).toHaveBeenCalledWith(409);
+  });
+
+  it('creates the program with an id and owner=webzero', async () => {
+    programService.findBySlug.mockResolvedValue(null);
+    programService.create.mockImplementation((p) => Promise.resolve({ ...p, createdAt: 'now' }));
+    const req = { body: validPayload };
+    const res = mockRes();
+    await programController.createProgram(req, res);
+    expect(programService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Dogfooding 2026',
+        slug: 'dogfooding-2026',
+        programType: 'dogfooding',
+        owner: 'webzero',
+      }),
+    );
+    const call = programService.create.mock.calls[0][0];
+    expect(typeof call.id).toBe('string');
+    expect(call.id.length).toBeGreaterThan(0);
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+});
+
+describe('ProgramController.updateProgram', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 404 when program is unknown', async () => {
+    programService.findBySlug.mockResolvedValue(null);
+    const req = { params: { slug: 'nope' }, body: { name: 'new' } };
+    const res = mockRes();
+    await programController.updateProgram(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns 422 when partial payload is invalid', async () => {
+    programService.findBySlug.mockResolvedValue({ slug: 's', name: 'n' });
+    const req = { params: { slug: 's' }, body: { programType: 'bogus' } };
+    const res = mockRes();
+    await programController.updateProgram(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('returns 409 when the new slug collides with a different program', async () => {
+    programService.findBySlug
+      .mockResolvedValueOnce({ slug: 'old', name: 'old' })
+      .mockResolvedValueOnce({ slug: 'new', name: 'other' });
+    const req = { params: { slug: 'old' }, body: { slug: 'new' } };
+    const res = mockRes();
+    await programController.updateProgram(req, res);
+    expect(res.status).toHaveBeenCalledWith(409);
+  });
+
+  it('updates on valid patch', async () => {
+    programService.findBySlug.mockResolvedValue({ slug: 's', name: 'n' });
+    programService.updateBySlug.mockResolvedValue({ slug: 's', name: 'updated' });
+    const req = { params: { slug: 's' }, body: { name: 'updated' } };
+    const res = mockRes();
+    await programController.updateProgram(req, res);
+    expect(programService.updateBySlug).toHaveBeenCalledWith('s', { name: 'updated' });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});

--- a/server/api/controllers/__tests__/program-application.test.js
+++ b/server/api/controllers/__tests__/program-application.test.js
@@ -7,7 +7,13 @@ vi.mock('../../services/project.service.js', () => ({
   default: { getProjectById: vi.fn() },
 }));
 vi.mock('../../services/program-application.service.js', () => ({
-  default: { listByProgram: vi.fn(), listByProject: vi.fn(), findOne: vi.fn(), create: vi.fn() },
+  default: {
+    listByProgram: vi.fn(),
+    listByProject: vi.fn(),
+    findOne: vi.fn(),
+    create: vi.fn(),
+    updateStatus: vi.fn(),
+  },
 }));
 
 const programService = (await import('../../services/program.service.js')).default;
@@ -172,5 +178,72 @@ describe('ProgramController.createApplication', () => {
     const res = mockRes();
     await programController.createApplication(req, res);
     expect(res.status).toHaveBeenCalledWith(409);
+  });
+});
+
+describe('ProgramController.updateApplicationStatus', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 422 for invalid status', async () => {
+    const req = { params: { slug: 's', applicationId: 'a' }, body: { status: 'bogus' }, user: { address: 'x' } };
+    const res = mockRes();
+    await programController.updateApplicationStatus(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('returns 422 for reviewNotes too long', async () => {
+    const req = {
+      params: { slug: 's', applicationId: 'a' },
+      body: { status: 'accepted', reviewNotes: 'x'.repeat(2001) },
+      user: { address: 'x' },
+    };
+    const res = mockRes();
+    await programController.updateApplicationStatus(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('returns 404 when program is unknown', async () => {
+    programService.findBySlug.mockResolvedValue(null);
+    const req = {
+      params: { slug: 'nope', applicationId: 'a' },
+      body: { status: 'accepted' },
+      user: { address: 'x' },
+    };
+    const res = mockRes();
+    await programController.updateApplicationStatus(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('updates on valid payload', async () => {
+    programService.findBySlug.mockResolvedValue({ id: 'p1' });
+    applicationService.updateStatus.mockResolvedValue({ id: 'a1', status: 'accepted' });
+    const req = {
+      params: { slug: 's', applicationId: 'a1' },
+      body: { status: 'accepted', reviewNotes: '  looks great  ' },
+      user: { address: 'admin' },
+    };
+    const res = mockRes();
+    await programController.updateApplicationStatus(req, res);
+    expect(applicationService.updateStatus).toHaveBeenCalledWith({
+      id: 'a1',
+      status: 'accepted',
+      reviewedBy: 'admin',
+      reviewNotes: 'looks great',
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('maps PostgREST no-rows error to 404', async () => {
+    programService.findBySlug.mockResolvedValue({ id: 'p1' });
+    const err = Object.assign(new Error('no rows'), { code: 'PGRST116' });
+    applicationService.updateStatus.mockRejectedValue(err);
+    const req = {
+      params: { slug: 's', applicationId: 'missing' },
+      body: { status: 'rejected' },
+      user: { address: 'admin' },
+    };
+    const res = mockRes();
+    await programController.updateApplicationStatus(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
   });
 });

--- a/server/api/controllers/program.controller.js
+++ b/server/api/controllers/program.controller.js
@@ -73,6 +73,57 @@ class ProgramController {
     }
   }
 
+  /**
+   * Phase 1 revamp (#47): admin review of a single application.
+   * Accepts a status transition + optional review notes. Review metadata
+   * (reviewed_by, reviewed_at) is stamped by the repository.
+   */
+  async updateApplicationStatus(req, res) {
+    try {
+      const { slug, applicationId } = req.params;
+      const { status, reviewNotes } = req.body || {};
+
+      const ALLOWED = ['submitted', 'accepted', 'rejected', 'withdrawn'];
+      if (!ALLOWED.includes(status)) {
+        return res.status(422).json({
+          status: 'error',
+          message: `status must be one of: ${ALLOWED.join(', ')}`,
+        });
+      }
+      if (reviewNotes !== undefined && reviewNotes !== null) {
+        if (typeof reviewNotes !== 'string' || reviewNotes.length > 2000) {
+          return res.status(422).json({
+            status: 'error',
+            message: 'reviewNotes must be a string with 2000 characters or fewer',
+          });
+        }
+      }
+
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+
+      const reviewedBy = req.user?.address || req.auth?.address || 'unknown';
+      const updated = await programApplicationService.updateStatus({
+        id: applicationId,
+        status,
+        reviewedBy,
+        reviewNotes: typeof reviewNotes === 'string' ? reviewNotes.trim() : null,
+      });
+
+      // updateStatus uses .single() which throws if no row matched; translate
+      // to 404 via the Postgres PGRST116 code we see on not-found.
+      res.status(200).json({ status: 'success', data: updated });
+    } catch (error) {
+      if (error?.code === 'PGRST116' || /no rows/i.test(error?.message || '')) {
+        return res.status(404).json({ status: 'error', message: 'Application not found' });
+      }
+      console.error('❌ Error updating application status:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to update application' });
+    }
+  }
+
   async updateProgram(req, res) {
     try {
       const { slug } = req.params;

--- a/server/api/controllers/program.controller.js
+++ b/server/api/controllers/program.controller.js
@@ -2,6 +2,8 @@ import programService from '../services/program.service.js';
 import programApplicationService from '../services/program-application.service.js';
 import projectService from '../services/project.service.js';
 import { validateApplicationFields } from '../utils/application-fields.validator.js';
+import { validateProgram } from '../utils/validation.js';
+import { randomUUID } from 'node:crypto';
 
 class ProgramController {
   async list(req, res) {
@@ -29,6 +31,86 @@ class ProgramController {
     } catch (error) {
       console.error('❌ Error fetching program:', error);
       res.status(500).json({ status: 'error', message: 'Failed to fetch program' });
+    }
+  }
+
+  // --- Phase 1 revamp: admin create/edit (#46) ---
+
+  async createProgram(req, res) {
+    try {
+      const payload = req.body || {};
+      const { valid, error: validationError } = validateProgram(payload, { partial: false });
+      if (!valid) {
+        return res.status(422).json({ status: 'error', message: validationError });
+      }
+
+      // Slug uniqueness pre-check (DB also enforces UNIQUE)
+      const existing = await programService.findBySlug(payload.slug);
+      if (existing) {
+        return res.status(409).json({
+          status: 'error',
+          message: `A program with slug "${payload.slug}" already exists.`,
+          code: 'slug_conflict',
+        });
+      }
+
+      const created = await programService.create({
+        id: payload.id || randomUUID(),
+        owner: 'webzero',
+        ...payload,
+      });
+      res.status(201).json({ status: 'success', data: created });
+    } catch (error) {
+      if (error?.code === '23505') {
+        return res.status(409).json({
+          status: 'error',
+          message: 'Slug conflict (race).',
+          code: 'slug_conflict',
+        });
+      }
+      console.error('❌ Error creating program:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to create program' });
+    }
+  }
+
+  async updateProgram(req, res) {
+    try {
+      const { slug } = req.params;
+      const patch = req.body || {};
+      const { valid, error: validationError } = validateProgram(patch, { partial: true });
+      if (!valid) {
+        return res.status(422).json({ status: 'error', message: validationError });
+      }
+
+      const existing = await programService.findBySlug(slug);
+      if (!existing) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+
+      // If the slug is being changed, enforce uniqueness.
+      if (patch.slug && patch.slug !== slug) {
+        const collision = await programService.findBySlug(patch.slug);
+        if (collision) {
+          return res.status(409).json({
+            status: 'error',
+            message: `A program with slug "${patch.slug}" already exists.`,
+            code: 'slug_conflict',
+          });
+        }
+      }
+
+      const updated = await programService.updateBySlug(slug, patch);
+      res.status(200).json({ status: 'success', data: updated });
+    } catch (error) {
+      if (error?.code === '23505') {
+        return res.status(409).json({
+          status: 'error',
+          message: 'Slug conflict (race).',
+          code: 'slug_conflict',
+        });
+      }
+      console.error('❌ Error updating program:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to update program' });
     }
   }
 

--- a/server/api/middleware/auth.middleware.js
+++ b/server/api/middleware/auth.middleware.js
@@ -41,7 +41,10 @@ const VALID_STATEMENTS = [
   // Phase 1 revamp statements
   "Post an update on Stadium",
   "Update funding signal on Stadium",
-  "Apply to program on Stadium"
+  "Apply to program on Stadium",
+  "Create program on Stadium",
+  "Update program on Stadium",
+  "Review application on Stadium"
 ];
 
 const EXPECTED_DOMAIN = process.env.EXPECTED_DOMAIN || 'localhost';

--- a/server/api/repositories/program.repository.js
+++ b/server/api/repositories/program.repository.js
@@ -22,6 +22,24 @@ const transformProgram = (row) => {
   };
 };
 
+const toSnakeCase = (data) => {
+  const row = {};
+  if ('id' in data) row.id = data.id;
+  if ('name' in data) row.name = data.name;
+  if ('slug' in data) row.slug = data.slug;
+  if ('programType' in data) row.program_type = data.programType;
+  if ('description' in data) row.description = data.description ?? null;
+  if ('status' in data) row.status = data.status;
+  if ('owner' in data) row.owner = data.owner ?? 'webzero';
+  if ('applicationsOpenAt' in data) row.applications_open_at = data.applicationsOpenAt ?? null;
+  if ('applicationsCloseAt' in data) row.applications_close_at = data.applicationsCloseAt ?? null;
+  if ('eventStartsAt' in data) row.event_starts_at = data.eventStartsAt ?? null;
+  if ('eventEndsAt' in data) row.event_ends_at = data.eventEndsAt ?? null;
+  if ('location' in data) row.location = data.location ?? null;
+  if ('maxApplicants' in data) row.max_applicants = data.maxApplicants ?? null;
+  return row;
+};
+
 class ProgramRepository {
   async list({ status } = {}) {
     let query = supabase.from('programs').select('*').order('created_at', { ascending: false });
@@ -39,6 +57,26 @@ class ProgramRepository {
 
   async findBySlug(slug) {
     const { data, error } = await supabase.from('programs').select('*').eq('slug', slug).maybeSingle();
+    if (error) throw error;
+    return transformProgram(data);
+  }
+
+  async create(payload) {
+    const row = toSnakeCase(payload);
+    const { data, error } = await supabase.from('programs').insert(row).select('*').single();
+    if (error) throw error;
+    return transformProgram(data);
+  }
+
+  async updateBySlug(slug, patch) {
+    const row = toSnakeCase(patch);
+    row.updated_at = new Date().toISOString();
+    const { data, error } = await supabase
+      .from('programs')
+      .update(row)
+      .eq('slug', slug)
+      .select('*')
+      .single();
     if (error) throw error;
     return transformProgram(data);
   }

--- a/server/api/routes/program.routes.js
+++ b/server/api/routes/program.routes.js
@@ -8,6 +8,10 @@ const router = Router();
 router.get('/', programController.list);
 router.get('/:slug', programController.getBySlug);
 
+// --- Phase 1 revamp: admin create/edit (#46) ---
+router.post('/', requireAdmin, programController.createProgram);
+router.patch('/:slug', requireAdmin, programController.updateProgram);
+
 // --- Phase 1 revamp: applications (#43) ---
 router.get('/:slug/applications', requireAdmin, programController.listApplicationsForProgram);
 router.post(

--- a/server/api/routes/program.routes.js
+++ b/server/api/routes/program.routes.js
@@ -12,12 +12,17 @@ router.get('/:slug', programController.getBySlug);
 router.post('/', requireAdmin, programController.createProgram);
 router.patch('/:slug', requireAdmin, programController.updateProgram);
 
-// --- Phase 1 revamp: applications (#43) ---
+// --- Phase 1 revamp: applications (#43, #47) ---
 router.get('/:slug/applications', requireAdmin, programController.listApplicationsForProgram);
 router.post(
   '/:slug/applications',
   requireTeamMemberOrAdminByBodyProject,
   programController.createApplication,
+);
+router.patch(
+  '/:slug/applications/:applicationId',
+  requireAdmin,
+  programController.updateApplicationStatus,
 );
 
 export default router;

--- a/server/api/services/program.service.js
+++ b/server/api/services/program.service.js
@@ -13,6 +13,14 @@ class ProgramService {
   async findBySlug(slug) {
     return await programRepository.findBySlug(slug);
   }
+
+  async create(payload) {
+    return await programRepository.create(payload);
+  }
+
+  async updateBySlug(slug, patch) {
+    return await programRepository.updateBySlug(slug, patch);
+  }
 }
 
 export default new ProgramService();

--- a/server/api/utils/validation.js
+++ b/server/api/utils/validation.js
@@ -272,3 +272,83 @@ export const validateFundingSignal = (data) => {
   return { valid: true };
 };
 
+/**
+ * Validate program payload (Phase 1 revamp, #46).
+ * @param {Object} data
+ * @param {Object} opts - { partial: boolean } — PATCH payloads only include changed fields.
+ * @returns {Object} - { valid: boolean, error: string }
+ */
+export const ALLOWED_PROGRAM_TYPES = ['dogfooding', 'pitch_off', 'hackathon', 'm2_incubator'];
+export const ALLOWED_PROGRAM_STATUSES = ['draft', 'open', 'closed', 'completed'];
+const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export const validateProgram = (data, { partial = false } = {}) => {
+  if (!data || typeof data !== 'object') {
+    return { valid: false, error: 'Program payload must be an object' };
+  }
+  const has = (k) => Object.prototype.hasOwnProperty.call(data, k);
+
+  if (!partial || has('name')) {
+    if (typeof data.name !== 'string' || !validateLength(data.name, 1, 200)) {
+      return { valid: false, error: 'name is required (1–200 characters)' };
+    }
+  }
+  if (!partial || has('slug')) {
+    if (typeof data.slug !== 'string' || !SLUG_RE.test(data.slug) || data.slug.length > 100) {
+      return { valid: false, error: 'slug must be kebab-case (a-z, 0-9, hyphens), 1–100 characters' };
+    }
+  }
+  if (!partial || has('programType')) {
+    if (!ALLOWED_PROGRAM_TYPES.includes(data.programType)) {
+      return { valid: false, error: `programType must be one of: ${ALLOWED_PROGRAM_TYPES.join(', ')}` };
+    }
+  }
+  if (!partial || has('status')) {
+    if (!ALLOWED_PROGRAM_STATUSES.includes(data.status)) {
+      return { valid: false, error: `status must be one of: ${ALLOWED_PROGRAM_STATUSES.join(', ')}` };
+    }
+  }
+
+  if (has('description') && data.description !== null) {
+    if (typeof data.description !== 'string' || data.description.length > 4000) {
+      return { valid: false, error: 'description must be a string (max 4000 characters)' };
+    }
+  }
+  if (has('location') && data.location !== null) {
+    if (typeof data.location !== 'string' || data.location.length > 200) {
+      return { valid: false, error: 'location must be a string (max 200 characters)' };
+    }
+  }
+  if (has('maxApplicants') && data.maxApplicants !== null) {
+    const n = Number(data.maxApplicants);
+    if (!Number.isInteger(n) || n < 1) {
+      return { valid: false, error: 'maxApplicants must be a positive integer' };
+    }
+  }
+
+  const isoOrNull = (val) => {
+    if (val === null || val === undefined || val === '') return true;
+    if (typeof val !== 'string') return false;
+    const d = new Date(val);
+    return !Number.isNaN(d.getTime());
+  };
+  for (const key of ['applicationsOpenAt', 'applicationsCloseAt', 'eventStartsAt', 'eventEndsAt']) {
+    if (has(key) && !isoOrNull(data[key])) {
+      return { valid: false, error: `${key} must be a valid ISO date string or null` };
+    }
+  }
+
+  if (has('applicationsOpenAt') && has('applicationsCloseAt') && data.applicationsOpenAt && data.applicationsCloseAt) {
+    if (new Date(data.applicationsOpenAt).getTime() >= new Date(data.applicationsCloseAt).getTime()) {
+      return { valid: false, error: 'applicationsOpenAt must be strictly before applicationsCloseAt' };
+    }
+  }
+  if (has('eventStartsAt') && has('eventEndsAt') && data.eventStartsAt && data.eventEndsAt) {
+    if (new Date(data.eventStartsAt).getTime() > new Date(data.eventEndsAt).getTime()) {
+      return { valid: false, error: 'eventStartsAt must be on or before eventEndsAt' };
+    }
+  }
+
+  return { valid: true };
+};
+


### PR DESCRIPTION
Block F of the Phase 1 revamp — admin side of the program flow. Closes #46 and #47.

**Stacked on #55 (Block D).** Target base is `revamp/block-d-program-applications` while that PR is open. Once #55 merges, I'll rebase this onto `develop` and retarget.

## Block F journey slice (per spec §12)

*"Admin can set up Dogfooding and process applications."* Admin opens `/admin` → ProgramsTable → clicks "Create program" → fills form → saves → row appears. Clicks the row → `/admin/programs/:slug` → clicks Load/refresh → sees applications → Accept one → status flips without reload.

## Commits

### `<sha>` — #46: admin create / edit programs

- Validator `validateProgram` in `server/api/utils/validation.js` — kebab-case slug, enum `programType`/`status`, date validity, cross-field window ordering (apps open < close, event starts ≤ ends), bounds on name/description/location, positive `max_applicants`. Works in partial mode for PATCH.
- Repository additions: `create`, `updateBySlug`, `toSnakeCase` helper (writes only provided keys — partial PATCH doesn't null-out untouched columns).
- Controller: `createProgram` (UUID id + owner='webzero' enforced; 409 on slug pre-check + DB-race), `updateProgram` (404 / 422 / 409 / 200).
- Routes: `POST /api/programs` + `PATCH /api/programs/:slug`, both `requireAdmin`.
- SIWS statements: `Create program on Stadium` + `Update program on Stadium`.
- 11 server unit tests.
- Client: `api.createProgram` + `api.updateProgram` + new `ProgramFormModal` (auto-slug from name until user edits; datetime-local inputs → ISO on submit; slug read-only in edit mode so we don't churn FKs). `ProgramsTable` extended with Create button + per-row Edit + clickable rows navigating to `/admin/programs/:slug`.

### `<sha>` — #47: admin applications queue

- Controller `updateApplicationStatus` (status enum check, optional `reviewNotes ≤ 2000` chars, 404 on unknown program, PGRST116 → 404 mapping, 200 on success).
- Route: `PATCH /api/programs/:slug/applications/:applicationId` (`requireAdmin`).
- SIWS statement: `Review application on Stadium`.
- 5 more server unit tests.
- Client: `api.updateApplicationStatus`, new `ApplicationCard` component (shows project link, submitter, submitted date, status badge, Dogfooding `feedback_focus`, review notes, Accept/Reject — visible only when status=submitted), new `/admin/programs/:slug` `AdminProgramPage` with filter chips (submitted / accepted / rejected / withdrawn / all) and explicit SIWS-signed Load/refresh (listing applications is admin-gated on the server, so the fetch has to happen after sign).

## Test plan

Automated:
- [x] `cd server && npm test` → **48/48 passing** (16 new + 32 existing).
- [x] `cd client && npm run build` → clean.

Playwright:
- [ ] On `/admin` without admin wallet, Create / Edit / row-click behaviours don't trigger write flows (admin session guards remain intact).
- [ ] On `/admin/programs/dogfooding-2026-berlin` without admin wallet, "Admin wallet required" prompt renders.

SIWS-gated (manual QA with an admin wallet):
- [ ] `/admin` → Create program → fill form → save → new row appears; clicking the row navigates to `/admin/programs/<new-slug>`.
- [ ] Two programs with same slug → second save fails with 409 surfaced as toast.
- [ ] Edit existing program → slug field read-only; name/status/dates update; row re-renders with new values.
- [ ] On `/admin/programs/<slug>` → connect admin wallet → Load/refresh → applications appear; Accept one → card re-renders with 'accepted' status; filter chips correctly narrow the list.

## Design notes

- **Applications load on explicit click, not on mount**, because listing them is SIWS-gated on the server. The alternative — auto-sign + auto-load — felt surprising to users. Explicit Load/refresh is transparent.
- **Slug read-only in edit mode** — renaming a program's slug means changing its primary key, which cascades to `program_applications.program_id` FKs. Out of scope for Phase 1.
- **No comment-back flow** on reject (just `reviewNotes` string). Notifications/email/Telegram are explicitly Phase 2+ per context-doc §64.

## Out of scope (deferred)

- Bulk accept/reject.
- Per-program-type rendering beyond Dogfooding's `feedback_focus`.
- Notifications on accept/reject.
- Withdraw flow from the builder side.