### PR TITLE
feat: admin Create Project UI (#80)

### DIFF
--- a/client/src/components/admin/CreateProjectModal.tsx
+++ b/client/src/components/admin/CreateProjectModal.tsx
@@ -1,0 +1,352 @@
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2, Plus, Trash2 } from "lucide-react";
+import { web3Enable, web3Accounts, web3FromSource } from "@polkadot/extension-dapp";
+import { SiwsMessage } from "@talismn/siws";
+import { generateSiwsStatement } from "@/lib/siwsUtils";
+import { api, type ApiProject } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+
+const ALLOWED_CATEGORIES = ["Gaming", "DeFi", "NFT", "Developer Tools", "Social", "AI", "Arts", "Mobile"];
+
+type TeamMemberRow = { name: string; walletAddress: string };
+
+export function CreateProjectModal({
+  open,
+  onOpenChange,
+  connectedAddress,
+  onSaved,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  connectedAddress: string | undefined;
+  onSaved: (project: ApiProject) => void;
+}) {
+  const [projectName, setProjectName] = useState("");
+  const [id, setId] = useState("");
+  const [description, setDescription] = useState("");
+  const [projectRepo, setProjectRepo] = useState("");
+  const [demoUrl, setDemoUrl] = useState("");
+  const [hackathonName, setHackathonName] = useState("");
+  const [hackathonId, setHackathonId] = useState("");
+  const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+  const [teamMembers, setTeamMembers] = useState<TeamMemberRow[]>([]);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (!open) return;
+    setProjectName("");
+    setId("");
+    setDescription("");
+    setProjectRepo("");
+    setDemoUrl("");
+    setHackathonName("");
+    setHackathonId("");
+    setSelectedCategories([]);
+    setTeamMembers([]);
+    setErrors({});
+  }, [open]);
+
+  const toggleCategory = (cat: string) => {
+    setSelectedCategories((prev) =>
+      prev.includes(cat) ? prev.filter((c) => c !== cat) : [...prev, cat],
+    );
+  };
+
+  const addTeamMember = () =>
+    setTeamMembers((prev) => [...prev, { name: "", walletAddress: "" }]);
+
+  const removeTeamMember = (i: number) =>
+    setTeamMembers((prev) => prev.filter((_, idx) => idx !== i));
+
+  const updateTeamMember = (i: number, field: keyof TeamMemberRow, value: string) =>
+    setTeamMembers((prev) => prev.map((m, idx) => (idx === i ? { ...m, [field]: value } : m)));
+
+  const validate = (): boolean => {
+    const e: Record<string, string> = {};
+    if (!projectName.trim()) e.projectName = "Project name is required.";
+    if (projectName.trim().length > 200) e.projectName = "Project name must be 200 characters or fewer.";
+    if (projectRepo && !projectRepo.startsWith("http") && !projectRepo.startsWith("www")) {
+      e.projectRepo = "Repository URL must start with www or http.";
+    }
+    if (demoUrl && !demoUrl.startsWith("http") && !demoUrl.startsWith("www")) {
+      e.demoUrl = "Demo URL must start with www or http.";
+    }
+    teamMembers.forEach((m, i) => {
+      if (!m.name.trim()) e[`teamMember_${i}_name`] = `Team member ${i + 1}: name is required.`;
+    });
+    setErrors(e);
+    return Object.keys(e).length === 0;
+  };
+
+  const handleSubmit = async () => {
+    if (!validate()) return;
+    if (!connectedAddress) {
+      toast({ title: "Connect an admin wallet first", variant: "destructive" });
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await web3Enable("Stadium");
+      const accounts = await web3Accounts();
+      const account = accounts.find((a) => a.address === connectedAddress);
+      if (!account) throw new Error("Connected wallet account not found");
+
+      const siws = new SiwsMessage({
+        domain: window.location.hostname,
+        uri: window.location.origin,
+        address: account.address,
+        nonce: Math.random().toString(36).slice(2),
+        statement: generateSiwsStatement({ action: "create-project" }),
+      });
+      const injector = await web3FromSource(account.meta.source);
+      const signed = (await siws.sign(injector)) as unknown as {
+        signature: string;
+        message?: string;
+      };
+      const messageStr =
+        typeof signed.message === "string" && signed.message
+          ? signed.message
+          : (siws as unknown as { toString: () => string }).toString();
+      const authHeader = btoa(
+        JSON.stringify({
+          message: messageStr,
+          signature: signed.signature,
+          address: account.address,
+        }),
+      );
+
+      const payload: Partial<ApiProject> & { projectName: string } = {
+        projectName: projectName.trim(),
+        description: description.trim() || undefined,
+        projectRepo: projectRepo.trim() || undefined,
+        demoUrl: demoUrl.trim() || undefined,
+        categories: selectedCategories.length > 0 ? selectedCategories : undefined,
+        teamMembers:
+          teamMembers.length > 0
+            ? teamMembers.map((m) => ({
+                name: m.name.trim(),
+                walletAddress: m.walletAddress.trim() || undefined,
+              }))
+            : undefined,
+        hackathon:
+          hackathonName.trim() || hackathonId.trim()
+            ? {
+                id: hackathonId.trim(),
+                name: hackathonName.trim(),
+                endDate: "",
+              }
+            : undefined,
+      };
+      if (id.trim()) payload.id = id.trim();
+
+      const res = await api.createProject(payload, authHeader);
+      onSaved(res.data);
+      toast({ title: "Project created" });
+      onOpenChange(false);
+    } catch (e) {
+      const err = e as Error & { status?: number };
+      toast({
+        title: "Couldn't create project",
+        description: err?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => (submitting ? null : onOpenChange(v))}>
+      <DialogContent className="sm:max-w-2xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Create project</DialogTitle>
+          <DialogDescription>
+            Add a new project to the M2 incubator. Only the project name is required.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <div className="sm:col-span-2 space-y-1">
+            <Label htmlFor="cp-name">Project name *</Label>
+            <Input
+              id="cp-name"
+              value={projectName}
+              onChange={(e) => setProjectName(e.target.value)}
+              aria-invalid={errors.projectName ? true : undefined}
+            />
+            {errors.projectName && (
+              <p className="text-xs text-destructive">{errors.projectName}</p>
+            )}
+          </div>
+
+          <div className="sm:col-span-2 space-y-1">
+            <Label htmlFor="cp-id">
+              ID{" "}
+              <span className="text-muted-foreground text-xs font-normal">
+                (optional — auto-derived from name if blank)
+              </span>
+            </Label>
+            <Input
+              id="cp-id"
+              value={id}
+              onChange={(e) => setId(e.target.value)}
+              placeholder="my-project-id"
+            />
+          </div>
+
+          <div className="sm:col-span-2 space-y-1">
+            <Label htmlFor="cp-description">Description</Label>
+            <Textarea
+              id="cp-description"
+              rows={3}
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="cp-repo">Repository URL</Label>
+            <Input
+              id="cp-repo"
+              value={projectRepo}
+              onChange={(e) => setProjectRepo(e.target.value)}
+              placeholder="https://github.com/org/repo"
+              aria-invalid={errors.projectRepo ? true : undefined}
+            />
+            {errors.projectRepo && (
+              <p className="text-xs text-destructive">{errors.projectRepo}</p>
+            )}
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="cp-demo">Demo URL</Label>
+            <Input
+              id="cp-demo"
+              value={demoUrl}
+              onChange={(e) => setDemoUrl(e.target.value)}
+              placeholder="https://demo.example.com"
+              aria-invalid={errors.demoUrl ? true : undefined}
+            />
+            {errors.demoUrl && (
+              <p className="text-xs text-destructive">{errors.demoUrl}</p>
+            )}
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="cp-hackathon-name">Hackathon name</Label>
+            <Input
+              id="cp-hackathon-name"
+              value={hackathonName}
+              onChange={(e) => setHackathonName(e.target.value)}
+              placeholder="WebZero Hackathon 2025"
+            />
+          </div>
+
+          <div className="space-y-1">
+            <Label htmlFor="cp-hackathon-id">Hackathon ID</Label>
+            <Input
+              id="cp-hackathon-id"
+              value={hackathonId}
+              onChange={(e) => setHackathonId(e.target.value)}
+              placeholder="wz-hackathon-2025"
+            />
+          </div>
+
+          <div className="sm:col-span-2 space-y-2">
+            <Label>Categories</Label>
+            <div className="flex flex-wrap gap-2">
+              {ALLOWED_CATEGORIES.map((cat) => (
+                <button
+                  key={cat}
+                  type="button"
+                  onClick={() => toggleCategory(cat)}
+                  className={`px-3 py-1 rounded-full text-xs border transition-colors ${
+                    selectedCategories.includes(cat)
+                      ? "bg-primary text-primary-foreground border-primary"
+                      : "border-border text-muted-foreground hover:border-primary/50"
+                  }`}
+                >
+                  {cat}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="sm:col-span-2 space-y-2">
+            <div className="flex items-center justify-between">
+              <Label>Team members</Label>
+              <Button type="button" variant="ghost" size="sm" onClick={addTeamMember}>
+                <Plus className="h-4 w-4 mr-1" aria-hidden="true" />
+                Add member
+              </Button>
+            </div>
+            {teamMembers.length === 0 && (
+              <p className="text-xs text-muted-foreground">No team members added yet.</p>
+            )}
+            {teamMembers.map((member, i) => (
+              <div key={i} className="grid grid-cols-[1fr_1fr_auto] gap-2 items-start">
+                <div className="space-y-1">
+                  <Input
+                    placeholder="Name"
+                    value={member.name}
+                    onChange={(e) => updateTeamMember(i, "name", e.target.value)}
+                    aria-invalid={errors[`teamMember_${i}_name`] ? true : undefined}
+                  />
+                  {errors[`teamMember_${i}_name`] && (
+                    <p className="text-xs text-destructive">
+                      {errors[`teamMember_${i}_name`]}
+                    </p>
+                  )}
+                </div>
+                <Input
+                  placeholder="Wallet address (optional)"
+                  value={member.walletAddress}
+                  onChange={(e) => updateTeamMember(i, "walletAddress", e.target.value)}
+                />
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => removeTeamMember(i)}
+                  aria-label="Remove team member"
+                >
+                  <Trash2 className="h-4 w-4" aria-hidden="true" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={submitting}>
+            {submitting ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                Creating…
+              </>
+            ) : (
+              "Create project"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -246,18 +246,28 @@ export const api = {
     if (USE_MOCK_DATA) {
       const { mockWinningProjects } = await import("./mockWinners");
       const mockProject = mockWinningProjects.find((p) => p.id === id);
-      
+
       if (mockProject) {
         return Promise.resolve({
           status: "success",
           data: mockProject
         });
       }
-      
+
+      // Fall back to localStorage-persisted projects (e.g. created via createProject in mock mode)
+      const stored = localStorage.getItem("projects");
+      if (stored) {
+        const lsProjects: ApiProject[] = JSON.parse(stored);
+        const lsProject = lsProjects.find((p) => p.id === id);
+        if (lsProject) {
+          return Promise.resolve({ status: "success", data: lsProject });
+        }
+      }
+
       // If project not found in mock data, return 404-like response
       throw new ApiError("Project not found", 404);
     }
-    
+
     return request(`/m2-program/${id}`);
   },
 
@@ -985,6 +995,50 @@ export const api = {
         ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
         : { "Content-Type": "application/json" },
       body: JSON.stringify(patch),
+    });
+  },
+
+  /**
+   * Phase 2 revamp: admin create project (issue #80).
+   */
+  createProject: async (
+    payload: Partial<ApiProject> & { projectName: string },
+    authHeader?: string,
+  ): Promise<{ status: string; data: ApiProject }> => {
+    if (USE_MOCK_DATA) {
+      const { mockWinningProjects } = await import("./mockWinners");
+      const id =
+        payload.id ||
+        payload.projectName
+          .trim()
+          .toLowerCase()
+          .replace(/[^a-z0-9\s-]/g, "")
+          .replace(/\s+/g, "-")
+          .replace(/-+/g, "-")
+          .replace(/^-|-$/g, "")
+          .slice(0, 100) +
+          `-${Date.now()}`;
+      const created: ApiProject = {
+        description: "",
+        ...payload,
+        id,
+      };
+      (mockWinningProjects as ApiProject[]).unshift(created);
+
+      // Persist to localStorage so the project survives a module reload
+      const stored = localStorage.getItem("projects");
+      const lsProjects: ApiProject[] = stored ? JSON.parse(stored) : [];
+      lsProjects.unshift(created);
+      localStorage.setItem("projects", JSON.stringify(lsProjects));
+
+      return { status: "success", data: created };
+    }
+    return request(`/m2-program`, {
+      method: "POST",
+      headers: authHeader
+        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
+        : { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
     });
   },
 

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -7,6 +7,7 @@ import {
   Wallet,
   AlertCircle,
   CheckCircle,
+  Plus,
 } from "lucide-react";
 import {
   Card,
@@ -46,6 +47,7 @@ import { ProgramsTable } from "@/components/admin/ProgramsTable";
 import { ConfirmPaymentModal } from "@/components/admin/ConfirmPaymentModal";
 import { ConfirmM1PayoutModal } from "@/components/admin/ConfirmM1PayoutModal";
 import { TestPaymentModal } from "@/components/admin/TestPaymentModal";
+import { CreateProjectModal } from "@/components/admin/CreateProjectModal";
 
 const formatAddress = (address = "") =>
   `${address.slice(0, 6)}...${address.slice(-4)}`;
@@ -93,6 +95,7 @@ const AdminPage = () => {
   const [showPayoutModal, setShowPayoutModal] = useState(false);
   const [showM1PayoutModal, setShowM1PayoutModal] = useState(false);
   const [showTestPaymentModal, setShowTestPaymentModal] = useState(false);
+  const [showCreateProjectModal, setShowCreateProjectModal] = useState(false);
   const [sortBy, setSortBy] = useState<'eventStartedAt' | 'projectName' | 'newest'>('eventStartedAt');
   const { toast } = useToast();
 
@@ -702,8 +705,18 @@ const AdminPage = () => {
           </p>
         </div>
         <div className="flex items-center gap-4">
-          <Button 
-            variant="outline" 
+          {isAuthenticated && !!walletState.selectedAccount?.address && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setShowCreateProjectModal(true)}
+            >
+              <Plus className="h-4 w-4 mr-1" aria-hidden="true" />
+              Create Project
+            </Button>
+          )}
+          <Button
+            variant="outline"
             onClick={() => setShowTestPaymentModal(true)}
             className="border-yellow-500 text-yellow-600 hover:bg-yellow-500/10"
           >
@@ -933,6 +946,14 @@ const AdminPage = () => {
       <TestPaymentModal
         open={showTestPaymentModal}
         onOpenChange={setShowTestPaymentModal}
+      />
+
+      {/* Create Project Modal */}
+      <CreateProjectModal
+        open={showCreateProjectModal}
+        onOpenChange={setShowCreateProjectModal}
+        connectedAddress={walletState.selectedAccount?.address}
+        onSaved={(project) => setProjects((prev) => [project, ...prev])}
       />
       </div>
     </div>

--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -131,3 +131,15 @@ Do **not** manually edit `- **Promoted**` lines.
 - **File(s)**: `server/api/controllers/project.controller.js:75`, `server/api/controllers/project.controller.js:188`
 - **Observed during**: issue #70 (revamp-P2-04 notify trigger wiring) — reviewer flagged
 - **Suggestion**: two pre-existing `console.log` calls (a debug payload preview in `updateProject`, and an M2-agreement confirmation log) predate Phase 2 and were left untouched. Server code elsewhere uses the `logger` utility (`server/api/utils/logger.js`). Convert these to `logger.debug`/`logger.info` (or remove the debug preview) in a dedicated cleanup pass — out of scope for #70's minimal diff.
+
+## [2026-05-19] project.controller.js uses bare console.error in catch blocks
+- **Severity**: nit
+- **File(s)**: `server/api/controllers/project.controller.js` (catch blocks ~lines 22, 41, 57, 67)
+- **Observed during**: issue #80 (admin Create Project UI) — reviewer flagged
+- **Suggestion**: several controller methods log errors with bare `console.error` while later methods in the same file use the `logger` utility (`server/api/utils/logger.js`). Pre-existing; pairs with the existing "[2026-05-18] Pre-existing console.log calls" entry. Standardise the whole file on `logger` in one cleanup pass.
+
+## [2026-05-19] No admin surface lists all projects (newly-created projects have no admin home)
+- **Severity**: minor
+- **File(s)**: `client/src/pages/AdminPage.tsx`
+- **Observed during**: issue #80 (admin Create Project UI) — UI verification
+- **Suggestion**: the `/admin` landing page has only winners / M2-projects / pending-review tables — all scoped. A project freshly created via the new "Create Project" modal (no winner status, no `m2Status`) appears in none of them. It is reachable at `/m2-program/:id` and via the public list, but an admin has no in-admin-panel surface to confirm or browse it. Consider an "All projects" admin table (searchable) so the create→manage loop is fully visible on `/admin`.

--- a/server/api/controllers/__tests__/project.controller.test.js
+++ b/server/api/controllers/__tests__/project.controller.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('../../services/project.service.js', () => ({
-  default: { updateProject: vi.fn(), getProjectById: vi.fn() },
+  default: { updateProject: vi.fn(), getProjectById: vi.fn(), createProject: vi.fn() },
 }));
 vi.mock('../../services/project-update.service.js', () => ({
   default: { listByProject: vi.fn(), create: vi.fn() },
@@ -29,6 +29,45 @@ const mockRes = () => {
   res.json = vi.fn(() => res);
   return res;
 };
+
+describe('ProjectController.createProject', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 201 when payload is valid', async () => {
+    const created = { id: 'test-project', projectName: 'Test Project' };
+    projectService.createProject.mockResolvedValue(created);
+    const req = { body: { projectName: 'Test Project' } };
+    const res = mockRes();
+    await projectController.createProject(req, res);
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({ status: 'success', data: created });
+    expect(projectService.createProject).toHaveBeenCalledWith({ projectName: 'Test Project' });
+  });
+
+  it('returns 400 when projectName is missing', async () => {
+    const req = { body: {} };
+    const res = mockRes();
+    await projectController.createProject(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(projectService.createProject).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when teamMembers contains an invalid entry', async () => {
+    const req = { body: { projectName: 'Test Project', teamMembers: [{ name: '' }] } };
+    const res = mockRes();
+    await projectController.createProject(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(projectService.createProject).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when service throws', async () => {
+    projectService.createProject.mockRejectedValue(new Error('db error'));
+    const req = { body: { projectName: 'Test Project' } };
+    const res = mockRes();
+    await projectController.createProject(req, res);
+    expect(res.status).toHaveBeenCalledWith(500);
+  });
+});
 
 describe('ProjectController.approveM2', () => {
   beforeEach(() => vi.clearAllMocks());

--- a/server/api/controllers/project.controller.js
+++ b/server/api/controllers/project.controller.js
@@ -4,7 +4,7 @@ import fundingSignalService from '../services/funding-signal.service.js';
 import paymentService from '../services/payment.service.js';
 import notificationService from '../services/notification.service.js';
 import { ALLOWED_CATEGORIES } from '../constants/allowedTech.js';
-import { validateSS58, validateM2Submission, validateSimpleUrl, validateProjectUpdate, validateFundingSignal } from '../utils/validation.js';
+import { validateSS58, validateM2Submission, validateSimpleUrl, validateProjectUpdate, validateFundingSignal, validateProject } from '../utils/validation.js';
 import { canEditM2Agreement, isSubmissionWindowOpen } from '../utils/dateHelpers.js';
 import logger from '../utils/logger.js';
 import { getAuthorizedAddresses } from '../../config/polkadot-config.js';
@@ -46,6 +46,11 @@ class ProjectController {
     async createProject(req, res) {
         try {
             const projectData = req.body || {};
+            const { valid, errors } = validateProject(projectData);
+            if (!valid) {
+                const firstError = Object.values(errors)[0] || 'Invalid project data';
+                return res.status(400).json({ status: 'error', message: firstError, errors });
+            }
             const created = await projectService.createProject(projectData);
             res.status(201).json({ status: "success", data: created });
         } catch (error) {

--- a/server/api/utils/validation.js
+++ b/server/api/utils/validation.js
@@ -1,6 +1,7 @@
 /**
  * Validation utility functions for Stadium backend
  */
+import { ALLOWED_CATEGORIES } from '../constants/allowedTech.js';
 
 /**
  * Validate SS58 address format (Polkadot/Substrate)
@@ -288,6 +289,80 @@ export const validateEmail = (email) => {
     return { valid: false, error: 'email must be a valid email address' };
   }
   return { valid: true, normalised: trimmed };
+};
+
+/**
+ * Validate project creation payload (Phase 2 revamp, #80).
+ * @param {Object} data
+ * @returns {Object} - { valid: boolean, errors: Record<string,string> }
+ */
+export const validateProject = (data) => {
+  const errors = {};
+
+  if (!data || typeof data !== 'object') {
+    return { valid: false, errors: { _root: 'Project payload must be an object' } };
+  }
+
+  // projectName is required
+  if (!data.projectName || typeof data.projectName !== 'string' || !validateLength(data.projectName, 1, 200)) {
+    errors.projectName = 'projectName is required (1–200 characters)';
+  }
+
+  if (data.description !== undefined && data.description !== null) {
+    if (typeof data.description !== 'string' || !validateLength(data.description, 0, 5000)) {
+      errors.description = 'description must be a string (max 5000 characters)';
+    }
+  }
+
+  for (const urlField of ['projectRepo', 'demoUrl', 'slidesUrl', 'liveUrl']) {
+    if (data[urlField] !== undefined && data[urlField] !== null && data[urlField] !== '') {
+      if (!validateSimpleUrl(data[urlField])) {
+        errors[urlField] = `${urlField} must start with www or http`;
+      }
+    }
+  }
+
+  if (data.donationAddress !== undefined && data.donationAddress !== null && data.donationAddress !== '') {
+    if (!validateSS58(data.donationAddress)) {
+      errors.donationAddress = 'donationAddress must be a valid SS58 address';
+    }
+  }
+
+  if (data.categories !== undefined && data.categories !== null) {
+    if (!Array.isArray(data.categories)) {
+      errors.categories = 'categories must be an array';
+    } else {
+      const bad = data.categories.filter(c => !ALLOWED_CATEGORIES.includes(String(c)));
+      if (bad.length > 0) {
+        errors.categories = `Invalid categories: ${bad.join(', ')}`;
+      }
+    }
+  }
+
+  if (data.teamMembers !== undefined && data.teamMembers !== null) {
+    if (!Array.isArray(data.teamMembers)) {
+      errors.teamMembers = 'teamMembers must be an array';
+    } else {
+      for (let i = 0; i < data.teamMembers.length; i++) {
+        const result = validateTeamMember(data.teamMembers[i]);
+        if (!result.valid) {
+          errors[`teamMembers[${i}]`] = result.error;
+        }
+      }
+    }
+  }
+
+  if (data.hackathon !== undefined && data.hackathon !== null) {
+    if (typeof data.hackathon !== 'object' || Array.isArray(data.hackathon)) {
+      errors.hackathon = 'hackathon must be an object';
+    } else if (data.hackathon.name !== undefined && data.hackathon.name !== null) {
+      if (typeof data.hackathon.name !== 'string' || !validateLength(data.hackathon.name, 1, 200)) {
+        errors['hackathon.name'] = 'hackathon.name must be a string (1–200 characters)';
+      }
+    }
+  }
+
+  return { valid: Object.keys(errors).length === 0, errors };
 };
 
 /**


### PR DESCRIPTION
## Summary

- Adds a "Create Project" button + modal (`CreateProjectModal.tsx`) to the `/admin` header so an admin can onboard a project **in-app** instead of running an offline `migration.js` / `seed-dev.js` script. The modal collects project name (required), an optional id (auto-derived from the name if blank), description, repo/demo URLs, hackathon name/id, category pills, and an editable team-member list.
- Save runs a SIWS signature (statement `"Create new project on Stadium"`, already in the server `VALID_STATEMENTS` whitelist) and POSTs to the **existing** `POST /api/m2-program/` endpoint.
- **Hardens the endpoint:** `createProject` (`project.controller.js`) previously wrote `req.body` with zero validation — it now runs a new `validateProject()` (`server/api/utils/validation.js`) and returns `400` on missing/invalid fields.
- `client/src/lib/api.ts` gains `createProject` with a mock-mode branch that persists the new project to the `localStorage`-backed projects store (so it survives a reload and is reachable at `/m2-program/:id`).

Closes #80

## Test plan
- [x] `cd server && npm test` — pass (125 tests, incl. 4 new `createProject` cases)
- [x] `cd client && npm run build` — pass
- [x] `cd client && npm run lint` — pass (zero warnings)

## UI verification (stadium-tester)

Target: local dev `http://localhost:8080` — mock mode + SIWS test-wallet harness. **3/3 UI scenarios PASS**; the 4th issue scenario is a server unit test.

| # | Scenario | Result | Notes |
|---|----------|--------|-------|
| 1 | On `/admin`, clicking "Create Project" opens the modal | PASS | |
| 2 | Fill valid fields + save → project is created and reachable | PASS | verified by inspecting the persisted mock store + loading `/m2-program/:id` (see note below) |
| 3 | Submit with the required field empty → inline error, no creation | PASS | "Project name is required." renders; modal stays open |
| 4 | `POST /api/m2-program/` with a missing required field → `400` | PASS | server Vitest test |

**Note on scenario 2:** the issue AC said the new project "appears in the admin tables." In practice `/admin` has only winners / M2 / pending-review tables — all scoped — so a freshly-created bare project appears in none of them. It *is* created and reachable at `/m2-program/:id` and via the public list. Verification therefore checks persistence + reachability. The missing admin "all projects" view is logged to the backlog (see below).

**Console errors during run:** the pre-existing `TeamPaymentSection` duplicate-key warning only (logged in PR #77); none introduced by this PR.

## Preview

https://stadium-git-feat-admin-create-project-80-sachalanskys-projects.vercel.app

The preview build is healthy. The "Create Project" affordance is admin-gated; the SIWS save needs the test-wallet harness (not enabled on Vercel previews), so the full create flow was verified on local dev — consistent with prior Phase 2 previews.

## Backlog items logged

Two entries appended to `docs/improvement-backlog.md`:
- *No admin surface lists all projects* — a project created via this modal has no `/admin` table to appear in (winners/M2-scoped only). Suggests an "All projects" admin view so the create→manage loop is fully visible.
- *`project.controller.js` uses bare `console.error` in catch blocks* — pre-existing; should standardise on the `logger` utility.

## Invariants verified
- [x] BYPASS_ADMIN_CHECK still false
- [x] `POST /api/m2-program/` still gated by `requireAdmin` — route untouched
- [x] No new console.log in client code
- [x] No new Supabase imports / no Supabase calls outside the repository
- [x] SIWS statement byte-matches the server `VALID_STATEMENTS` whitelist
