### PR TITLE
feat(phase-2): Notifications card + focus-refetch (#71)

### DIFF
--- a/client/src/components/project/NotificationsCard.tsx
+++ b/client/src/components/project/NotificationsCard.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Bell, Loader2 } from "lucide-react";
+import { web3Enable, web3Accounts, web3FromSource } from "@polkadot/extension-dapp";
+import { SiwsMessage } from "@talismn/siws";
+import { generateSiwsStatement } from "@/lib/siwsUtils";
+import { api } from "@/lib/api";
+import { validateEmail } from "@/lib/validation";
+import { useToast } from "@/hooks/use-toast";
+
+export function NotificationsCard({ connectedAddress }: { connectedAddress: string }) {
+  const { toast } = useToast();
+
+  const [loading, setLoading] = useState(true);
+  const [emailSet, setEmailSet] = useState(false);
+  const [notificationsEnabled, setNotificationsEnabled] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [emailInput, setEmailInput] = useState("");
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    setLoading(true);
+    api
+      .getWalletContact(connectedAddress)
+      .then((data) => {
+        if (!active) return;
+        setEmailSet(data.email_set);
+        setNotificationsEnabled(data.notifications_enabled);
+        setShowForm(!data.email_set);
+      })
+      .catch(() => {
+        if (active) setShowForm(true);
+      })
+      .finally(() => {
+        if (active) setLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [connectedAddress]);
+
+  // Only reachable from the confirmation view, which is gated on an email
+  // already being on file — so this path intentionally skips email validation.
+  const handleToggle = async (checked: boolean) => {
+    setNotificationsEnabled(checked);
+    setSubmitting(true);
+    try {
+      await web3Enable("Stadium");
+      const accounts = await web3Accounts();
+      const account = accounts.find((a) => a.address === connectedAddress) || accounts[0];
+      if (!account) throw new Error("No wallet account found");
+
+      const siws = new SiwsMessage({
+        domain: window.location.hostname,
+        uri: window.location.origin,
+        address: account.address,
+        nonce: Math.random().toString(36).slice(2),
+        statement: generateSiwsStatement({ action: "update-notifications" }),
+      });
+      const injector = await web3FromSource(account.meta.source);
+      const signed = (await siws.sign(injector)) as unknown as { signature: string; message?: string };
+      const messageStr =
+        typeof signed.message === "string" && signed.message
+          ? signed.message
+          : (siws as unknown as { toString: () => string }).toString();
+      const authHeader = btoa(
+        JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address }),
+      );
+
+      const res = await api.updateWalletContact(connectedAddress, { notificationsEnabled: checked }, authHeader);
+      setNotificationsEnabled(res.notifications_enabled);
+    } catch (e) {
+      setNotificationsEnabled(!checked);
+      const err = e as Error;
+      toast({
+        title: "Couldn't update notifications",
+        description: err?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setEmailError(null);
+    const result = validateEmail(emailInput);
+    if (!result.valid) {
+      setEmailError(result.error ?? "invalid email");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await web3Enable("Stadium");
+      const accounts = await web3Accounts();
+      const account = accounts.find((a) => a.address === connectedAddress) || accounts[0];
+      if (!account) throw new Error("No wallet account found");
+
+      const siws = new SiwsMessage({
+        domain: window.location.hostname,
+        uri: window.location.origin,
+        address: account.address,
+        nonce: Math.random().toString(36).slice(2),
+        statement: generateSiwsStatement({ action: "update-notifications" }),
+      });
+      const injector = await web3FromSource(account.meta.source);
+      const signed = (await siws.sign(injector)) as unknown as { signature: string; message?: string };
+      const messageStr =
+        typeof signed.message === "string" && signed.message
+          ? signed.message
+          : (siws as unknown as { toString: () => string }).toString();
+      const authHeader = btoa(
+        JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address }),
+      );
+
+      const res = await api.updateWalletContact(
+        connectedAddress,
+        { email: result.normalised, notificationsEnabled },
+        authHeader,
+      );
+      setEmailSet(res.email_set);
+      setNotificationsEnabled(res.notifications_enabled);
+      setShowForm(false);
+      setEmailInput("");
+      toast({ title: "You'll get email about this project" });
+    } catch (e) {
+      const err = e as Error;
+      toast({
+        title: "Couldn't save notification preferences",
+        description: err?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg flex items-center gap-2">
+            <Bell className="w-5 h-5" aria-hidden="true" />
+            Notifications
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            Loading…
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!emailSet || showForm) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg flex items-center gap-2">
+            <Bell className="w-5 h-5" aria-hidden="true" />
+            Notifications
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            Want an email when something changes? Drop your address.
+          </p>
+          <div className="space-y-1">
+            <Label htmlFor="notif-email">Email address</Label>
+            <Input
+              id="notif-email"
+              type="email"
+              placeholder="you@example.com"
+              value={emailInput}
+              onChange={(e) => setEmailInput(e.target.value)}
+              aria-invalid={emailError ? true : undefined}
+              disabled={submitting}
+            />
+            {emailError && <p className="text-xs text-destructive">{emailError}</p>}
+          </div>
+          <div className="flex items-center justify-between">
+            <Label htmlFor="notif-toggle" className="text-sm">
+              Notify me about this project
+            </Label>
+            <Switch
+              id="notif-toggle"
+              checked={notificationsEnabled}
+              onCheckedChange={setNotificationsEnabled}
+              disabled={submitting}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Button onClick={handleSave} disabled={submitting} size="sm">
+              {submitting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin mr-2" aria-hidden="true" />
+                  Saving…
+                </>
+              ) : (
+                "Save"
+              )}
+            </Button>
+            {emailSet && (
+              <Button variant="ghost" size="sm" onClick={() => { setShowForm(false); setEmailInput(""); setEmailError(null); }} disabled={submitting}>
+                Cancel
+              </Button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg flex items-center gap-2">
+          <Bell className="w-5 h-5" aria-hidden="true" />
+          Notifications
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">You'll get email about this project</p>
+        <div className="flex items-center justify-between">
+          <Label htmlFor="notif-toggle-set" className="text-sm">
+            Notify me about this project
+          </Label>
+          <Switch
+            id="notif-toggle-set"
+            checked={notificationsEnabled}
+            onCheckedChange={handleToggle}
+            disabled={submitting}
+          />
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="px-0 text-sm"
+          onClick={() => { setShowForm(true); setEmailInput(""); setEmailError(null); }}
+          disabled={submitting}
+        >
+          Update email
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/components/project/ProjectProgramsSection.tsx
+++ b/client/src/components/project/ProjectProgramsSection.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Loader2, Sparkles, ExternalLink } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Loader2, RotateCw, Sparkles, ExternalLink } from "lucide-react";
 import { api, type ApiProgram, type ApiProgramApplication } from "@/lib/api";
 
 type Row = ApiProgramApplication & { program?: ApiProgram };
@@ -27,12 +28,14 @@ const statusVariant = (status: ApiProgramApplication["status"]) => {
  * Implementation: fetches applications + all programs in parallel, joins
  * on programId. Small-scale data today; if the programs table grows, this
  * becomes a dedicated per-project-with-program-metadata endpoint.
+ *
+ * Phase 2 revamp (#71): adds focus-refetch and a manual refresh button.
  */
 export function ProjectProgramsSection({ projectId }: { projectId: string }) {
   const [rows, setRows] = useState<Row[] | null>(null);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
+  const refetch = useCallback(() => {
     let active = true;
     setLoading(true);
     Promise.all([api.getApplicationsForProject(projectId), api.listPrograms()])
@@ -53,6 +56,18 @@ export function ProjectProgramsSection({ projectId }: { projectId: string }) {
       active = false;
     };
   }, [projectId]);
+
+  useEffect(() => {
+    const cleanup = refetch();
+    return cleanup;
+  }, [refetch]);
+
+  useEffect(() => {
+    window.addEventListener("focus", refetch);
+    return () => {
+      window.removeEventListener("focus", refetch);
+    };
+  }, [refetch]);
 
   if (loading) {
     return (
@@ -106,7 +121,18 @@ export function ProjectProgramsSection({ projectId }: { projectId: string }) {
                     <span className="text-sm font-medium">{name}</span>
                   )}
                 </div>
-                <Badge variant={statusVariant(r.status)}>{r.status}</Badge>
+                <div className="flex items-center gap-1">
+                  <Badge variant={statusVariant(r.status)}>{r.status}</Badge>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-6 w-6"
+                    onClick={refetch}
+                    aria-label="Refresh application status"
+                  >
+                    <RotateCw className="h-3.5 w-3.5" aria-hidden="true" />
+                  </Button>
+                </div>
               </li>
             );
           })}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1073,6 +1073,44 @@ export const api = {
     });
   },
 
+  /**
+   * Phase 2 revamp: wallet contacts / notification preferences (#71).
+   */
+  getWalletContact: async (address: string): Promise<{ email_set: boolean; notifications_enabled: boolean }> => {
+    if (USE_MOCK_DATA) {
+      const { mockWalletContacts } = await import("./mockWalletContacts");
+      const entry = mockWalletContacts[address];
+      return { email_set: !!entry?.email, notifications_enabled: entry?.notificationsEnabled ?? true };
+    }
+    const res = await request(`/wallet-contacts/${encodeURIComponent(address)}`);
+    return res.data;
+  },
+
+  updateWalletContact: async (
+    address: string,
+    payload: { email?: string | null; notificationsEnabled?: boolean },
+    authHeader?: string,
+  ): Promise<{ email_set: boolean; notifications_enabled: boolean }> => {
+    if (USE_MOCK_DATA) {
+      const { mockWalletContacts } = await import("./mockWalletContacts");
+      const existing = mockWalletContacts[address];
+      mockWalletContacts[address] = {
+        email: payload.email !== undefined ? payload.email : (existing?.email ?? null),
+        notificationsEnabled: payload.notificationsEnabled !== undefined ? payload.notificationsEnabled : (existing?.notificationsEnabled ?? true),
+      };
+      const updated = mockWalletContacts[address];
+      return { email_set: !!updated.email, notifications_enabled: updated.notificationsEnabled };
+    }
+    const res = await request(`/wallet-contacts/${encodeURIComponent(address)}`, {
+      method: "PUT",
+      headers: authHeader
+        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
+        : { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: payload.email, notifications_enabled: payload.notificationsEnabled }),
+    });
+    return res.data;
+  },
+
   applyToProgram: async (
     slug: string,
     payload: { project_id: string; application_fields: Record<string, unknown> },

--- a/client/src/lib/mockWalletContacts.ts
+++ b/client/src/lib/mockWalletContacts.ts
@@ -1,0 +1,11 @@
+/**
+ * Mock fixture for `wallet_contacts`. Seeded for a couple of wallets so
+ * NotificationsCard renders in preview mode.
+ *
+ * Phase 2 revamp, issue #71.
+ */
+
+export const mockWalletContacts: Record<string, { email: string | null; notificationsEnabled: boolean }> = {
+  "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY": { email: "harness@example.com", notificationsEnabled: true },
+  "5MockWalletAddressRedactedForPreviewPurposes00000": { email: null, notificationsEnabled: false },
+};

--- a/client/src/lib/siwsUtils.ts
+++ b/client/src/lib/siwsUtils.ts
@@ -3,7 +3,7 @@
  */
 
 export interface SiwsContext {
-  action: 'update-team' | 'submit-deliverable' | 'update-project' | 'register-address' | 'admin-action' | 'create-project' | 'delete-project' | 'review-project' | 'approve-project' | 'reject-project' | 'post-update' | 'update-funding-signal' | 'apply-to-program' | 'create-program' | 'update-program' | 'review-application';
+  action: 'update-team' | 'submit-deliverable' | 'update-project' | 'register-address' | 'admin-action' | 'create-project' | 'delete-project' | 'review-project' | 'approve-project' | 'reject-project' | 'post-update' | 'update-funding-signal' | 'apply-to-program' | 'create-program' | 'update-program' | 'review-application' | 'update-notifications';
   projectId?: string;
   projectTitle?: string;
   programTitle?: string;
@@ -66,6 +66,10 @@ export function generateSiwsStatement(context: SiwsContext): string {
       return `Update program on ${baseDomain}`;
     case 'review-application':
       return `Review application on ${baseDomain}`;
+
+    // Phase 2 revamp (#71): notification preferences
+    case 'update-notifications':
+      return `Update notification preferences for wallet on Stadium`;
 
     default:
       return `Sign in to ${baseDomain}`;

--- a/client/src/lib/validation.ts
+++ b/client/src/lib/validation.ts
@@ -1,0 +1,14 @@
+// keep in sync with server/api/utils/validation.js — no runtime sharing across the server/client split
+
+export function validateEmail(email: string): { valid: boolean; error?: string; normalised?: string } {
+  if (typeof email !== "string") return { valid: false, error: "email must be a string" };
+  const trimmed = email.trim().toLowerCase();
+  if (trimmed.length === 0 || trimmed.length > 254) {
+    return { valid: false, error: "email must be 1–254 characters" };
+  }
+  const emailRe = /^[^@\s]{1,64}@[^@\s]+\.[^@\s]{2,}$/;
+  if (!emailRe.test(trimmed)) {
+    return { valid: false, error: "email must be a valid email address" };
+  }
+  return { valid: true, normalised: trimmed };
+}

--- a/client/src/pages/ProgramDetailPage.tsx
+++ b/client/src/pages/ProgramDetailPage.tsx
@@ -1,10 +1,10 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { Navigation } from "@/components/Navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Calendar, MapPin, Loader2, Wallet, CheckCircle2 } from "lucide-react";
+import { Calendar, MapPin, Loader2, Wallet, CheckCircle2, RotateCw } from "lucide-react";
 import { web3Enable, web3Accounts } from "@polkadot/extension-dapp";
 import {
   api,
@@ -108,7 +108,7 @@ const ProgramDetailPage = () => {
   }, [connectedAddress]);
 
   // Load applications this wallet's projects already submitted to THIS program.
-  useEffect(() => {
+  const refetchApplications = useCallback(() => {
     if (!program || myProjects.length === 0) {
       setMyApplications([]);
       return;
@@ -127,6 +127,18 @@ const ProgramDetailPage = () => {
       active = false;
     };
   }, [program, myProjects]);
+
+  useEffect(() => {
+    const cleanup = refetchApplications();
+    return cleanup;
+  }, [refetchApplications]);
+
+  useEffect(() => {
+    window.addEventListener("focus", refetchApplications);
+    return () => {
+      window.removeEventListener("focus", refetchApplications);
+    };
+  }, [refetchApplications]);
 
   const existingApplication = useMemo(() => myApplications[0] || null, [myApplications]);
 
@@ -182,6 +194,15 @@ const ProgramDetailPage = () => {
         <div className="inline-flex items-center gap-2 rounded-md border bg-muted px-3 py-2 text-sm">
           <CheckCircle2 className="h-4 w-4 text-primary" aria-hidden="true" />
           Applied — status: <Badge variant="secondary">{existingApplication.status}</Badge>
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-6 w-6"
+            onClick={refetchApplications}
+            aria-label="Refresh application status"
+          >
+            <RotateCw className="h-3.5 w-3.5" aria-hidden="true" />
+          </Button>
         </div>
       );
     }

--- a/client/src/pages/ProjectDetailsPage.tsx
+++ b/client/src/pages/ProjectDetailsPage.tsx
@@ -47,6 +47,7 @@ import { ProjectUpdatesTab } from "@/components/project/ProjectUpdatesTab";
 import { FundingSignalBadge } from "@/components/project/FundingSignalBadge";
 import { EditFundingSignalModal } from "@/components/project/EditFundingSignalModal";
 import { ProjectProgramsSection } from "@/components/project/ProjectProgramsSection";
+import { NotificationsCard } from "@/components/project/NotificationsCard";
 import type { ApiFundingSignal } from "@/lib/api";
 import { EditProjectDetailsModal } from "@/components/EditProjectDetailsModal";
 import { isAdmin as checkIsAdmin } from "@/lib/constants";
@@ -1094,6 +1095,11 @@ const ProjectDetailsPage = () => {
                       </Button>
                     )}
                   </div>
+                )}
+
+                {/* Notifications card — Phase 2 revamp (#71) */}
+                {(isTeamMember || isAdmin) && connectedAddress && (
+                  <NotificationsCard connectedAddress={connectedAddress} />
                 )}
 
                 {/* Programs section — Phase 1 revamp (#45) */}


### PR DESCRIPTION
## Summary

- **NotificationsCard** on the project Overview tab — team-gated (`(isTeamMember || isAdmin) && connectedAddress`, same gate as the funding-signal block). A team member enters their email + a global opt-out toggle; Save is SIWS-signed (`"Update notification preferences for wallet on Stadium"`) and PUTs to `/api/wallet-contacts/:address`. When an email is already on file the card shows a confirmation state — it does **not** pre-fill the address, because the P2-01 GET deliberately returns only `{ email_set, notifications_enabled }`, never the raw email.
- **Focus-refetch + Refresh button** on both application-status surfaces (`ProjectProgramsSection`, `ProgramDetailPage`) — a `window` focus listener (with cleanup) and a `RotateCw` button re-run the status fetch, so a left-open tab updates itself when refocused.
- **`client/src/lib/validation.ts`** (new) — `validateEmail` mirroring `server/api/utils/validation.js` exactly (same regex, same 1–254 bound); used inline before any SIWS prompt.
- `getWalletContact` / `updateWalletContact` added to `api.ts` with mock-mode branches; `mockWalletContacts.ts` fixture; `'update-notifications'` SIWS action added to `siwsUtils.ts`.

Closes #71

## Test plan
- [x] `cd client && npm run build` — pass (tsc + vite, 0 type errors)
- [x] `cd client && npm run lint` — pass (0 warnings)
- [n/a] `cd server && npm test` — no server changes in this PR

## UI verification (stadium-tester)

Target: local dev `http://localhost:8080` — mock mode + SIWS test-wallet harness (`VITE_USE_MOCK_DATA=true VITE_USE_TEST_WALLET=true`). **6/6 scenarios PASS.**

| # | Scenario | Result | Notes |
|---|----------|--------|-------|
| 1 | On `/m2-program/<id>` as an unauthenticated visitor, the Notifications card is NOT visible | PASS | card copy absent from DOM |
| 2 | On `/m2-program/<id>` as a team-member wallet, the card is visible | PASS | harness wallet seeded `email_set=true` → confirmation state |
| 3 | Enter a valid email + Save (SIWS harness) → card flips to confirmation | PASS | SIWS signed via //Alice; confirmation + success toast |
| 4 | On `/programs/<slug>`, window focus triggers an application-status re-fetch | PASS | focus listener fires the refetch; indicator re-renders, no error |
| 5 | On `/programs/<slug>`, clicking Refresh re-runs the fetch | PASS | Refresh button wired; refetch executes, no error |
| 6 | Invalid email (`not-an-email`) + Save → inline error, no SIWS, no PUT | PASS | shows "email must be a valid email address"; stays in the form |

**Preview mode**: `window.__STADIUM_MOCK__ = true`.
**Console errors during run**: only the pre-existing `TeamPaymentSection.tsx` duplicate-key warning (already logged in PR #77) — surfaced because the test connects the wallet via the Team & Payments tab. Not introduced by this PR.
**Note on S4/S5**: these confirm the focus listener and Refresh button are wired and the re-fetch executes without error. Observing an actual data-delta would need a mock-mutation hook the harness does not have, so they verify the mechanism, not a status change. Manual verification of the cross-tab delta is in the issue's Manual QA checklist.

## Preview

https://stadium-git-feat-notifications-card-p2-05-sachalanskys-projects.vercel.app

Verified the preview build: `window.__STADIUM_MOCK__ === true`; `/m2-program/plata-mia-15ac43` renders and the Notifications card is correctly hidden for the unauthenticated visitor (scenario S1). The team-member card states (S2/S3/S6) were verified on local dev with the SIWS test-wallet harness — the Vercel preview has no test wallet, so the card cannot be exercised there, consistent with all prior Phase 2 previews.

## Backlog items logged
- none new. (The spec's "pre-fill the email from GET" wording conflicts with P2-01's privacy contract — resolved here via the confirmation-state design; noted in the PR summary above rather than the backlog.)

## Invariants verified
- [x] BYPASS_ADMIN_CHECK still false
- [x] Admin routes still use auth.middleware.js (no route changes — client-only PR)
- [x] No new console.log in client (new code uses none; card has no console.*)
- [x] No new Supabase imports (client-only; no Supabase on the client)
- [x] Card hidden for non-team visitors — gated identically to the funding-signal block
- [x] SIWS statement byte-matches the server whitelist in auth.middleware.js
