### PR TITLE
chore(client): make lint pass on develop (0 errors, 0 warnings)

### DIFF
--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -24,6 +24,19 @@ export default tseslint.config(
         { allowConstantExport: true },
       ],
       "@typescript-eslint/no-unused-vars": "off",
+      // Polkadot/SIWS typings and third-party extension shims make selective `any`
+      // usage the pragmatic choice here. Not enforced at the repo level; the IDE
+      // will still surface it in hover. Revisit post-Phase-2.
+      "@typescript-eslint/no-explicit-any": "off",
+    },
+  },
+  {
+    // shadcn/ui components ship with co-exports (cva variants) that trip
+    // react-refresh's single-export-per-file rule. Vendor code; not ours to
+    // restructure.
+    files: ["src/components/ui/**/*.{ts,tsx}"],
+    rules: {
+      "react-refresh/only-export-components": "off",
     },
   }
 );

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -95,6 +95,8 @@ const HomePage = () => {
       }
     };
     loadHackathons();
+    // Run once on mount; `toast` is stable across renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Load projects when selected hackathon changes

--- a/client/src/pages/ProjectDetailsPage.tsx
+++ b/client/src/pages/ProjectDetailsPage.tsx
@@ -63,7 +63,7 @@ function ensureSubmissionUrl(url: string): string {
 
 /** Renders summary text with bullet lines as a proper list */
 function SummaryWithBullets({ text }: { text: string }) {
-  const bulletPattern = /^[\-\•\*·]\s+/;
+  const bulletPattern = /^[-•*·]\s+/;
   const lines = text.split("\n");
   return (
     <ul className="list-disc pl-4 space-y-1 text-sm text-muted-foreground leading-relaxed">
@@ -328,6 +328,9 @@ const ProjectDetailsPage = () => {
 
   useEffect(() => {
     fetchProject();
+    // Adding `fetchProject` to deps would cause a fetch loop — it's redefined
+    // on every render. The effect is intentionally keyed on the route param.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id]);
 
   // Phase 1 revamp (#42): fetch the funding signal alongside the project.

--- a/client/tailwind.config.ts
+++ b/client/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -161,5 +162,5 @@ export default {
     		}
     	}
     },
-	plugins: [require("tailwindcss-animate")],
+	plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary

`develop` was sitting on 98 pre-existing lint problems (90 errors + 8 warnings). Since the only GitHub Actions workflow is `claude.yml` (Claude bot, not CI), nothing ever enforced `npm run lint` — so `/pre-pr-check` couldn't distinguish *new* lint issues introduced by a PR from accumulated debt. This PR gets `develop` to a clean lint baseline so that guardrail becomes meaningful again.

## Approach

Relax-rules + quick-wins (the choice approved out of the lint-debt discussion). No type rewrites; no churn across 20+ files.

**`client/eslint.config.js`:**
- `@typescript-eslint/no-explicit-any` → **`off`**. 86 uses across the repo, concentrated in Polkadot / SIWS shims and `client/src/lib/api.ts`. The rule was never enforced in practice; dropping it matches the team's actual posture. The IDE still surfaces `any` on hover. Revisit post-Phase-2 when the codebase has stabilised.
- New overrides block for `src/components/ui/**`: disables `react-refresh/only-export-components`. shadcn vendor files co-export cva variants alongside components; not ours to restructure.

**`client/tailwind.config.ts`:**
- `require("tailwindcss-animate")` → `import tailwindcssAnimate from "tailwindcss-animate"`. Module has proper ESM, no wrapping needed.

**`client/src/pages/HomePage.tsx:98` and `ProjectDetailsPage.tsx:331`:**
- Narrow `eslint-disable-next-line react-hooks/exhaustive-deps` with a one-line reason per site.
  - `HomePage`: effect runs once on mount; `toast` from `useToast` is stable across renders.
  - `ProjectDetailsPage`: effect is intentionally keyed on the `id` route param. Adding `fetchProject` to the deps array would fetch-loop — it's redefined every render.

**`client/src/pages/ProjectDetailsPage.tsx:66`:**
- `/^[\-\•\*·]\s+/` → `/^[-•*·]\s+/`. Inside a character class, `-` at the first position doesn't need escaping and `•`/`*` are always literal. Behaviour identical; previous escapes were just noise.

## After

```
> eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0
(exit 0, no output)
```

`--max-warnings 0` is preserved — so every future PR's lint diff is the true lint diff.

## Verification

```
server tests:  PASS (66/66)
client build:  PASS (clean)
client lint:   PASS (0 errors, 0 warnings)
```

## Scope

Four files, 21 lines net. No behaviour change to runtime code (regex semantics preserved, hook behaviour preserved, tailwind plugin unchanged). The only actual semantics delta is the ESLint config policy.

## Follow-ups (out of scope)

- The `@typescript-eslint/no-explicit-any` rule can be ratcheted back to `warn` (and eventually `error`) once the Polkadot SIWS surface stabilises. Track in the improvement backlog if someone wants to adopt stricter types.
- `client/.eslintrc.cjs` still exists alongside `eslint.config.js`. ESLint 9 uses the flat config; the `.cjs` is a legacy artifact that can be deleted in a follow-up cleanup.

## Test plan

- [x] `cd server && npm test` → 66/66.
- [x] `cd client && npm run build` → clean.
- [x] `cd client && npm run lint` → exit 0, no output.
- [ ] Against the Vercel preview built from this branch: smoke check that UI still renders (no Tailwind animate plugin regression from the require→import swap).