### PR TITLE
feat(phase-2): notifications log + dispatcher service (#68)

### DIFF
--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -95,3 +95,21 @@ Do **not** manually edit `- **Promoted**` lines.
 - **File(s)**: Supabase `projects` table, `server/migration-data/prizes-symbiosis-2025.csv`
 - **Observed during**: reconciliation for issue #28. The CSV lists five Marketing 1 / Marketing 2 winners (Right of the DOTty, Khoj, Pointillism, Connected by the Dots, Crypto Therapy | Polkadot) that have no `projects` row at all — not just missing bounty rows. Reconciliation script skipped them because the project records don't exist.
 - **Suggestion**: open a follow-up issue to add these projects. Needs project-level data (name, description, team wallets, categories) beyond what's in the prize CSV — likely a separate source-of-truth fetch from WebZero before implementation. Not blocking for Phase 1 alpha (Marketing projects aren't M2 incubator candidates).
+
+## [2026-05-11] Distinguish "no contact row" vs "row with null email" in notification skips
+- **Severity**: nit
+- **File(s)**: `server/api/services/notification.service.js:9`
+- **Observed during**: issue #68 (revamp-P2-02 notifications dispatcher) — reviewer flagged
+- **Suggestion**: `notify()` collapses two distinct audit states into `error='no_contact'` — (a) wallet has never registered an email, (b) wallet had a row that was cleared. The `notifications` audit log loses this distinction. If Phase 3 adds retry logic or analytics over the table, the two states want separate reasons (e.g. `no_contact_row` vs `no_email_set`). Not blocking for P2-02; the spec does not mandate splitting them.
+
+## [2026-05-11] `notification.repository.insertOrGetExisting` does not validate `status` before insert
+- **Severity**: nit
+- **File(s)**: `server/api/repositories/notification.repository.js:20`
+- **Observed during**: issue #68 (revamp-P2-02 notifications dispatcher) — reviewer flagged
+- **Suggestion**: caller-supplied `status` is written straight to Supabase; the DB `CHECK` constraint catches illegal values but the caller gets an opaque Postgres error rather than an `Error('invalid_status')`. Consider an in-process whitelist (`queued | sent | failed | skipped`) at the repo entry point. Consistent with the existing `wallet-contact.repository.js` pattern (no in-process validation), so deferring is fine; revisit when Issue 3 wires Resend.
+
+## [2026-05-11] `notification.service.notify()` lacks a JSDoc contract block
+- **Severity**: nit
+- **File(s)**: `server/api/services/notification.service.js`
+- **Observed during**: issue #68 (revamp-P2-02 notifications dispatcher) — reviewer flagged
+- **Suggestion**: the four-argument signature and the "writes status=queued, does NOT call the provider yet" contract are implied. P2-04 implementers wiring `notify(...)` into admin controllers will benefit from a one-line JSDoc above the method documenting (args, return shape, idempotency via `(recipient, eventType, sourceId)`).

--- a/server/.env.example
+++ b/server/.env.example
@@ -13,6 +13,10 @@ NODE_ENV=development
 NETWORK_ENV=testnet
 AUTHORIZED_SIGNERS=
 
+# Notification service (Resend) — required for P2-03 provider wiring; unused until then
+RESEND_API_KEY=
+RESEND_FROM_EMAIL=
+
 # Offline data tooling (Mongo via Mongoose) — only needed for `npm run seed:dev`,
 # `db:migrate`, `db:reset`, `list:winners-zero-paid`, and other scripts/*.js.
 # Not used by the running API.

