### PR TITLE
feat(client): mock-mode coverage for admin-approval flows

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -389,8 +389,32 @@ export const api = {
     return teamResult;
   },
 
-  webzeroApprove: async (projectId: string, authHeader?: string) =>
-    request(`/m2-program/${projectId}/approve`, {
+  webzeroApprove: async (projectId: string, authHeader?: string) => {
+    if (USE_MOCK_DATA) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      const stored = localStorage.getItem('projects');
+      if (stored) {
+        const projects = JSON.parse(stored);
+        const index = projects.findIndex((p: { id: string }) => p.id === projectId);
+        if (index !== -1) {
+          projects[index].m2Status = 'completed';
+          projects[index].changesRequested = undefined;
+          localStorage.setItem('projects', JSON.stringify(projects));
+        }
+      }
+
+      const { mockWinningProjects } = await import('./mockWinners');
+      const mockProject = mockWinningProjects.find((p) => p.id === projectId);
+      if (mockProject) {
+        mockProject.m2Status = 'completed';
+        mockProject.changesRequested = undefined;
+      }
+
+      return { success: true };
+    }
+
+    return request(`/m2-program/${projectId}/approve`, {
       method: "POST",
       headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -398,17 +422,45 @@ export const api = {
         webzeroApproved: true,
         webzeroApprovalDate: new Date().toISOString(),
       }),
-    }),
+    });
+  },
 
