### PR TITLE
feat(phase-2): Resend integration — send queued notifications (#69)

### DIFF
--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -36,6 +36,10 @@ React component
 
 The repository owns all `.from('projects').select(...)` style calls. A controller should never import the Supabase client directly.
 
+### Notifications
+
+`notification.service.js` is the dispatcher. Call `notify(walletAddress, eventType, sourceId, payload)` to write an audit row to the `notifications` table and, for eligible recipients (contact row present, email set, `notificationsEnabled` not false), send a transactional email via Resend. The four valid event types are `application_accepted`, `application_rejected`, `m2_approved`, and `m2_changes_requested`. To disable email locally, unset `RESEND_API_KEY` — sends become `failed` / `provider_not_configured` but the server still runs. Under `NODE_ENV=test` a mock transport (`__tests__/mock-resend.js`) is used automatically and no network call fires.
+
 ### SIWS admin auth flow
 
 **Client side** (`client/src/lib/siwsUtils.ts` + `AdminPage.tsx`):

--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -113,3 +113,15 @@ Do **not** manually edit `- **Promoted**` lines.
 - **File(s)**: `server/api/services/notification.service.js`
 - **Observed during**: issue #68 (revamp-P2-02 notifications dispatcher) — reviewer flagged
 - **Suggestion**: the four-argument signature and the "writes status=queued, does NOT call the provider yet" contract are implied. P2-04 implementers wiring `notify(...)` into admin controllers will benefit from a one-line JSDoc above the method documenting (args, return shape, idempotency via `(recipient, eventType, sourceId)`).
+
+## [2026-05-18] Warn at startup when RESEND_API_KEY is set but RESEND_FROM_EMAIL is not
+- **Severity**: nit
+- **File(s)**: `server/api/services/email-transport.js`, `server/server.js`
+- **Observed during**: issue #69 (revamp-P2-03 Resend integration) — reviewer flagged
+- **Suggestion**: if `RESEND_API_KEY` is configured but `RESEND_FROM_EMAIL` is unset, `notify()` passes `from: undefined` to Resend, which returns a 4xx that is caught and marks the row `failed`. The send silently fails with an opaque reason. Add a one-time startup check (or a guard inside `_trySend`) that surfaces a clear `from_email_not_configured` error instead of an opaque provider 4xx.
+
+## [2026-05-18] No length guard on admin feedback in the m2-changes-requested email body
+- **Severity**: nit
+- **File(s)**: `server/api/services/notification-templates/m2-changes-requested.js`
+- **Observed during**: issue #69 (revamp-P2-03 Resend integration) — reviewer flagged
+- **Suggestion**: `payload.feedback` is rendered into the email body verbatim (now HTML-escaped). Very long admin feedback produces an oversized email. Consider truncating with a "see the full feedback on your project page" link once P2-05 ships the project-page feedback surface.

--- a/server/api/services/__tests__/email-transport.test.js
+++ b/server/api/services/__tests__/email-transport.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+beforeEach(() => {
+  vi.resetModules();
+});
+
+describe('getEmailTransport', () => {
+  it('returns null when NODE_ENV is not test and RESEND_API_KEY is unset', async () => {
+    const originalEnv = process.env.NODE_ENV;
+    const originalKey = process.env.RESEND_API_KEY;
+
+    process.env.NODE_ENV = 'production';
+    delete process.env.RESEND_API_KEY;
+
+    const { getEmailTransport } = await import('../email-transport.js');
+    const result = await getEmailTransport();
+
+    expect(result).toBeNull();
+
+    process.env.NODE_ENV = originalEnv;
+    if (originalKey !== undefined) process.env.RESEND_API_KEY = originalKey;
+  });
+
+  it('returns the mock transport (never a real Resend client) when NODE_ENV is test', async () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'test';
+
+    const { getEmailTransport } = await import('../email-transport.js');
+    const result = await getEmailTransport();
+
+    expect(result).not.toBeNull();
+    expect(typeof result.send).toBe('function');
+
+    process.env.NODE_ENV = originalEnv;
+  });
+});