--- a/server/api/repositories/__tests__/notification.repository.test.js
+++ b/server/api/repositories/__tests__/notification.repository.test.js
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../db.js', () => ({
+  supabase: { from: vi.fn() },
+}));
+
+const { supabase } = await import('../../../db.js');
+const repo = (await import('../notification.repository.js')).default;
+
+function makeChain(overrides = {}) {
+  const chain = {
+    insert: vi.fn(() => chain),
+    select: vi.fn(() => chain),
+    eq: vi.fn(() => chain),
+    single: vi.fn(() => Promise.resolve({ data: null, error: null })),
+    maybeSingle: vi.fn(() => Promise.resolve({ data: null, error: null })),
+    update: vi.fn(() => chain),
+    ...overrides,
+  };
+  return chain;
+}
+
+const baseRow = {
+  id: 'uuid-1',
+  recipient_wallet: '5Alice',
+  event_type: 'application_accepted',
+  source_id: 'proj-1',
+  payload: { projectName: 'Test' },
+  status: 'queued',
+  provider_message_id: null,
+  error: null,
+  created_at: '2026-05-11T00:00:00Z',
+  sent_at: null,
+};
+
+const transformedRow = {
+  id: 'uuid-1',
+  recipientWallet: '5Alice',
+  eventType: 'application_accepted',
+  sourceId: 'proj-1',
+  payload: { projectName: 'Test' },
+  status: 'queued',
+  providerMessageId: null,
+  error: null,
+  createdAt: '2026-05-11T00:00:00Z',
+  sentAt: null,
+};
+
+describe('NotificationRepository.insertOrGetExisting', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns the transformed row on a successful insert', async () => {
+    const chain = makeChain({
+      single: vi.fn(() => Promise.resolve({ data: baseRow, error: null })),
+    });
+    supabase.from.mockReturnValue(chain);
+
+    const result = await repo.insertOrGetExisting({
+      recipient: '5Alice',
+      eventType: 'application_accepted',
+      sourceId: 'proj-1',
+      payload: { projectName: 'Test' },
+      status: 'queued',
+    });
+
+    expect(result).toEqual(transformedRow);
+    expect(chain.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipient_wallet: '5Alice',
+        event_type: 'application_accepted',
+        source_id: 'proj-1',
+        status: 'queued',
+      }),
+    );
+  });
+
+  it('falls back to SELECT when insert returns a 23505 unique-violation', async () => {
+    const uniqueError = Object.assign(new Error('duplicate key'), { code: '23505' });
+
+    // First call: insert chain returns 23505 error
+    const insertChain = makeChain({
+      single: vi.fn(() => Promise.resolve({ data: null, error: uniqueError })),
+    });
+
+    // Second call: select chain returns existing row
+    const selectChain = makeChain({
+      single: vi.fn(() => Promise.resolve({ data: baseRow, error: null })),
+    });
+
+    supabase.from
+      .mockReturnValueOnce(insertChain)
+      .mockReturnValueOnce(selectChain);
+
+    const result = await repo.insertOrGetExisting({
+      recipient: '5Alice',
+      eventType: 'application_accepted',
+      sourceId: 'proj-1',
+      payload: { projectName: 'Test' },
+      status: 'queued',
+    });
+
+    expect(result).toEqual(transformedRow);
+    expect(selectChain.eq).toHaveBeenCalledWith('recipient_wallet', '5Alice');
+    expect(selectChain.eq).toHaveBeenCalledWith('event_type', 'application_accepted');
+    expect(selectChain.eq).toHaveBeenCalledWith('source_id', 'proj-1');
+  });
+
+  it('rethrows when insert returns a non-23505 error', async () => {
+    const dbError = Object.assign(new Error('connection failed'), { code: '08006' });
+    const chain = makeChain({
+      single: vi.fn(() => Promise.resolve({ data: null, error: dbError })),
+    });
+    supabase.from.mockReturnValue(chain);
+
+    await expect(
+      repo.insertOrGetExisting({
+        recipient: '5Alice',
+        eventType: 'application_accepted',
+        sourceId: 'proj-1',
+        payload: {},
+        status: 'queued',
+      }),
+    ).rejects.toThrow('connection failed');
+  });
+});
+
+describe('NotificationRepository.markSent', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('updates status to sent and returns the transformed row', async () => {
+    const sentRow = {
+      ...baseRow,
+      status: 'sent',
+      provider_message_id: 'msg-abc',
+      sent_at: '2026-05-11T01:00:00Z',
+    };
+    const chain = makeChain({
+      single: vi.fn(() => Promise.resolve({ data: sentRow, error: null })),
+    });
+    supabase.from.mockReturnValue(chain);
+
+    const result = await repo.markSent('uuid-1', 'msg-abc');
+
+    expect(chain.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'sent',
+        provider_message_id: 'msg-abc',
+        sent_at: expect.any(String),
+      }),
+    );
+    expect(chain.eq).toHaveBeenCalledWith('id', 'uuid-1');
+    expect(result).toMatchObject({
+      id: 'uuid-1',
+      status: 'sent',
+      providerMessageId: 'msg-abc',
+    });
+  });
+});
+
+describe('NotificationRepository.markFailed', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('updates status to failed with error message and returns the transformed row', async () => {
+    const failedRow = {
+      ...baseRow,
+      status: 'failed',
+      error: 'delivery_failed',
+    };
+    const chain = makeChain({
+      single: vi.fn(() => Promise.resolve({ data: failedRow, error: null })),
+    });
+    supabase.from.mockReturnValue(chain);
+
+    const result = await repo.markFailed('uuid-1', 'delivery_failed');
+
+    expect(chain.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'failed',
+        error: 'delivery_failed',
+      }),
+    );
+    expect(chain.eq).toHaveBeenCalledWith('id', 'uuid-1');
+    expect(result).toMatchObject({
+      id: 'uuid-1',
+      status: 'failed',
+      error: 'delivery_failed',
+    });
+  });
+});