-  requestChanges: async (projectId: string, feedback: string, authHeader?: string) =>
-    request(`/m2-program/${projectId}/request-changes`, {
+  requestChanges: async (projectId: string, feedback: string, authHeader?: string) => {
+    if (USE_MOCK_DATA) {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+      const requestedDate = new Date().toISOString();
+      const changesRequested = { feedback, requestedBy: 'admin', requestedDate };
+
+      const stored = localStorage.getItem('projects');
+      if (stored) {
+        const projects = JSON.parse(stored);
+        const index = projects.findIndex((p: { id: string }) => p.id === projectId);
+        if (index !== -1) {
+          projects[index].m2Status = 'building';
+          projects[index].changesRequested = changesRequested;
+          localStorage.setItem('projects', JSON.stringify(projects));
+        }
+      }
+
+      const { mockWinningProjects } = await import('./mockWinners');
+      const mockProject = mockWinningProjects.find((p) => p.id === projectId);
+      if (mockProject) {
+        mockProject.m2Status = 'building';
+        mockProject.changesRequested = changesRequested;
+      }
+
+      return { success: true };
+    }
+
+    return request(`/m2-program/${projectId}/request-changes`, {
       method: "POST",
       headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : { "Content-Type": "application/json" },
       body: JSON.stringify({
         feedback,
         requestedChangesDate: new Date().toISOString(),
       }),
-    }),
+    });
+  },
 
   submitM2Agreement: async (projectId: string, agreement: {
     mentorName: string;
@@ -668,7 +720,80 @@ export const api = {
     authHeader?: string
   ) => {
     if (USE_MOCK_DATA) {
-      await new Promise(resolve => setTimeout(resolve, 500));
+      if (!['M1', 'M2', 'BOUNTY'].includes(data.milestone)) {
+        throw new ApiError('Invalid milestone. Must be M1, M2, or BOUNTY', 400);
+      }
+      if (!data.amount || data.amount <= 0) {
+        throw new ApiError('Invalid amount', 400);
+      }
+      if (!['USDC', 'DOT'].includes(data.currency)) {
+        throw new ApiError('Invalid currency. Must be USDC or DOT', 400);
+      }
+      if (!data.transactionProof || !data.transactionProof.startsWith('http')) {
+        throw new ApiError('Valid transaction proof URL is required', 400);
+      }
+      if (data.milestone === 'BOUNTY' && !data.bountyName) {
+        throw new ApiError('bountyName is required for BOUNTY payments', 400);
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 500));
+
+      const { mockWinningProjects } = await import('./mockWinners');
+      const mockProject = mockWinningProjects.find((p) => p.id === projectId);
+      if (!mockProject) {
+        throw new ApiError('Project not found', 404);
+      }
+
+      const totalPaid = (mockProject.totalPaid as Array<{
+        milestone: string;
+        bountyName?: string;
+      }> | undefined) ?? [];
+      const alreadyPaid =
+        data.milestone === 'BOUNTY'
+          ? totalPaid.some(
+              (p) => p.milestone === 'BOUNTY' && p.bountyName === data.bountyName,
+            )
+          : totalPaid.some((p) => p.milestone === data.milestone);
+      if (alreadyPaid) {
+        throw new ApiError(
+          data.milestone === 'BOUNTY'
+            ? `Bounty "${data.bountyName}" has already been paid`
+            : `${data.milestone} has already been paid`,
+          400,
+        );
+      }
+
+      const paidDate = new Date().toISOString();
+      const paymentEntry: Record<string, unknown> = {
+        milestone: data.milestone,
+        amount: data.amount,
+        currency: data.currency,
+        transactionProof: data.transactionProof,
+        paidDate,
+      };
+      if (data.milestone === 'BOUNTY') paymentEntry.bountyName = data.bountyName;
+
+      const nextTotalPaid = [...totalPaid, paymentEntry];
+      (mockProject as { totalPaid?: unknown }).totalPaid = nextTotalPaid;
+      if (data.milestone === 'M2') {
+        mockProject.m2Status = 'completed';
+        mockProject.completionDate = paidDate;
+      }
+
+      const stored = localStorage.getItem('projects');
+      if (stored) {
+        const projects = JSON.parse(stored);
+        const index = projects.findIndex((p: { id: string }) => p.id === projectId);
+        if (index !== -1) {
+          projects[index].totalPaid = nextTotalPaid;
+          if (data.milestone === 'M2') {
+            projects[index].m2Status = 'completed';
+            projects[index].completionDate = paidDate;
+          }
+          localStorage.setItem('projects', JSON.stringify(projects));
+        }
+      }
+
       return { success: true };
     }
     


### PR DESCRIPTION
## Summary

Follow-up to #62 (SIWS test-wallet harness). The harness let Playwright sign SIWS writes, but three admin-approval functions in `client/src/lib/api.ts` — `webzeroApprove`, `requestChanges`, `confirmPayment` — still always hit the real API even when `VITE_USE_MOCK_DATA=true`. That meant the tester could *start* Block F's admin-review loop but the actual approve/reject/pay actions would fail against a preview URL. This PR closes that gap.

## What's in the diff

Three functions in `client/src/lib/api.ts`, each gains an `if (USE_MOCK_DATA)` branch mirroring the `submitM2Agreement` / `updateM2Agreement` idiom: 500 ms delay, update `localStorage['projects']`, update the in-memory `mockWinningProjects` array, return `{ success: true }`.

Server parity on each:

- **`webzeroApprove`** — sets `m2Status='completed'`, clears any prior `changesRequested`. `webzeroApproved` / `webzeroApprovalDate` are written by the server but never read by any client code (greped the whole `client/src` tree), so not surfaced on the mock.
- **`requestChanges`** — sets `m2Status='building'`, stores `{ feedback, requestedBy: 'admin', requestedDate }` on `changesRequested`.
- **`confirmPayment`** — full server-parity input validation (milestone enum, positive amount, currency enum, transactionProof URL prefix, BOUNTY→bountyName). Rejects duplicates with a 400 `ApiError` — M1/M2 matched by milestone, BOUNTY by `milestone + bountyName`, matching `server/api/controllers/project.controller.js:418-434`. Appends to `totalPaid`; for M2 also sets `m2Status='completed'` and `completionDate`.

## Verification

Five Playwright tests driven through the harness runner against `http://localhost:8080` with `VITE_USE_MOCK_DATA=true VITE_USE_TEST_WALLET=true`:

```
Running 5 tests using 1 worker
  ✓ webzeroApprove mock flips m2Status to completed and clears changesRequested
  ✓ requestChanges mock flips m2Status to building and stores feedback
  ✓ confirmPayment mock appends to totalPaid and sets completion on M2
  ✓ confirmPayment mock rejects duplicate M2 payment with 400
  ✓ confirmPayment mock rejects BOUNTY without bountyName
  5 passed (7.0s)
```

Tests drive the mock paths directly via `page.evaluate(() => import('/src/lib/api.ts'))` against the Vite dev server — no need to script the full admin connect-wallet UI flow.

```
server tests:  PASS (66/66)
client build:  PASS
client lint:   pre-existing 98 problems on develop, unchanged — this PR adds 0
```

The two `no-explicit-any` errors on `api.ts` at lines 308 and 323 already exist on `develop` (confirmed via `git stash && npm run lint`). My additions use typed predicates instead of `any`.

## Guardrails

- **No behaviour change outside mock mode.** The real-API branches are byte-identical to before.
- **Client-only change.** No server/repo touches. No new deps.
- **Mock mutates the same objects as other mocks** (`mockWinningProjects` + `localStorage['projects']`) — any existing mock consumer that reads from either will reflect approvals/payments immediately.

## Out of scope / follow-ups

- The harness's preview-URL value still depends on Vercel dashboard env (`VITE_USE_TEST_WALLET=true` + Alice in `VITE_ADMIN_ADDRESSES`, Preview scope only) — tracked separately.
- Pre-existing lint debt on `develop` — separate cleanup PR.

## Test plan

Automated (already green locally):
- [x] `cd server && npm test` → 66/66.
- [x] `cd client && npm run build` → clean.
- [x] 5-test harness verification → all pass.

Against the Vercel Preview built from this branch (after the Preview env flags are set):
- [ ] `/admin/programs/<slug>` admin can Accept an application → status flips without reload (mock mutation reflected).
- [ ] `/admin` → Approve M2 on a project → project's `m2Status` moves to `completed` on next Overview render.
- [ ] `/admin` → Request changes on a project → project's `m2Status` moves to `building`, feedback visible.
- [ ] WinnersTable → Confirm payment for an unpaid milestone → row reflects the new `totalPaid` entry.