### PR TITLE
feat(tester): SIWS test-wallet harness (//Alice) + runner fix

### DIFF
--- a/.claude/skills/stadium-tester/SKILL.md
+++ b/.claude/skills/stadium-tester/SKILL.md
@@ -20,9 +20,23 @@ If either is missing, stop and ask. Do not invent scenarios.
 
 - **Never run against production.** Refuse if the target matches `stadium.joinwebzero.com` or `stadium-production-*.up.railway.app`. The runner script enforces this too — exit code `3` means it tripped that guard.
 - **Mock-mode required on remote targets.** On any non-`localhost` URL, the first test must assert `window.__STADIUM_MOCK__ === true`. If false, fail the entire run with a `mock-mode-not-enabled` reason and stop.
-- **SIWS-gated flows are out of scope.** Any scenario whose action requires a Polkadot wallet signature → mark `SKIPPED (needs-auth-harness)` and continue. Don't try to mock the wallet.
+- **SIWS-gated flows need the test-wallet harness.** A scenario whose action requires a Polkadot wallet signature only runs when the target URL was built with `VITE_USE_TEST_WALLET=true` (see below). If that flag isn't active, mark the scenario `SKIPPED (needs-auth-harness)` and continue. Don't hand-roll a wallet mock.
 - **No destructive admin actions even in mock mode.** `confirmPayment`, `markAllAsPaid`, etc. are SKIPPED until we have an explicit safe path.
 - **No code outside `/tmp`.** Per-run spec files go in `/tmp`, never under `client/` or anywhere else in the repo.
+
+## Test-wallet mode
+
+To exercise SIWS-gated scenarios (post update, edit funding signal, apply to program, create/edit program, review application, update team), the target build must have `VITE_USE_TEST_WALLET=true` set. That flag turns on `client/src/lib/testWalletInjection.ts`, which registers a synthetic `window.injectedWeb3['polkadot-js']` backed by the real //Alice sr25519 keypair. Signatures produced by Alice verify normally through `@polkadot/util-crypto.signatureVerify` — no server-side bypass.
+
+The flag is double-gated: even when set, the injection no-ops in production builds (`import.meta.env.PROD`). Enable it only for local dev (`VITE_USE_TEST_WALLET=true npm run dev`) and Vercel **Preview** envs — never in Production, and never add Alice's address to the server's `ADMIN_WALLETS` / `AUTHORIZED_SIGNERS` on prod (the mnemonic is public).
+
+Alice is seeded as a team member of `plata-mia-15ac43` in `client/src/lib/mockWinners.ts`. For admin-gated scenarios, the Preview deployment's `VITE_ADMIN_ADDRESSES` must include Alice's SS58-42 address (`5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY`). Production must not.
+
+The runner (`scripts/run-playwright.mjs`) forwards `VITE_USE_TEST_WALLET` from the invoking shell into the Playwright spawn env; pass it through when running the tester locally if the dev server was started without it.
+
+A runnable SIWS-gated scenario can assert `window.__TEST_WALLET_ENABLED__ === true` in a preflight check and fall back to `SKIPPED (needs-auth-harness)` if the flag isn't live on the target.
+
+**Still skipped even with the harness**: admin approval / payment flows (`webzeroApprove`, `requestChanges`, `confirmPayment`) have no mock-mode branch in `client/src/lib/api.ts` — they always hit the real API. Those remain `SKIPPED (needs-mock-coverage)` until mocks are added.
 
 ## Procedure
 

--- a/.claude/skills/stadium-tester/scripts/run-playwright.mjs
+++ b/.claude/skills/stadium-tester/scripts/run-playwright.mjs
@@ -20,7 +20,7 @@
  */
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync, writeFileSync, existsSync } from "node:fs";
+import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -60,12 +60,32 @@ if (!existsSync(args.spec)) {
   process.exit(2);
 }
 