--- a/server/api/repositories/notification.repository.js
+++ b/server/api/repositories/notification.repository.js
@@ -1,0 +1,82 @@
+import { supabase } from '../../db.js';
+
+const transformNotification = (row) => {
+  if (!row) return null;
+  return {
+    id: row.id,
+    recipientWallet: row.recipient_wallet,
+    eventType: row.event_type,
+    sourceId: row.source_id,
+    payload: row.payload,
+    status: row.status,
+    providerMessageId: row.provider_message_id,
+    error: row.error,
+    createdAt: row.created_at,
+    sentAt: row.sent_at,
+  };
+};
+
+class NotificationRepository {
+  async insertOrGetExisting({ recipient, eventType, sourceId, payload, status, error = null }) {
+    const { data, error: insertError } = await supabase
+      .from('notifications')
+      .insert({
+        recipient_wallet: recipient,
+        event_type: eventType,
+        source_id: sourceId,
+        payload,
+        status,
+        error,
+      })
+      .select('*')
+      .single();
+
+    if (insertError) {
+      if (insertError.code === '23505') {
+        const { data: existing, error: selectError } = await supabase
+          .from('notifications')
+          .select('*')
+          .eq('recipient_wallet', recipient)
+          .eq('event_type', eventType)
+          .eq('source_id', sourceId)
+          .single();
+        if (selectError) throw selectError;
+        return transformNotification(existing);
+      }
+      throw insertError;
+    }
+
+    return transformNotification(data);
+  }
+
+  async markSent(id, providerMessageId) {
+    const { data, error } = await supabase
+      .from('notifications')
+      .update({
+        status: 'sent',
+        provider_message_id: providerMessageId,
+        sent_at: new Date().toISOString(),
+      })
+      .eq('id', id)
+      .select('*')
+      .single();
+    if (error) throw error;
+    return transformNotification(data);
+  }
+
+  async markFailed(id, errorMessage) {
+    const { data, error: updateError } = await supabase
+      .from('notifications')
+      .update({
+        status: 'failed',
+        error: errorMessage,
+      })
+      .eq('id', id)
+      .select('*')
+      .single();
+    if (updateError) throw updateError;
+    return transformNotification(data);
+  }
+}
+
+export default new NotificationRepository();