--- a/server/api/services/__tests__/mock-resend.js
+++ b/server/api/services/__tests__/mock-resend.js
@@ -1,0 +1,5 @@
+import { vi } from 'vitest';
+
+export const mockResend = {
+  send: vi.fn().mockResolvedValue({ id: 'res_test_default' }),
+};

--- a/server/api/services/__tests__/notification.service.send.test.js
+++ b/server/api/services/__tests__/notification.service.send.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../repositories/wallet-contact.repository.js', () => ({
+  default: { findByWallet: vi.fn() },
+}));
+
+vi.mock('../../repositories/notification.repository.js', () => ({
+  default: {
+    insertOrGetExisting: vi.fn(),
+    markSent: vi.fn(),
+    markFailed: vi.fn(),
+  },
+}));
+
+vi.mock('../email-transport.js', () => ({
+  getEmailTransport: vi.fn(),
+}));
+
+const walletContactRepo = (await import('../../repositories/wallet-contact.repository.js')).default;
+const notificationRepo = (await import('../../repositories/notification.repository.js')).default;
+const { getEmailTransport } = await import('../email-transport.js');
+const service = (await import('../notification.service.js')).default;
+
+const WALLET = '5Bob';
+const EVENT_TYPE = 'application_accepted';
+const SOURCE_ID = 'proj-2';
+const PAYLOAD = { projectName: 'Demo', programName: 'Dogfooding' };
+const EMAIL = 'bob@example.com';
+
+const queuedRow = {
+  id: 'uuid-2',
+  recipientWallet: WALLET,
+  eventType: EVENT_TYPE,
+  sourceId: SOURCE_ID,
+  payload: PAYLOAD,
+  status: 'queued',
+  providerMessageId: null,
+  error: null,
+  createdAt: '2026-05-11T00:00:00Z',
+  sentAt: null,
+};
+
+const sentRow = { ...queuedRow, status: 'sent', providerMessageId: 'res_abc' };
+const failedRow = { ...queuedRow, status: 'failed', error: 'send failed' };
+const providerNotConfiguredRow = { ...queuedRow, status: 'failed', error: 'provider_not_configured' };
+
+describe('NotificationService send path', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    walletContactRepo.findByWallet.mockResolvedValue({
+      walletAddress: WALLET,
+      email: EMAIL,
+      notificationsEnabled: true,
+    });
+    notificationRepo.insertOrGetExisting.mockResolvedValue(queuedRow);
+  });
+
+  it('happy path — markSent called with rowId and provider message id; returned row status is sent', async () => {
+    const mockTransport = { send: vi.fn().mockResolvedValue({ id: 'res_abc' }) };
+    getEmailTransport.mockResolvedValue(mockTransport);
+    notificationRepo.markSent.mockResolvedValue(sentRow);
+
+    const result = await service.notify(WALLET, EVENT_TYPE, SOURCE_ID, PAYLOAD);
+
+    expect(notificationRepo.markSent).toHaveBeenCalledWith('uuid-2', 'res_abc');
+    expect(result.status).toBe('sent');
+  });
+
+  it('provider 4xx — markFailed called; notify does not throw', async () => {
+    const sendError = new Error('4xx bad request');
+    const mockTransport = { send: vi.fn().mockRejectedValue(sendError) };
+    getEmailTransport.mockResolvedValue(mockTransport);
+    notificationRepo.markFailed.mockResolvedValue(failedRow);
+
+    const result = await expect(
+      service.notify(WALLET, EVENT_TYPE, SOURCE_ID, PAYLOAD),
+    ).resolves.toBeDefined();
+
+    expect(notificationRepo.markFailed).toHaveBeenCalledWith('uuid-2', '4xx bad request');
+    return result;
+  });
+
+  it('RESEND_API_KEY unset — getEmailTransport returns null — markFailed called with provider_not_configured', async () => {
+    getEmailTransport.mockResolvedValue(null);
+    notificationRepo.markFailed.mockResolvedValue(providerNotConfiguredRow);
+
+    const result = await service.notify(WALLET, EVENT_TYPE, SOURCE_ID, PAYLOAD);
+
+    expect(notificationRepo.markFailed).toHaveBeenCalledWith('uuid-2', 'provider_not_configured');
+    expect(result.status).toBe('failed');
+  });
+
+  it('no network — fetch is never called with api.resend.com during a happy-path run', async () => {
+    const mockTransport = { send: vi.fn().mockResolvedValue({ id: 'res_net' }) };
+    getEmailTransport.mockResolvedValue(mockTransport);
+    notificationRepo.markSent.mockResolvedValue({ ...queuedRow, status: 'sent', providerMessageId: 'res_net' });
+
+    const fetchSpy = vi.spyOn(global, 'fetch');
+
+    await service.notify(WALLET, EVENT_TYPE, SOURCE_ID, PAYLOAD);
+
+    const resendCalls = fetchSpy.mock.calls.filter(
+      ([url]) => typeof url === 'string' && url.includes('api.resend.com'),
+    );
+    expect(resendCalls).toHaveLength(0);
+
+    fetchSpy.mockRestore();
+  });
+});
+