+// Specs and the generated config both land in /tmp, so bare `@playwright/test`
+// imports can't resolve (ESM walks up from the importer's dir; /tmp has no
+// node_modules). Point every import at the absolute entry file inside
+// client/node_modules instead.
+const PLAYWRIGHT_ENTRY = resolve(CLIENT_DIR, "node_modules/@playwright/test/index.mjs");
+if (!existsSync(PLAYWRIGHT_ENTRY)) {
+  console.error(JSON.stringify({
+    error: "playwright-not-installed",
+    message: `@playwright/test not found at ${PLAYWRIGHT_ENTRY}. Run .claude/skills/stadium-tester/setup.sh first.`,
+  }));
+  process.exit(2);
+}
+
+// --- rewrite `@playwright/test` imports in the spec to absolute paths ---
+const specSrc = readFileSync(args.spec, "utf8");
+const rewritten = specSrc.replace(
+  /(from\s+['"])@playwright\/test(['"])/g,
+  `$1${PLAYWRIGHT_ENTRY}$2`,
+);
+if (rewritten !== specSrc) writeFileSync(args.spec, rewritten);
+
 // --- minimal playwright config so the skill doesn't need to ship one ---
-// Written into /tmp adjacent to the spec so we don't pollute the repo.
 const configPath = args.spec.replace(/\.spec\.mjs$/, ".config.mjs");
 writeFileSync(
   configPath,
-  `import { defineConfig } from '@playwright/test';
+  `import { defineConfig } from '${PLAYWRIGHT_ENTRY}';
 export default defineConfig({
   testDir: '${dirname(args.spec)}',
   testMatch: ['${args.spec.split("/").pop()}'],
@@ -84,10 +104,23 @@ export default defineConfig({
 );
 
 // --- run playwright (resolves @playwright/test from client/node_modules) ---
+// VITE_USE_TEST_WALLET is forwarded if set on the host so the tester can drive
+// SIWS-gated flows against a dev server / preview URL that bundled the flag.
+// The flag is client-side only — the server never sees it.
 const result = spawnSync(
   "npx",
   ["--no-install", "playwright", "test", "--config", configPath],
-  { cwd: CLIENT_DIR, encoding: "utf8", env: { ...process.env, CI: "1" } },
+  {
+    cwd: CLIENT_DIR,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CI: "1",
+      ...(process.env.VITE_USE_TEST_WALLET
+        ? { VITE_USE_TEST_WALLET: process.env.VITE_USE_TEST_WALLET }
+        : {}),
+    },
+  },
 );
 
 // Surface raw reporter output to stderr for debugging

--- a/client/.env.example
+++ b/client/.env.example
@@ -12,3 +12,12 @@ VITE_ADMIN_ADDRESSES=
 # localStorage. Production must leave this unset or "false". Set to "true" in
 # Vercel's Preview environment so branch previews don't hit production.
 VITE_USE_MOCK_DATA=false
+
+# Test-wallet harness: when "true", injects a synthetic Polkadot-JS extension
+# backed by the well-known //Alice dev keypair so Playwright / the stadium-tester
+# Skill can exercise SIWS-gated write flows without a real wallet extension.
+# Double-gated: even with this flag set, the injection no-ops in production
+# builds (import.meta.env.PROD). Only enable in Vercel's Preview env (not
+# Production) and for local dev. The mnemonic is public — never add Alice's
+# address to the server's ADMIN_WALLETS / AUTHORIZED_SIGNERS on prod.
+VITE_USE_TEST_WALLET=false

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Playwright / stadium-tester scratch
+test-results
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
         "@polkadot/api": "^16.5.1",
         "@polkadot/api-contract": "^16.5.1",
         "@polkadot/extension-dapp": "^0.61.3",
+        "@polkadot/keyring": "^13.5.3",
         "@polkadot/types": "^16.5.1",
         "@polkadot/util": "^13.5.3",
         "@polkadot/util-crypto": "^13.5.3",
@@ -68,6 +69,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
+        "@playwright/test": "^1.59.1",
         "@tailwindcss/typography": "^0.5.15",
         "@types/node": "^22.5.5",
         "@types/react": "^18.3.3",
@@ -1665,6 +1667,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polkadot-api/json-rpc-provider": {
@@ -6970,6 +6988,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/client/package.json
+++ b/client/package.json
@@ -14,6 +14,7 @@
     "@polkadot/api": "^16.5.1",
     "@polkadot/api-contract": "^16.5.1",
     "@polkadot/extension-dapp": "^0.61.3",
+    "@polkadot/keyring": "^13.5.3",
     "@polkadot/types": "^16.5.1",
     "@polkadot/util": "^13.5.3",
     "@polkadot/util-crypto": "^13.5.3",
@@ -70,6 +71,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/typography": "^0.5.15",
     "@types/node": "^22.5.5",
     "@types/react": "^18.3.3",

--- a/client/src/lib/mockWinners.ts
+++ b/client/src/lib/mockWinners.ts
@@ -126,6 +126,15 @@ export const mockWinningProjects: MockApiProject[] = [
         "twitter": "ziginiz",
         "github": null,
         "linkedin": null
+      },
+      {
+        "name": "Test Harness (preview only)",
+        "walletAddress": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+        "customUrl": null,
+        "role": "Team",
+        "twitter": null,
+        "github": null,
+        "linkedin": null
       }
     ],
     "bountyPrize": [

--- a/client/src/lib/testWalletInjection.ts
+++ b/client/src/lib/testWalletInjection.ts
@@ -1,0 +1,57 @@
+/**
+ * Playwright harness: synthetic Polkadot-JS extension backed by a real
+ * sr25519 keypair (//Alice dev account). Lets the stadium-tester Skill
+ * exercise SIWS-gated flows in a headless browser without a wallet extension.
+ *
+ * Double-gated — activates only when BOTH hold:
+ *   - import.meta.env.VITE_USE_TEST_WALLET === 'true'
+ *   - import.meta.env.PROD !== true
+ *
+ * A production build ignores the flag. Never wire this wallet into prod
+ * ADMIN_WALLETS / AUTHORIZED_SIGNERS on the server — the mnemonic is public.
+ */
+import { cryptoWaitReady } from '@polkadot/util-crypto';
+import { Keyring } from '@polkadot/keyring';
+import { u8aToHex, stringToU8a } from '@polkadot/util';
+
+const ENABLED =
+  import.meta.env.VITE_USE_TEST_WALLET === 'true' &&
+  import.meta.env.PROD !== true;
+
+const DEV_MNEMONIC =
+  'bottom drive obey lake curtain smoke basket hold race lonely fit walk';
+
+if (ENABLED && typeof window !== 'undefined') {
+  const win = window as unknown as { injectedWeb3?: Record<string, unknown>; __TEST_WALLET_ENABLED__?: boolean };
+  win.injectedWeb3 = {
+    ...(win.injectedWeb3 ?? {}),
+    'polkadot-js': {
+      version: '0.0.0-test-wallet',
+      enable: async () => {
+        await cryptoWaitReady();
+        const pair = new Keyring({ type: 'sr25519', ss58Format: 42 }).addFromUri(
+          '//Alice',
+        );
+        const account = { address: pair.address, type: 'sr25519', name: 'Test Harness' };
+        return {
+          accounts: {
+            get: async () => [account],
+            subscribe: (cb: (accounts: typeof account[]) => void) => {
+              cb([account]);
+              return () => {};
+            },
+          },
+          signer: {
+            signRaw: async ({ data }: { address: string; data: string; type: string }) => ({
+              id: Date.now(),
+              signature: u8aToHex(pair.sign(stringToU8a(data))),
+            }),
+          },
+          metadata: { get: async () => [], provide: async () => false },
+          provider: { send: async () => ({}) },
+        };
+      },
+    },
+  };
+  win.__TEST_WALLET_ENABLED__ = true;
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,3 +1,4 @@
+import './lib/testWalletInjection'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -112,6 +112,7 @@ Client verification is `npm run build` (tsc + Vite) and `npm run lint`. Both mus
 - `npm run build` output deployed by Vercel.
 - Env vars: `VITE_API_BASE_URL`, `VITE_ADMIN_ADDRESSES` (comma-separated).
 - Preview deployments from PRs work normally.
+- **Preview env only**: `VITE_USE_MOCK_DATA=true` serves fixtures instead of the API. `VITE_USE_TEST_WALLET=true` activates the `//Alice` test-wallet harness so the `stadium-tester` Skill can exercise SIWS-gated flows. Alice's SS58-42 address (`5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY`) must also be in `VITE_ADMIN_ADDRESSES` on Preview for admin flows to pass the client gate. **Production must leave both flags unset** and must never include Alice's address in `VITE_ADMIN_ADDRESSES` or the server's `ADMIN_WALLETS` / `AUTHORIZED_SIGNERS` — the //Alice mnemonic is public.
 
 Do **not** modify Railway/Vercel config from an issue unless the issue explicitly calls for it.
 


### PR DESCRIPTION
## Summary

Unblocks autonomous Playwright verification of SIWS-gated write flows. Injects a synthetic Polkadot-JS extension backed by the well-known `//Alice` dev keypair so `stadium-tester` can sign in a headless browser. Phase 1 spec §6 flagged this as the biggest agentic-velocity blocker — six of the thirteen Phase 1 issues had write flows the tester couldn't exercise.

Also fixes a latent bug in the tester runner that's why recent PRs (#45 #46 #47 etc.) all shipped with unchecked Playwright boxes in their test plans — the runner had never actually worked end-to-end from /tmp.

## What's in the diff

**Client:**
- `client/src/lib/testWalletInjection.ts` (new) — registers `window.injectedWeb3['polkadot-js']` synchronously at module load; `enable()` lazily derives `//Alice` via `@polkadot/keyring` and returns real sr25519 signatures. Double-gated on `VITE_USE_TEST_WALLET === 'true' && !import.meta.env.PROD` — a prod build DCEs the whole block.
- `client/src/main.tsx` — imports the injection at the top so it registers before `AdminPage` starts polling `window.injectedWeb3`.
- `client/src/lib/mockWinners.ts` — Alice's SS58-42 address seeded as a team member on `plata-mia-15ac43` so team-gated flows pass the client-side team check.
- `client/package.json` — `@polkadot/keyring` promoted to explicit dep (was transitive); `@playwright/test` promoted to explicit devDep so fresh clones get it from `npm install` instead of `setup.sh`.

**Tester skill:**
- `.claude/skills/stadium-tester/scripts/run-playwright.mjs` — fixes the runner. Specs and the generated config both live in `/tmp`, but they import `@playwright/test` as a bare specifier; ESM walks up from the importer's directory and `/tmp` has no `node_modules`, so resolution fails. The runner now rewrites `from '@playwright/test'` in the spec and the generated config to the absolute path `client/node_modules/@playwright/test/index.mjs`. Also forwards `VITE_USE_TEST_WALLET` through the Playwright spawn env.
- `.claude/skills/stadium-tester/SKILL.md` — new "Test-wallet mode" section documenting when/how to use the harness, and what still can't run (`webzeroApprove` / `requestChanges` / `confirmPayment` have no mock-mode branch in `api.ts`, so they stay SKIPPED pending separate mock coverage).
- `client/.env.example`, `docs/AGENT_GUIDE.md` — env vars + Vercel Preview-only config guidance.

## Guardrails

- **Double-gated injection.** Even if `VITE_USE_TEST_WALLET=true` leaks into a prod build, the `!import.meta.env.PROD` check makes the whole injection statically false, so Rollup DCEs it.
- **Prod-safety verified.** `VITE_USE_TEST_WALLET=true npm run build` produces a dist with zero references to the `__TEST_WALLET_ENABLED__` sentinel — confirmed by grepping every file in `dist/assets/*.js`.
- **Alice stays out of prod auth lists.** Alice's mnemonic is publicly known — anyone could sign as her. The PR adds her to `VITE_ADMIN_ADDRESSES` **only via Vercel Preview env var** (dashboard action, not code). Production's `VITE_ADMIN_ADDRESSES` stays unchanged; the server's `ADMIN_WALLETS` / `AUTHORIZED_SIGNERS` on prod must not include her either.
- **Prod-URL denylist unchanged** — `run-playwright.mjs` still refuses `stadium.joinwebzero.com` with exit 3.
- **`BYPASS_ADMIN_CHECK` unchanged.**

## Verification

Local end-to-end against `http://localhost:8080` with `VITE_USE_MOCK_DATA=true VITE_USE_TEST_WALLET=true npm run dev`:

```
Running 3 tests using 1 worker
  ✓ test-wallet harness is active on dev server
  ✓ injected extension registers under window.injectedWeb3["polkadot-js"]
  ✓ injected extension yields //Alice account and signs raw data
  3 passed (3.5s)
```

`enable()` returns the canonical SS58-42 Alice address `5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY` and `signRaw` produces a `0x`-prefixed sr25519 signature that verifies through `@polkadot/util-crypto.signatureVerify` — i.e. if this were pointed at a real server (follow-up), the same signatures would pass the real auth middleware.

```
server tests:  PASS (66/66)
client build:  PASS
client lint:   98 pre-existing (90 errors, 8 warnings) — NOT introduced by this PR
```

Lint baseline is broken on `develop` (confirmed via `git stash && npm run lint` — same 98). The only GitHub Actions workflow is `claude.yml`; no CI has ever enforced `npm run lint`. **Not fixed here** — separate cleanup PR.

## Vercel Preview config needed (dashboard, outside code)

Before this harness is useful on preview URLs:

1. Set `VITE_USE_TEST_WALLET=true` on the **Preview** env (not Production).
2. Append `5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY` to `VITE_ADMIN_ADDRESSES` on the **Preview** env (not Production).

Without these, SIWS-gated scenarios targeting a preview URL still get `SKIPPED (needs-auth-harness)` — the harness is inert without the build-time flag.

## Out of scope (follow-ups)

- **Admin-approval mock-mode gaps.** `webzeroApprove`, `requestChanges`, `confirmPayment` in `client/src/lib/api.ts` have no mock branch — they always hit the real API. Harness doesn't help those. Separate small PR to add mocks, or keep them SKIPPED.
- **Real-staging server verification.** Adding Alice to `AUTHORIZED_SIGNERS` on a staging Railway env + seeding team_members in staging Supabase would let the tester hit a real backend. Needs a staging env to exist first.
- **Pre-existing lint debt on `develop`.** 98 problems. Separate cleanup PR.

## Test plan

Automated (already passed locally):
- [x] `cd server && npm test` → 66/66.
- [x] `cd client && npm run build` → clean.
- [x] Tester harness check against local dev server → 3/3 pass.
- [x] Prod-URL denylist fires (exit 3) against `stadium.joinwebzero.com`.
- [x] Prod build (`VITE_USE_TEST_WALLET=true npm run build`) DCEs the injection — grep `__TEST_WALLET_ENABLED__` in `dist/assets/*.js` returns 0 hits.

Against the Vercel Preview built from this branch (after dashboard env is set):
- [ ] `/m2-program/plata-mia-15ac43` Updates tab visible; "Post update" button visible when connected as the injected Alice wallet.
- [ ] Clicking Post update → modal opens → submit triggers SIWS `signRaw` (no human prompt) → new update appears at top of list (mock-mode in-memory write).
- [ ] `/admin` → injected Alice is auto-selected as admin account; Programs table renders.

Non-code (manual before next use):
- [ ] `VITE_USE_TEST_WALLET` set on Vercel **Preview** only.
- [ ] Alice's address appended to `VITE_ADMIN_ADDRESSES` on Vercel **Preview** only.