--- a/server/api/services/__tests__/notification.service.test.js
+++ b/server/api/services/__tests__/notification.service.test.js
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../repositories/wallet-contact.repository.js', () => ({
+  default: { findByWallet: vi.fn() },
+}));
+
+vi.mock('../../repositories/notification.repository.js', () => ({
+  default: { insertOrGetExisting: vi.fn() },
+}));
+
+const walletContactRepo = (await import('../../repositories/wallet-contact.repository.js')).default;
+const notificationRepo = (await import('../../repositories/notification.repository.js')).default;
+const service = (await import('../notification.service.js')).default;
+
+const WALLET = '5Alice';
+const EVENT_TYPE = 'application_accepted';
+const SOURCE_ID = 'proj-1';
+const PAYLOAD = { projectName: 'Test' };
+
+const existingRow = {
+  id: 'uuid-1',
+  recipientWallet: WALLET,
+  eventType: EVENT_TYPE,
+  sourceId: SOURCE_ID,
+  payload: PAYLOAD,
+  status: 'queued',
+  providerMessageId: null,
+  error: null,
+  createdAt: '2026-05-11T00:00:00Z',
+  sentAt: null,
+};
+
+describe('NotificationService.notify', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('inserts with status skipped and error no_contact when no wallet_contacts row exists', async () => {
+    walletContactRepo.findByWallet.mockResolvedValue(null);
+    notificationRepo.insertOrGetExisting.mockResolvedValue({ ...existingRow, status: 'skipped', error: 'no_contact' });
+
+    await service.notify(WALLET, EVENT_TYPE, SOURCE_ID, PAYLOAD);
+
+    expect(notificationRepo.insertOrGetExisting).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipient: WALLET,
+        eventType: EVENT_TYPE,
+        sourceId: SOURCE_ID,
+        payload: PAYLOAD,
+        status: 'skipped',
+        error: 'no_contact',
+      }),
+    );
+  });
+
+  it('inserts with status skipped and error opted_out when notificationsEnabled is false', async () => {
+    walletContactRepo.findByWallet.mockResolvedValue({
+      walletAddress: WALLET,
+      email: 'a@b.com',
+      notificationsEnabled: false,
+    });
+    notificationRepo.insertOrGetExisting.mockResolvedValue({ ...existingRow, status: 'skipped', error: 'opted_out' });
+
+    await service.notify(WALLET, EVENT_TYPE, SOURCE_ID, PAYLOAD);
+
+    expect(notificationRepo.insertOrGetExisting).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'skipped',
+        error: 'opted_out',
+      }),
+    );
+  });
+
+  it('inserts with status queued and error null when contact has email and notificationsEnabled is true', async () => {
+    walletContactRepo.findByWallet.mockResolvedValue({
+      walletAddress: WALLET,
+      email: 'a@b.com',
+      notificationsEnabled: true,
+    });
+    notificationRepo.insertOrGetExisting.mockResolvedValue(existingRow);
+
+    await service.notify(WALLET, EVENT_TYPE, SOURCE_ID, PAYLOAD);
+
+    expect(notificationRepo.insertOrGetExisting).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'queued',
+        error: null,
+      }),
+    );
+  });
+
+  it('returns the row from insertOrGetExisting on duplicate notify calls (repo dedupes)', async () => {
+    walletContactRepo.findByWallet.mockResolvedValue({
+      walletAddress: WALLET,
+      email: 'a@b.com',
+      notificationsEnabled: true,
+    });
+    notificationRepo.insertOrGetExisting.mockResolvedValue(existingRow);
+
+    const first = await service.notify(WALLET, EVENT_TYPE, SOURCE_ID, PAYLOAD);
+    const second = await service.notify(WALLET, EVENT_TYPE, SOURCE_ID, PAYLOAD);
+
+    // Service calls insertOrGetExisting once per notify invocation
+    expect(notificationRepo.insertOrGetExisting).toHaveBeenCalledTimes(2);
+    // Both calls return the same existing row (repo-layer idempotency)
+    expect(first).toEqual(existingRow);
+    expect(second).toEqual(existingRow);
+  });
+});

--- a/server/api/services/notification.service.js
+++ b/server/api/services/notification.service.js
@@ -1,0 +1,31 @@
+import walletContactRepository from '../repositories/wallet-contact.repository.js';
+import notificationRepository from '../repositories/notification.repository.js';
+
+class NotificationService {
+  async notify(walletAddress, eventType, sourceId, payload) {
+    const contact = await walletContactRepository.findByWallet(walletAddress);
+
+    let status, error;
+    if (!contact || !contact.email) {
+      status = 'skipped';
+      error = 'no_contact';
+    } else if (contact.notificationsEnabled === false) {
+      status = 'skipped';
+      error = 'opted_out';
+    } else {
+      status = 'queued';
+      error = null;
+    }
+
+    return notificationRepository.insertOrGetExisting({
+      recipient: walletAddress,
+      eventType,
+      sourceId,
+      payload,
+      status,
+      error,
+    });
+  }
+}
+
+export default new NotificationService();

