### PR TITLE
chore(backlog): log TeamPaymentSection duplicate-key bug

### DIFF
--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -131,3 +131,9 @@ Do **not** manually edit `- **Promoted**` lines.
 - **File(s)**: `server/api/controllers/project.controller.js:75`, `server/api/controllers/project.controller.js:188`
 - **Observed during**: issue #70 (revamp-P2-04 notify trigger wiring) — reviewer flagged
 - **Suggestion**: two pre-existing `console.log` calls (a debug payload preview in `updateProject`, and an M2-agreement confirmation log) predate Phase 2 and were left untouched. Server code elsewhere uses the `logger` utility (`server/api/utils/logger.js`). Convert these to `logger.debug`/`logger.info` (or remove the debug preview) in a dedicated cleanup pass — out of scope for #70's minimal diff.
+
+## [2026-05-18] TeamPaymentSection keys team-member rows by wallet address
+- **Severity**: minor
+- **File(s)**: `client/src/components/TeamPaymentSection.tsx:210`
+- **Observed during**: full user-journey test pass (team-member journeys, Team & Payments tab)
+- **Suggestion**: team-member cards render with `key={member.walletAddress || index}`. Wallet address is not guaranteed unique across a project's team members — in the mock dataset two Plata Mia members share the redacted address `5MockWalletAddressRedactedForPreviewPurposes00000`, so React logs "Encountered two children with the same key" (3× per Team & Payments render). The `|| index` fallback only triggers on a *falsy* address, so a non-empty-but-duplicate address still collides. Production addresses are normally distinct so it does not surface there, but keying on a non-unique field is fragile. Key by a stable unique member id, or always fold in the index (e.g. `` key={`${member.walletAddress}-${index}`} ``).


### PR DESCRIPTION
## Summary

Logs one improvement-backlog entry — no code change.

`client/src/components/TeamPaymentSection.tsx:210` renders team-member cards with `key={member.walletAddress || index}`. Wallet address is not guaranteed unique across a project's team members; when two members share an address React logs a duplicate-key warning. Surfaced during a full user-journey test pass — two Plata Mia mock team members share the redacted address `5MockWalletAddressRedacted...00000`, producing the warning 3× whenever the Team & Payments tab renders.

Latent (production addresses are normally distinct) but fragile — keying on a non-unique field. Logged for a future fix; not fixed here.

## Test plan
- [x] Docs-only change — `docs/improvement-backlog.md` append. No code, tests, or build affected.

## Invariants verified
- [x] No code changed — backlog entry only