--- a/server/api/services/__tests__/notification.service.test.js
+++ b/server/api/services/__tests__/notification.service.test.js
@@ -5,19 +5,28 @@ vi.mock('../../repositories/wallet-contact.repository.js', () => ({
 }));
 
 vi.mock('../../repositories/notification.repository.js', () => ({
-  default: { insertOrGetExisting: vi.fn() },
+  default: {
+    insertOrGetExisting: vi.fn(),
+    markSent: vi.fn(),
+    markFailed: vi.fn(),
+  },
+}));
+
+vi.mock('../email-transport.js', () => ({
+  getEmailTransport: vi.fn(),
 }));
 
 const walletContactRepo = (await import('../../repositories/wallet-contact.repository.js')).default;
 const notificationRepo = (await import('../../repositories/notification.repository.js')).default;
+const { getEmailTransport } = await import('../email-transport.js');
 const service = (await import('../notification.service.js')).default;
 
 const WALLET = '5Alice';
 const EVENT_TYPE = 'application_accepted';
 const SOURCE_ID = 'proj-1';
-const PAYLOAD = { projectName: 'Test' };
+const PAYLOAD = { projectName: 'Test', programName: 'Dogfooding' };
 
-const existingRow = {
+const queuedRow = {
   id: 'uuid-1',
   recipientWallet: WALLET,
   eventType: EVENT_TYPE,
@@ -30,12 +39,21 @@ const existingRow = {
   sentAt: null,
 };
 
+const sentRow = { ...queuedRow, status: 'sent', providerMessageId: 'res_test_default' };
+
+const mockTransport = { send: vi.fn().mockResolvedValue({ id: 'res_test_default' }) };
+
 describe('NotificationService.notify', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getEmailTransport.mockResolvedValue(mockTransport);
+    notificationRepo.markSent.mockResolvedValue(sentRow);
+    notificationRepo.markFailed.mockResolvedValue({ ...queuedRow, status: 'failed' });
+  });
 
   it('inserts with status skipped and error no_contact when no wallet_contacts row exists', async () => {
     walletContactRepo.findByWallet.mockResolvedValue(null);
-    notificationRepo.insertOrGetExisting.mockResolvedValue({ ...existingRow, status: 'skipped', error: 'no_contact' });
+    notificationRepo.insertOrGetExisting.mockResolvedValue({ ...queuedRow, status: 'skipped', error: 'no_contact' });
 
     await service.notify(WALLET, EVENT_TYPE, SOURCE_ID, PAYLOAD);
 
@@ -57,7 +75,7 @@ describe('NotificationService.notify', () => {
       email: 'a@b.com',
       notificationsEnabled: false,
     });
-    notificationRepo.insertOrGetExisting.mockResolvedValue({ ...existingRow, status: 'skipped', error: 'opted_out' });
+    notificationRepo.insertOrGetExisting.mockResolvedValue({ ...queuedRow, status: 'skipped', error: 'opted_out' });
 
     await service.notify(WALLET, EVENT_TYPE, SOURCE_ID, PAYLOAD);
 
@@ -75,7 +93,7 @@ describe('NotificationService.notify', () => {
       email: 'a@b.com',
       notificationsEnabled: true,
     });
-    notificationRepo.insertOrGetExisting.mockResolvedValue(existingRow);
+    notificationRepo.insertOrGetExisting.mockResolvedValue(queuedRow);
 
     await service.notify(WALLET, EVENT_TYPE, SOURCE_ID, PAYLOAD);
 
@@ -87,21 +105,28 @@ describe('NotificationService.notify', () => {
     );
   });
 
-  it('returns the row from insertOrGetExisting on duplicate notify calls (repo dedupes)', async () => {
+  it('does not re-send on a duplicate notify call — repo dedupe returns an already-sent row', async () => {
     walletContactRepo.findByWallet.mockResolvedValue({
       walletAddress: WALLET,
       email: 'a@b.com',
       notificationsEnabled: true,
     });
-    notificationRepo.insertOrGetExisting.mockResolvedValue(existingRow);
+    // First call: a fresh queued row → triggers a send.
+    // Second call: the repo's unique index dedupes and hands back the
+    // already-sent row → notify() must return it without sending again.
+    notificationRepo.insertOrGetExisting
+      .mockResolvedValueOnce(queuedRow)
+      .mockResolvedValueOnce(sentRow);
 
     const first = await service.notify(WALLET, EVENT_TYPE, SOURCE_ID, PAYLOAD);
     const second = await service.notify(WALLET, EVENT_TYPE, SOURCE_ID, PAYLOAD);
 
-    // Service calls insertOrGetExisting once per notify invocation
     expect(notificationRepo.insertOrGetExisting).toHaveBeenCalledTimes(2);
-    // Both calls return the same existing row (repo-layer idempotency)
-    expect(first).toEqual(existingRow);
-    expect(second).toEqual(existingRow);
+    // The send + markSent fire exactly once, on the first call only.
+    expect(mockTransport.send).toHaveBeenCalledTimes(1);
+    expect(notificationRepo.markSent).toHaveBeenCalledTimes(1);
+    expect(first.status).toBe('sent');
+    expect(second.status).toBe('sent');
+    expect(second).toBe(sentRow);
   });
 });

--- a/server/api/services/email-transport.js
+++ b/server/api/services/email-transport.js
@@ -1,0 +1,24 @@
+import { Resend } from 'resend';
+
+export async function getEmailTransport() {
+  if (process.env.NODE_ENV === 'test') {
+    // Lazy import: mock-resend.js imports `vi` from vitest — a static import
+    // would pull the test framework into the production module graph.
+    const { mockResend } = await import('./__tests__/mock-resend.js');
+    return mockResend;
+  }
+
+  if (!process.env.RESEND_API_KEY) {
+    return null;
+  }
+
+  const resend = new Resend(process.env.RESEND_API_KEY);
+
+  return {
+    async send({ from, to, subject, html, text }) {
+      const { data, error } = await resend.emails.send({ from, to, subject, html, text });
+      if (error) throw new Error(error.message ?? String(error));
+      return { id: data.id };
+    },
+  };
+}

--- a/server/api/services/notification-templates/application-accepted.js
+++ b/server/api/services/notification-templates/application-accepted.js
@@ -1,0 +1,16 @@
+import { escapeHtml } from './escape.js';
+
+export function subject(payload) {
+  return `You're in — ${payload.programName}`;
+}
+
+export function html(payload) {
+  const projectUrl = payload.projectUrl ?? 'https://stadium.webzero.dev';
+  return `<p>Great news — <strong>${escapeHtml(payload.projectName)}</strong> has been accepted into <strong>${escapeHtml(payload.programName)}</strong>.</p>
+<p>Head to your <a href="${escapeHtml(projectUrl)}">project page</a> to see what's next.</p>`;
+}
+
+export function text(payload) {
+  const projectUrl = payload.projectUrl ?? 'https://stadium.webzero.dev';
+  return `Great news — ${payload.projectName} has been accepted into ${payload.programName}.\n\nHead to your project page to see what's next: ${projectUrl}`;
+}

--- a/server/api/services/notification-templates/application-rejected.js
+++ b/server/api/services/notification-templates/application-rejected.js
@@ -1,0 +1,14 @@
+import { escapeHtml } from './escape.js';
+
+export function subject(payload) {
+  return `Update on your ${payload.programName} application`;
+}
+
+export function html(payload) {
+  return `<p>Thanks for applying to <strong>${escapeHtml(payload.programName)}</strong> with <strong>${escapeHtml(payload.projectName)}</strong>.</p>
+<p>We weren't able to move forward this time, but we'd love to see you back for future programs.</p>`;
+}
+
+export function text(payload) {
+  return `Thanks for applying to ${payload.programName} with ${payload.projectName}.\n\nWe weren't able to move forward this time, but we'd love to see you back for future programs.`;
+}

--- a/server/api/services/notification-templates/escape.js
+++ b/server/api/services/notification-templates/escape.js
@@ -1,0 +1,11 @@
+const HTML_ENTITIES = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+};
+
+export function escapeHtml(value) {
+  return String(value ?? '').replace(/[&<>"']/g, (ch) => HTML_ENTITIES[ch]);
+}

--- a/server/api/services/notification-templates/index.js
+++ b/server/api/services/notification-templates/index.js
@@ -1,0 +1,21 @@
+import * as applicationAccepted from './application-accepted.js';
+import * as applicationRejected from './application-rejected.js';
+import * as m2Approved from './m2-approved.js';
+import * as m2ChangesRequested from './m2-changes-requested.js';
+
+const templates = {
+  application_accepted: applicationAccepted,
+  application_rejected: applicationRejected,
+  m2_approved: m2Approved,
+  m2_changes_requested: m2ChangesRequested,
+};
+
+export function renderEmail(eventType, payload) {
+  const tmpl = templates[eventType];
+  if (!tmpl) throw new Error('unknown_event_type');
+  return {
+    subject: tmpl.subject(payload),
+    html: tmpl.html(payload),
+    text: tmpl.text(payload),
+  };
+}

--- a/server/api/services/notification-templates/m2-approved.js
+++ b/server/api/services/notification-templates/m2-approved.js
@@ -1,0 +1,13 @@
+import { escapeHtml } from './escape.js';
+
+export function subject(payload) {
+  return `${payload.projectName} — milestone 2 approved`;
+}
+
+export function html(payload) {
+  return `<p>Milestone 2 for <strong>${escapeHtml(payload.projectName)}</strong> has been approved. Nice work.</p>`;
+}
+
+export function text(payload) {
+  return `Milestone 2 for ${payload.projectName} has been approved. Nice work.`;
+}

--- a/server/api/services/notification-templates/m2-changes-requested.js
+++ b/server/api/services/notification-templates/m2-changes-requested.js
@@ -1,0 +1,15 @@
+import { escapeHtml } from './escape.js';
+
+export function subject(payload) {
+  return `${payload.projectName} — feedback on your milestone 2`;
+}
+
+export function html(payload) {
+  return `<p>We've reviewed milestone 2 for <strong>${escapeHtml(payload.projectName)}</strong> and have some feedback for you:</p>
+<blockquote>${escapeHtml(payload.feedback)}</blockquote>
+<p>Make the updates and resubmit when you're ready.</p>`;
+}
+
+export function text(payload) {
+  return `We've reviewed milestone 2 for ${payload.projectName} and have some feedback for you:\n\n${payload.feedback}\n\nMake the updates and resubmit when you're ready.`;
+}

--- a/server/api/services/notification.service.js
+++ b/server/api/services/notification.service.js
@@ -1,5 +1,7 @@
 import walletContactRepository from '../repositories/wallet-contact.repository.js';
 import notificationRepository from '../repositories/notification.repository.js';
+import { getEmailTransport } from './email-transport.js';
+import { renderEmail } from './notification-templates/index.js';
 
 class NotificationService {
   async notify(walletAddress, eventType, sourceId, payload) {
@@ -17,7 +19,7 @@ class NotificationService {
       error = null;
     }
 
-    return notificationRepository.insertOrGetExisting({
+    const row = await notificationRepository.insertOrGetExisting({
       recipient: walletAddress,
       eventType,
       sourceId,
@@ -25,6 +27,43 @@ class NotificationService {
       status,
       error,
     });
+
+    if (row.status === 'queued') {
+      return this._trySend(row, eventType, payload, contact.email);
+    }
+
+    return row;
+  }
+
+  async _trySend(row, eventType, payload, toEmail) {
+    // A send failure must never throw to the caller — notify() is invoked from
+    // admin controllers (P2-04) where a throw would break the admin action.
+    // This outer guard catches transport/render/repository-write failures alike.
+    try {
+      const transport = await getEmailTransport();
+
+      if (transport === null) {
+        return await notificationRepository.markFailed(row.id, 'provider_not_configured');
+      }
+
+      try {
+        const { subject, html, text } = renderEmail(eventType, payload);
+        const result = await transport.send({
+          from: process.env.RESEND_FROM_EMAIL,
+          to: toEmail,
+          subject,
+          html,
+          text,
+        });
+        return await notificationRepository.markSent(row.id, result.id);
+      } catch (err) {
+        return await notificationRepository.markFailed(row.id, String(err?.message ?? err));
+      }
+    } catch {
+      // Last resort: getEmailTransport or a markFailed write itself failed.
+      // Return the unmodified queued row rather than throwing.
+      return row;
+    }
   }
 }
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -19,6 +19,7 @@
         "express": "^5.1.0",
         "mongoose": "^8.16.1",
         "polkadot-api": "^1.13.1",
+        "resend": "^6.12.3",
         "ws": "^8.19.0"
       },
       "devDependencies": {
@@ -4159,6 +4160,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -5256,6 +5263,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -6900,6 +6913,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.8",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
@@ -7088,6 +7107,27 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.12.3",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.3.tgz",
+      "integrity": "sha512-FkEi6YPnVL96/LvH8+QP7NaeaBy5brYXwlRqUCqZZeNL0/iyKij18IPmyPXYauT/2ODn1JG04qKz+qlJfzqzTw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.92.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve-from": {
@@ -7497,6 +7537,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "license": "MIT",
@@ -7594,6 +7644,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.92.2",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.92.2.tgz",
+      "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/tagged-tag": {
@@ -7994,9 +8053,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
       "cpu": [
         "ppc64"
       ],
@@ -8011,9 +8070,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
       "cpu": [
         "arm"
       ],
@@ -8028,9 +8087,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
       "cpu": [
         "arm64"
       ],
@@ -8045,9 +8104,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
       "cpu": [
         "x64"
       ],
@@ -8062,9 +8121,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
       "cpu": [
         "arm64"
       ],
@@ -8079,9 +8138,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
       "cpu": [
         "x64"
       ],
@@ -8096,9 +8155,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
       "cpu": [
         "arm64"
       ],
@@ -8113,9 +8172,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
       "cpu": [
         "x64"
       ],
@@ -8130,9 +8189,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
       "cpu": [
         "arm"
       ],
@@ -8147,9 +8206,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
       "cpu": [
         "arm64"
       ],
@@ -8164,9 +8223,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
       "cpu": [
         "ia32"
       ],
@@ -8181,9 +8240,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
       "cpu": [
         "loong64"
       ],
@@ -8198,9 +8257,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
       "cpu": [
         "mips64el"
       ],
@@ -8215,9 +8274,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
       "cpu": [
         "ppc64"
       ],
@@ -8232,9 +8291,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
       "cpu": [
         "riscv64"
       ],
@@ -8249,9 +8308,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
       "cpu": [
         "s390x"
       ],
@@ -8266,9 +8325,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
       "cpu": [
         "x64"
       ],
@@ -8283,9 +8342,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
       "cpu": [
         "arm64"
       ],
@@ -8300,9 +8359,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
       "cpu": [
         "x64"
       ],
@@ -8317,9 +8376,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
       "cpu": [
         "arm64"
       ],
@@ -8334,9 +8393,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
       "cpu": [
         "x64"
       ],
@@ -8351,9 +8410,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
       "cpu": [
         "arm64"
       ],
@@ -8368,9 +8427,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
       "cpu": [
         "x64"
       ],
@@ -8385,9 +8444,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
       "cpu": [
         "arm64"
       ],
@@ -8402,9 +8461,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
       "cpu": [
         "ia32"
       ],
@@ -8419,9 +8478,9 @@
       }
     },
     "node_modules/vitest/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
       "cpu": [
         "x64"
       ],

--- a/server/package.json
+++ b/server/package.json
@@ -34,6 +34,7 @@
     "express": "^5.1.0",
     "mongoose": "^8.16.1",
     "polkadot-api": "^1.13.1",
+    "resend": "^6.12.3",
     "ws": "^8.19.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

- Extend `notification.service.js` `notify(...)` so a `queued` row triggers a transactional email send via Resend, then flips the row to `sent` (with `provider_message_id`) or `failed` (with `error`).
- New `email-transport.js` adapter — mock transport under `NODE_ENV=test`, `null` (→ `failed`/`provider_not_configured`, no crash) when `RESEND_API_KEY` is unset, real Resend client otherwise. A future provider swap touches this one file plus the templates.
- Four short, builder-voice email templates under `notification-templates/` (`application_accepted`, `application_rejected`, `m2_approved`, `m2_changes_requested`), rendered via `renderEmail(eventType, payload)`. All interpolated values are HTML-escaped.
- Send failures are fully isolated — every path in `_trySend` (transport, render, repository write) is caught; `notify(...)` never throws. This is load-bearing for P2-04, where `notify(...)` is called from admin controllers and a throw would break the admin action.

Closes #69

## Test plan
- [x] `cd server && npm test` — pass (13 files, 104 tests)
- [x] `cd client && npm run build` — pass
- [x] `cd client && npm run lint` — pass (zero warnings)

## UI verification (stadium-tester)

**Not applicable — server-only issue.** Issue #69 adds the Resend SDK, a transport adapter, and email templates; it has no client surface. All four `## Test scenarios` are state-of-row assertions on `notify(...)` calls, not user-visible UI flows, so the Playwright tester has nothing to drive.

The four issue scenarios are covered by Vitest, mapped 1:1:

| Issue scenario | Test |
|---|---|
| `notify(...)` happy path, mocked Resend `{ id: 'res_abc' }` → row `sent`, `provider_message_id='res_abc'` | `notification.service.send.test.js` — happy-path send |
| `notify(...)`, mocked Resend 4xx → row `failed`, `error` populated, no exception bubbles | `notification.service.send.test.js` — provider rejection |
| `notify(...)` with `RESEND_API_KEY` unset → row `failed`, `error='provider_not_configured'`, no crash | `notification.service.send.test.js` — provider not configured |
| `notify(...)` under `NODE_ENV=test` short-circuits to mock transport — no `api.resend.com` call | `notification.service.send.test.js` — fetch-spy asserts no network; `email-transport.test.js` — mock-branch + null-branch unit tests |

## Preview

N/A — no client surface affected.

## Backlog items logged

Two non-blocking observations from the pre-PR review, appended to `docs/improvement-backlog.md`:

- *Warn at startup when `RESEND_API_KEY` is set but `RESEND_FROM_EMAIL` is not* — currently `from: undefined` produces an opaque Resend 4xx that is caught and marks the row `failed`. A clearer `from_email_not_configured` signal would help.
- *No length guard on admin feedback in the `m2-changes-requested` email body* — very long feedback produces an oversized email; consider truncation + a "see full feedback on your project page" link once P2-05 ships that surface.

Pre-PR review found 2 blockers, both fixed before this PR was opened: (1) `renderEmail`'s `unknown_event_type` throw was outside the try/catch — now inside; (2) the `provider_not_configured` and catch-block `markFailed` writes were unguarded — `_trySend` now has a last-resort outer guard so a repository failure can't bubble either. Three should-fix items also addressed: the dedupe test now genuinely verifies no re-send on a deduped row, all template interpolations are HTML-escaped, and `email-transport.js`'s `NODE_ENV=test` branch has a dedicated test.

## Invariants verified
- [x] BYPASS_ADMIN_CHECK still false (no client/admin-page change)
- [x] Admin routes still use auth.middleware.js (no new routes in this PR)
- [x] No new console.log in client (no client changes)
- [x] No new Mongoose imports in `server/api/**` (Resend is external HTTP; DB access unchanged)
- [x] ESM `import` syntax only; no `require()`
- [x] No `notify(...)` call sites wired into controllers (deferred to P2-04)