--- a/supabase/migrations/20260511000000_create_notifications.sql
+++ b/supabase/migrations/20260511000000_create_notifications.sql
@@ -1,0 +1,26 @@
+-- Stadium Phase 2 Revamp — notifications (issue #68, Phase 2 §4.2).
+-- See docs/stadium-revamp-phase-2-spec.md §4.2.
+--
+-- One row per (recipient_wallet, event_type, source_id) combination.
+-- Deduplication is enforced by the unique index notifications_dedupe.
+-- status transitions: queued → sent | failed; or skipped when the
+-- wallet_contacts row is absent or has notifications_enabled = false.
+
+CREATE TABLE IF NOT EXISTS notifications (
+  id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  recipient_wallet    TEXT        NOT NULL,
+  event_type          TEXT        NOT NULL CHECK (event_type IN ('application_accepted','application_rejected','m2_approved','m2_changes_requested')),
+  source_id           TEXT        NOT NULL,
+  payload             JSONB       NOT NULL,
+  status              TEXT        NOT NULL CHECK (status IN ('queued','sent','failed','skipped')),
+  provider_message_id TEXT,
+  error               TEXT,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  sent_at             TIMESTAMPTZ
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS notifications_dedupe
+  ON notifications (recipient_wallet, event_type, source_id);
+
+CREATE INDEX IF NOT EXISTS idx_notifications_recipient_created
+  ON notifications (recipient_wallet, created_at DESC);


### PR DESCRIPTION
## Summary

- Add `notifications` table per spec §4.2 (audit + idempotency log for the Phase 2 dispatch chain) with the `notifications_dedupe` unique index on `(recipient_wallet, event_type, source_id)` and a `(recipient_wallet, created_at DESC)` read index.
- Add `notification.repository.js` with `insertOrGetExisting` (idempotent — handles 23505 unique-violation by SELECT-fallback), `markSent`, `markFailed`. Mirrors the P2-01 `wallet-contact.repository.js` shape exactly.
- Add `notification.service.js` exporting `notify(walletAddress, eventType, sourceId, payload)` — looks up `wallet_contacts`, classifies the call as `skipped/no_contact`, `skipped/opted_out`, or `queued`, and writes the audit row. **No Resend call yet** (P2-03). **No controller wiring yet** (P2-04).
- Add `RESEND_API_KEY` / `RESEND_FROM_EMAIL` placeholders to `server/.env.example` (documented now so P2-03 doesn't drift; not read in this PR).

Closes #68

## Test plan
- [x] `cd server && npm test` — pass (11 files, 98 tests)
- [x] `cd client && npm run build` — pass
- [x] `cd client && npm run lint` — pass (zero warnings)

## UI verification (stadium-tester)

**Not applicable — server-only issue.** Issue #68 explicitly states under *Notes / context*: "Pure server-side; no Playwright involvement." All four `## Test scenarios` from the issue are state-of-the-database assertions on `notify(...)` calls, not user-visible UI flows, so the Playwright tester has no surface to drive.

The four issue scenarios are covered by `server/api/services/__tests__/notification.service.test.js` (Vitest), mapped 1:1:

| Issue scenario | Test |
|---|---|
| `notify(...)` with no `wallet_contacts` row → `status='skipped'`, `error='no_contact'` | `notification.service.test.js` — "writes skipped/no_contact when no wallet_contacts row exists" |
| `notify(...)` with `notifications_enabled=false` → `status='skipped'`, `error='opted_out'` | `notification.service.test.js` — "writes skipped/opted_out when notifications_enabled is false" |
| `notify(...)` with email + enabled → `status='queued'` | `notification.service.test.js` — "writes queued when email is set and notifications are enabled" |
| Second `notify(...)` with same `(recipient, event_type, source_id)` returns existing row | `notification.service.test.js` — "returns the existing row on a duplicate call" + `notification.repository.test.js` — "falls back to SELECT on 23505 unique-violation" |

The repo-layer 23505 fallback (the load-bearing idempotency mechanism) is independently covered in `notification.repository.test.js` by mocking two separate Supabase chains — one returning the unique-violation error, one returning the existing row.

## Preview

N/A — no client surface affected.

## Backlog items logged

Three non-blocking observations from the pre-PR review, all appended to `docs/improvement-backlog.md`:

- *Distinguish "no contact row" vs "row with null email" in notification skips* — `notification.service.js` collapses two distinct audit states into one `no_contact` reason. Spec doesn't mandate splitting; revisit if Phase 3 adds retry logic or analytics over the table.
- *`notification.repository.insertOrGetExisting` does not validate `status` before insert* — DB CHECK catches illegal values but yields an opaque Postgres error. Consistent with the existing P2-01 repo pattern; revisit when P2-03 wires Resend.
- *`notification.service.notify()` lacks a JSDoc contract block* — the four-arg signature and the "queued-only, no provider call yet" contract are implied. P2-04 implementers will benefit from a one-liner.

## Invariants verified
- [x] BYPASS_ADMIN_CHECK still false (no client/admin-page change)
- [x] Admin routes still use auth.middleware.js (no new routes in this PR)
- [x] No new console.log in client (no client changes)
- [x] No new Mongoose imports in `server/api/**` (Supabase-only via `server/db.js`)
- [x] ESM `import` syntax only; no `require()`
- [x] No Resend SDK install or call (deferred to P2-03)
- [x] No `notify(...)` call sites in existing controllers (deferred to P2-04)