### PR TITLE
feat: multi-chain sign-in — Substrate + Ethereum + Solana

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,5 +129,8 @@ mongodb-data/
 # Supabase CLI cache
 supabase/.temp/
 
+# Playwright MCP session artifacts (console logs + page snapshots)
+.playwright-mcp/
+
 # Generated descriptors (optional: uncomment if not needed in repo)
 # server/.papi/

--- a/client/.env.example
+++ b/client/.env.example
@@ -4,7 +4,9 @@ VITE_API_BASE_URL=http://localhost:2000/api
 # For production:
 # VITE_API_BASE_URL=https://hw4os4c00wg4k80o.apps.joinwebzero.com/api
 
-# Admin wallet addresses (comma-separated)
+# Admin wallet addresses (comma-separated). Each entry is either `chain:address`
+# or a bare address (bare ⇒ substrate). Supported chains: substrate, ethereum.
+# Example: VITE_ADMIN_ADDRESSES=5Grw...,ethereum:0xAbC123...
 VITE_ADMIN_ADDRESSES=
 
 # Preview / offline mode: when "true", the client serves fixtures from

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -45,6 +45,7 @@
         "@radix-ui/react-tooltip": "^1.2.7",
         "@talismn/siws": "^1.0.0",
         "@tanstack/react-query": "^5.56.2",
+        "bs58": "^6.0.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -5002,6 +5003,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
     "node_modules/bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
@@ -5085,6 +5092,15 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
       }
     },
     "node_modules/bufferutil": {

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -65,6 +65,7 @@
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^0.9.9",
+        "viem": "^2.50.3",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -86,6 +87,12 @@
         "typescript-eslint": "^8.0.1",
         "vite": "^5.4.1"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -1595,6 +1602,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/curves": {
@@ -3982,6 +4001,33 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -4774,6 +4820,27 @@
         "vite": "^4 || ^5 || ^6 || ^7"
       }
     },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -5025,7 +5092,6 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz",
       "integrity": "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -6338,6 +6404,21 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -6860,6 +6941,51 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ox": {
+      "version": "0.14.22",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.22.tgz",
+      "integrity": "sha512-nb5msL8qWbPglhIfZbGJAfw3cqiJjFMiWmACt7kgyWtLib12tcctbHufMT9Hb0Lr6Pt4k9I3dbpueTpbhvbqvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/p-limit": {
@@ -8099,7 +8225,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "peer": true,
       "bin": {
@@ -8238,7 +8364,6 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.5.tgz",
       "integrity": "sha512-EYZR+OpIXp9Y1eG1iueg8KRsY8TuT8VNgnanZ0uA3STqhHQTLwbl+WX76/9X5OY12yQubymBpaBSmMPkSTQcKA==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -8285,6 +8410,51 @@
         "d3-shape": "^3.1.0",
         "d3-time": "^3.0.0",
         "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/viem": {
+      "version": "2.50.3",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.50.3.tgz",
+      "integrity": "sha512-xJ4XlnkKM2Of0A0TPS4KZNZU1YLYM8+mMirkNA+atTg6Crjg0YqWvSIckszSEmlQ4qH/5lhZ/DILgmNlepbV5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.22",
+        "ws": "8.20.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/vite": {
@@ -8471,10 +8641,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -8521,6 +8692,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/client/package.json
+++ b/client/package.json
@@ -67,6 +67,7 @@
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.9",
+    "viem": "^2.50.3",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/client/package.json
+++ b/client/package.json
@@ -47,6 +47,7 @@
     "@radix-ui/react-tooltip": "^1.2.7",
     "@talismn/siws": "^1.0.0",
     "@tanstack/react-query": "^5.56.2",
+    "bs58": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/client/src/components/TeamPaymentSection.tsx
+++ b/client/src/components/TeamPaymentSection.tsx
@@ -6,6 +6,13 @@ import { Separator } from "@/components/ui/separator";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { 
   Users, 
   Wallet, 
@@ -25,9 +32,21 @@ import {
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 
+type WalletChain = 'substrate' | 'ethereum' | 'solana';
+
+const CHAIN_OPTIONS: { value: WalletChain; label: string }[] = [
+  { value: 'substrate', label: 'Polkadot' },
+  { value: 'ethereum', label: 'Ethereum' },
+  { value: 'solana', label: 'Solana' },
+];
+
+const chainLabel = (chain?: WalletChain) =>
+  CHAIN_OPTIONS.find((o) => o.value === (chain || 'substrate'))?.label ?? 'Polkadot';
+
 interface TeamMember {
   name: string;
   walletAddress?: string;
+  walletChain?: WalletChain;
   role?: string;
   twitter?: string;
   github?: string;
@@ -46,17 +65,23 @@ interface Payment {
 interface TeamPaymentSectionProps {
   teamMembers?: TeamMember[];
   donationAddress?: string;
+  donationChain?: WalletChain;
   totalPaid?: Payment[];
   m2Status?: 'building' | 'under_review' | 'completed';
   isTeamMember: boolean;
   isAdmin: boolean;
   isConnected: boolean;
-  onSave: (data: { teamMembers: TeamMember[]; donationAddress: string }) => Promise<void>;
+  onSave: (data: {
+    teamMembers: TeamMember[];
+    donationAddress: string;
+    donationChain: WalletChain;
+  }) => Promise<void>;
 }
 
 export function TeamPaymentSection({
   teamMembers = [],
   donationAddress,
+  donationChain = 'substrate',
   totalPaid = [],
   m2Status,
   isTeamMember,
@@ -72,6 +97,7 @@ export function TeamPaymentSection({
   // Editable state
   const [editedMembers, setEditedMembers] = useState<TeamMember[]>([]);
   const [editedPayoutAddress, setEditedPayoutAddress] = useState("");
+  const [editedPayoutChain, setEditedPayoutChain] = useState<WalletChain>('substrate');
 
   // Determine if user can edit
   const canEdit = isConnected && (isTeamMember || isAdmin);
@@ -81,17 +107,19 @@ export function TeamPaymentSection({
     if (canEdit) {
       setEditedMembers(teamMembers.length > 0 ? [...teamMembers] : [{ name: "", walletAddress: "" }]);
       setEditedPayoutAddress(donationAddress || "");
+      setEditedPayoutChain(donationChain);
     }
-  }, [canEdit, teamMembers, donationAddress]);
+  }, [canEdit, teamMembers, donationAddress, donationChain]);
 
   // Check if there are unsaved changes
   const hasChanges = () => {
     if (!isEditing) return false;
-    
+
     const membersChanged = JSON.stringify(editedMembers) !== JSON.stringify(teamMembers);
     const addressChanged = editedPayoutAddress !== (donationAddress || "");
-    
-    return membersChanged || addressChanged;
+    const chainChanged = editedPayoutChain !== donationChain;
+
+    return membersChanged || addressChanged || chainChanged;
   };
 
   const truncateAddress = (addr: string) => {
@@ -144,8 +172,14 @@ export function TeamPaymentSection({
 
   // Team member editing functions
   const updateMember = (index: number, field: keyof TeamMember, value: string) => {
-    setEditedMembers(prev => prev.map((m, i) => 
+    setEditedMembers(prev => prev.map((m, i) =>
       i === index ? { ...m, [field]: value } : m
+    ));
+  };
+
+  const updateMemberChain = (index: number, chain: WalletChain) => {
+    setEditedMembers(prev => prev.map((m, i) =>
+      i === index ? { ...m, walletChain: chain } : m
     ));
   };
 
@@ -177,6 +211,7 @@ export function TeamPaymentSection({
         teamMembers: validMembers.map(m => ({
           name: m.name.trim(),
           walletAddress: m.walletAddress?.trim() || undefined,
+          walletChain: m.walletChain || 'substrate',
           role: m.role?.trim() || undefined,
           twitter: m.twitter?.trim() || undefined,
           github: m.github?.trim() || undefined,
@@ -184,6 +219,7 @@ export function TeamPaymentSection({
           customUrl: m.customUrl?.trim() || undefined,
         })),
         donationAddress: editedPayoutAddress.trim(),
+        donationChain: editedPayoutChain,
       });
       
       toast({
@@ -202,6 +238,7 @@ export function TeamPaymentSection({
     // Reset to original values
     setEditedMembers(teamMembers.length > 0 ? [...teamMembers] : [{ name: "", walletAddress: "" }]);
     setEditedPayoutAddress(donationAddress || "");
+    setEditedPayoutChain(donationChain);
     setIsEditing(false);
   };
 
@@ -224,6 +261,9 @@ export function TeamPaymentSection({
                 <code className="text-xs text-muted-foreground font-mono">
                   {truncateAddress(member.walletAddress)}
                 </code>
+                <Badge variant="outline" className="text-[10px]">
+                  {chainLabel(member.walletChain)}
+                </Badge>
                 <Button
                   variant="ghost"
                   size="icon"
@@ -305,15 +345,33 @@ export function TeamPaymentSection({
               </div>
             </div>
             
-            {/* Row 2: Wallet Address */}
-            <div>
-              <Label className="text-xs text-muted-foreground">Wallet Address</Label>
-              <Input
-                value={member.walletAddress || ""}
-                onChange={(e) => updateMember(index, 'walletAddress', e.target.value)}
-                placeholder="SS58 address (e.g., 5Abc...)"
-                className="h-9 font-mono text-sm"
-              />
+            {/* Row 2: Wallet Address + chain */}
+            <div className="grid grid-cols-[1fr_auto] gap-3">
+              <div>
+                <Label className="text-xs text-muted-foreground">Wallet Address</Label>
+                <Input
+                  value={member.walletAddress || ""}
+                  onChange={(e) => updateMember(index, 'walletAddress', e.target.value)}
+                  placeholder="Wallet address"
+                  className="h-9 font-mono text-sm"
+                />
+              </div>
+              <div>
+                <Label className="text-xs text-muted-foreground">Chain</Label>
+                <Select
+                  value={member.walletChain || 'substrate'}
+                  onValueChange={(v) => updateMemberChain(index, v as WalletChain)}
+                >
+                  <SelectTrigger className="h-9 w-[130px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {CHAIN_OPTIONS.map((o) => (
+                      <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
             </div>
             
             {/* Row 3: Social Links */}
@@ -449,22 +507,43 @@ export function TeamPaymentSection({
           {isEditing ? (
             <div className="space-y-2">
               <Label className="text-xs text-muted-foreground">Payout Wallet Address</Label>
-              <Input
-                value={editedPayoutAddress}
-                onChange={(e) => setEditedPayoutAddress(e.target.value)}
-                placeholder="SS58 address for receiving payments"
-                className="font-mono text-sm"
-              />
+              <div className="grid grid-cols-[1fr_auto] gap-3">
+                <Input
+                  value={editedPayoutAddress}
+                  onChange={(e) => setEditedPayoutAddress(e.target.value)}
+                  placeholder="Address for receiving payments"
+                  className="font-mono text-sm"
+                />
+                <Select
+                  value={editedPayoutChain}
+                  onValueChange={(v) => setEditedPayoutChain(v as WalletChain)}
+                >
+                  <SelectTrigger className="w-[130px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {CHAIN_OPTIONS.map((o) => (
+                      <SelectItem key={o.value} value={o.value}>{o.label}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
               <p className="text-xs text-muted-foreground">
-                This address will receive M2 milestone payments
+                This address will receive M2 milestone payments. Automated payouts
+                run on Polkadot; other chains are settled manually.
               </p>
             </div>
           ) : donationAddress ? (
             <Card className="bg-secondary/50">
               <CardContent className="p-4">
-                <p className="text-xs text-muted-foreground mb-1">
-                  Payout Wallet Address
-                </p>
+                <div className="flex items-center gap-2 mb-1">
+                  <p className="text-xs text-muted-foreground">
+                    Payout Wallet Address
+                  </p>
+                  <Badge variant="outline" className="text-[10px]">
+                    {chainLabel(donationChain)}
+                  </Badge>
+                </div>
                 <div className="flex items-center justify-between gap-2">
                   <code className="text-sm font-mono break-all">
                     {donationAddress}

--- a/client/src/components/WalletConnectionBanner.tsx
+++ b/client/src/components/WalletConnectionBanner.tsx
@@ -3,13 +3,23 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Wallet, X } from "lucide-react";
+import type { Chain } from "@/lib/auth/types";
+import { ChainPicker } from "@/components/auth/ChainPicker";
 
 interface WalletConnectionBannerProps {
   onConnect: () => void;
   isConnected: boolean;
+  /** When provided, a chain picker is shown so the user can choose an ecosystem. */
+  chain?: Chain;
+  onChainChange?: (chain: Chain) => void;
 }
 
-export function WalletConnectionBanner({ onConnect, isConnected }: WalletConnectionBannerProps) {
+export function WalletConnectionBanner({
+  onConnect,
+  isConnected,
+  chain,
+  onChainChange,
+}: WalletConnectionBannerProps) {
   const [dismissed, setDismissed] = useState(false);
 
   // Check if banner was dismissed in session
@@ -36,6 +46,8 @@ export function WalletConnectionBanner({ onConnect, isConnected }: WalletConnect
   // Don't show if connected or dismissed
   if (isConnected || dismissed) return null;
 
+  const showChainPicker = chain !== undefined && onChainChange !== undefined;
+
   return (
     <AnimatePresence>
       <motion.div
@@ -46,13 +58,16 @@ export function WalletConnectionBanner({ onConnect, isConnected }: WalletConnect
       >
         <Alert className="mb-6 border-primary/50 bg-primary/10">
           <Wallet className="h-4 w-4" />
-          <AlertDescription className="flex items-center justify-between gap-4">
-            <span className="flex-1">
+          <AlertDescription className="flex flex-wrap items-center justify-between gap-4">
+            <span className="flex-1 min-w-[16rem]">
               Connect your wallet to update team details, milestone deliverables and manage payment information. Contact WebZero if you are having trouble signing in.
             </span>
             <div className="flex items-center gap-2">
-              <Button 
-                size="sm" 
+              {showChainPicker && (
+                <ChainPicker value={chain} onChange={onChainChange} />
+              )}
+              <Button
+                size="sm"
                 onClick={onConnect}
                 className="bg-primary hover:bg-primary/90"
               >
@@ -73,4 +88,3 @@ export function WalletConnectionBanner({ onConnect, isConnected }: WalletConnect
     </AnimatePresence>
   );
 }
-

--- a/client/src/components/auth/ChainPicker.tsx
+++ b/client/src/components/auth/ChainPicker.tsx
@@ -1,0 +1,48 @@
+/**
+ * Segmented control for choosing which wallet ecosystem to sign in with.
+ */
+
+import type { Chain } from "@/lib/auth/types";
+import { ALL_CHAINS, getProvider } from "@/lib/auth/registry";
+import { cn } from "@/lib/utils";
+
+interface ChainPickerProps {
+  value: Chain;
+  onChange: (chain: Chain) => void;
+  className?: string;
+}
+
+export function ChainPicker({ value, onChange, className }: ChainPickerProps) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Sign-in chain"
+      className={cn(
+        "inline-flex gap-1 rounded-lg border border-border p-1",
+        className,
+      )}
+    >
+      {ALL_CHAINS.map((chain) => {
+        const provider = getProvider(chain);
+        const selected = value === chain;
+        return (
+          <button
+            key={chain}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            onClick={() => onChange(chain)}
+            className={cn(
+              "rounded-md px-3 py-1.5 text-sm font-medium transition-colors",
+              selected
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {provider?.label ?? chain}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/client/src/components/project/NotificationsCard.tsx
+++ b/client/src/components/project/NotificationsCard.tsx
@@ -5,15 +5,14 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Bell, Loader2 } from "lucide-react";
-import { web3Enable, web3Accounts, web3FromSource } from "@polkadot/extension-dapp";
-import { SiwsMessage } from "@talismn/siws";
-import { generateSiwsStatement } from "@/lib/siwsUtils";
+import { useWalletAuth } from "@/lib/auth/useWalletAuth";
 import { api } from "@/lib/api";
 import { validateEmail } from "@/lib/validation";
 import { useToast } from "@/hooks/use-toast";
 
 export function NotificationsCard({ connectedAddress }: { connectedAddress: string }) {
   const { toast } = useToast();
+  const auth = useWalletAuth();
 
   const [loading, setLoading] = useState(true);
   const [emailSet, setEmailSet] = useState(false);
@@ -27,7 +26,7 @@ export function NotificationsCard({ connectedAddress }: { connectedAddress: stri
     let active = true;
     setLoading(true);
     api
-      .getWalletContact(connectedAddress)
+      .getWalletContact(connectedAddress, auth.account?.chain ?? 'substrate')
       .then((data) => {
         if (!active) return;
         setEmailSet(data.email_set);
@@ -43,7 +42,7 @@ export function NotificationsCard({ connectedAddress }: { connectedAddress: stri
     return () => {
       active = false;
     };
-  }, [connectedAddress]);
+  }, [connectedAddress, auth.account?.chain]);
 
   // Only reachable from the confirmation view, which is gated on an email
   // already being on file — so this path intentionally skips email validation.
@@ -51,27 +50,7 @@ export function NotificationsCard({ connectedAddress }: { connectedAddress: stri
     setNotificationsEnabled(checked);
     setSubmitting(true);
     try {
-      await web3Enable("Stadium");
-      const accounts = await web3Accounts();
-      const account = accounts.find((a) => a.address === connectedAddress) || accounts[0];
-      if (!account) throw new Error("No wallet account found");
-
-      const siws = new SiwsMessage({
-        domain: window.location.hostname,
-        uri: window.location.origin,
-        address: account.address,
-        nonce: Math.random().toString(36).slice(2),
-        statement: generateSiwsStatement({ action: "update-notifications" }),
-      });
-      const injector = await web3FromSource(account.meta.source);
-      const signed = (await siws.sign(injector)) as unknown as { signature: string; message?: string };
-      const messageStr =
-        typeof signed.message === "string" && signed.message
-          ? signed.message
-          : (siws as unknown as { toString: () => string }).toString();
-      const authHeader = btoa(
-        JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address }),
-      );
+      const authHeader = await auth.signAction("update-notifications");
 
       const res = await api.updateWalletContact(connectedAddress, { notificationsEnabled: checked }, authHeader);
       setNotificationsEnabled(res.notifications_enabled);
@@ -98,27 +77,7 @@ export function NotificationsCard({ connectedAddress }: { connectedAddress: stri
 
     setSubmitting(true);
     try {
-      await web3Enable("Stadium");
-      const accounts = await web3Accounts();
-      const account = accounts.find((a) => a.address === connectedAddress) || accounts[0];
-      if (!account) throw new Error("No wallet account found");
-
-      const siws = new SiwsMessage({
-        domain: window.location.hostname,
-        uri: window.location.origin,
-        address: account.address,
-        nonce: Math.random().toString(36).slice(2),
-        statement: generateSiwsStatement({ action: "update-notifications" }),
-      });
-      const injector = await web3FromSource(account.meta.source);
-      const signed = (await siws.sign(injector)) as unknown as { signature: string; message?: string };
-      const messageStr =
-        typeof signed.message === "string" && signed.message
-          ? signed.message
-          : (siws as unknown as { toString: () => string }).toString();
-      const authHeader = btoa(
-        JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address }),
-      );
+      const authHeader = await auth.signAction("update-notifications");
 
       const res = await api.updateWalletContact(
         connectedAddress,

--- a/client/src/lib/addressUtils.ts
+++ b/client/src/lib/addressUtils.ts
@@ -1,5 +1,6 @@
 import { decodeAddress } from '@polkadot/util-crypto'
 import { u8aToHex } from '@polkadot/util'
+import bs58 from 'bs58'
 
 export type AddrChain = 'substrate' | 'ethereum' | 'solana'
 
@@ -7,7 +8,7 @@ export type AddrChain = 'substrate' | 'ethereum' | 'solana'
  * Reduce an address to its canonical comparison form for the given chain:
  *   - substrate: decoded public key hex (cross-prefix safe)
  *   - ethereum:  lowercased 0x address (EIP-55 checksum is display-only)
- *   - solana:    not yet normalized (Phase C) — returns null, callers fall back
+ *   - solana:    canonical base58 of the 32-byte ed25519 public key
  *
  * Returns null when the address is invalid for the chain.
  */
@@ -18,7 +19,12 @@ export function normalizeAddr(address?: string | null, chain: AddrChain = 'subst
     return /^0x[a-fA-F0-9]{40}$/.test(eth) ? eth.toLowerCase() : null
   }
   if (chain === 'solana') {
-    return null
+    try {
+      const decoded = bs58.decode(address.trim())
+      return decoded.length === 32 ? bs58.encode(decoded) : null
+    } catch {
+      return null
+    }
   }
   // substrate — SS58 is base58, never 0x-prefixed hex
   if (/^0x/i.test(address.trim())) return null

--- a/client/src/lib/addressUtils.ts
+++ b/client/src/lib/addressUtils.ts
@@ -1,31 +1,66 @@
 import { decodeAddress } from '@polkadot/util-crypto'
 import { u8aToHex } from '@polkadot/util'
 
+export type AddrChain = 'substrate' | 'ethereum' | 'solana'
+
 /**
- * Compare two SS58 addresses by their decoded public keys.
- * Works across different SS58 prefixes (Polkadot, Kusama, Substrate generic, etc.).
- * Falls back to case-insensitive string comparison if decoding fails.
+ * Reduce an address to its canonical comparison form for the given chain:
+ *   - substrate: decoded public key hex (cross-prefix safe)
+ *   - ethereum:  lowercased 0x address (EIP-55 checksum is display-only)
+ *   - solana:    not yet normalized (Phase C) — returns null, callers fall back
+ *
+ * Returns null when the address is invalid for the chain.
  */
-export function addressesEqual(a?: string | null, b?: string | null): boolean {
-  if (!a || !b) return false
+export function normalizeAddr(address?: string | null, chain: AddrChain = 'substrate'): string | null {
+  if (!address) return null
+  if (chain === 'ethereum') {
+    const eth = address.trim()
+    return /^0x[a-fA-F0-9]{40}$/.test(eth) ? eth.toLowerCase() : null
+  }
+  if (chain === 'solana') {
+    return null
+  }
+  // substrate — SS58 is base58, never 0x-prefixed hex
+  if (/^0x/i.test(address.trim())) return null
   try {
-    return u8aToHex(decodeAddress(a)) === u8aToHex(decodeAddress(b))
+    return u8aToHex(decodeAddress(address))
   } catch {
-    return a.toLowerCase() === b.toLowerCase()
+    return null
   }
 }
 
 /**
- * Check if an address exists in a list of addresses or objects with walletAddress.
- * Supports both string arrays (e.g. ADMIN_ADDRESSES) and object arrays (e.g. teamMembers).
+ * Compare two addresses on the same chain. For substrate this matches across
+ * SS58 prefixes; for ethereum it is case-insensitive. Falls back to
+ * case-insensitive string comparison when an address cannot be normalized.
+ */
+export function addressesEqual(
+  a?: string | null,
+  b?: string | null,
+  chain: AddrChain = 'substrate'
+): boolean {
+  if (!a || !b) return false
+  const na = normalizeAddr(a, chain)
+  const nb = normalizeAddr(b, chain)
+  if (na && nb) return na === nb
+  return a.toLowerCase() === b.toLowerCase()
+}
+
+/**
+ * Check if an address exists in a list of addresses or objects with
+ * walletAddress. List objects may carry their own `walletChain`; otherwise the
+ * `chain` argument applies to every entry.
  */
 export function addressInList(
   address: string | undefined | null,
-  list: Array<{ walletAddress?: string } | string>
+  list: Array<{ walletAddress?: string; walletChain?: AddrChain } | string>,
+  chain: AddrChain = 'substrate'
 ): boolean {
   if (!address) return false
   return list.some(item => {
-    const addr = typeof item === 'string' ? item : item.walletAddress
-    return addressesEqual(address, addr)
+    if (typeof item === 'string') {
+      return addressesEqual(address, item, chain)
+    }
+    return addressesEqual(address, item.walletAddress, item.walletChain || chain)
   })
 }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -356,9 +356,10 @@ export const api = {
   },
 
   updateTeam: async (projectId: string, data: {
-    teamMembers: Array<{ 
-      name: string; 
+    teamMembers: Array<{
+      name: string;
       walletAddress?: string;
+      walletChain?: 'substrate' | 'ethereum' | 'solana';
       role?: string;
       twitter?: string;
       github?: string;
@@ -366,6 +367,7 @@ export const api = {
       customUrl?: string;
     }>;
     donationAddress?: string;
+    donationChain?: 'substrate' | 'ethereum' | 'solana';
   }, authHeader?: string) => {
     if (USE_MOCK_DATA) {
       // Simulate API delay
@@ -400,7 +402,10 @@ export const api = {
       await request(`/m2-program/${projectId}/payout-address`, {
         method: 'PATCH',
         headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : { "Content-Type": "application/json" },
-        body: JSON.stringify({ donationAddress: data.donationAddress })
+        body: JSON.stringify({
+          donationAddress: data.donationAddress,
+          donationChain: data.donationChain || 'substrate',
+        })
       });
     }
 
@@ -650,7 +655,8 @@ export const api = {
   updatePayoutAddress: async (
     projectId: string,
     donationAddress: string,
-    authHeader?: string
+    authHeader?: string,
+    donationChain: 'substrate' | 'ethereum' | 'solana' = 'substrate'
   ) => {
     if (USE_MOCK_DATA) {
       // Simulate API delay
@@ -674,7 +680,7 @@ export const api = {
     return request(`/m2-program/${projectId}`, {
       method: 'PATCH',
       headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : { "Content-Type": "application/json" },
-      body: JSON.stringify({ donationAddress })
+      body: JSON.stringify({ donationAddress, donationChain })
     });
   },
 
@@ -1152,13 +1158,18 @@ export const api = {
   /**
    * Phase 2 revamp: wallet contacts / notification preferences (#71).
    */
-  getWalletContact: async (address: string): Promise<{ email_set: boolean; notifications_enabled: boolean }> => {
+  getWalletContact: async (
+    address: string,
+    chain: 'substrate' | 'ethereum' | 'solana' = 'substrate',
+  ): Promise<{ email_set: boolean; notifications_enabled: boolean }> => {
     if (USE_MOCK_DATA) {
       const { mockWalletContacts } = await import("./mockWalletContacts");
       const entry = mockWalletContacts[address];
       return { email_set: !!entry?.email, notifications_enabled: entry?.notificationsEnabled ?? true };
     }
-    const res = await request(`/wallet-contacts/${encodeURIComponent(address)}`);
+    const res = await request(
+      `/wallet-contacts/${encodeURIComponent(address)}?chain=${encodeURIComponent(chain)}`,
+    );
     return res.data;
   },
 

--- a/client/src/lib/auth/ethereumProvider.ts
+++ b/client/src/lib/auth/ethereumProvider.ts
@@ -1,0 +1,125 @@
+/**
+ * Ethereum (SIWE — Sign-In With Ethereum, EIP-4361) wallet provider.
+ *
+ * Discovers wallets via EIP-6963 (multi-wallet announcement) and falls back to
+ * the legacy `window.ethereum` injection. The SIWE message is built with viem
+ * and signed with `personal_sign` (EIP-191).
+ */
+
+import { getAddress } from 'viem'
+import { createSiweMessage, generateSiweNonce } from 'viem/siwe'
+import type { WalletProvider, WalletAccount, SignParams } from './types'
+import { encodeAuthPayload } from './types'
+
+interface Eip1193Provider {
+  request(args: { method: string; params?: unknown[] }): Promise<unknown>
+}
+
+interface Eip6963ProviderDetail {
+  info: { uuid: string; name: string; icon: string; rdns: string }
+  provider: Eip1193Provider
+}
+
+// EIP-6963 announced wallets, collected as they arrive.
+const discovered: Eip6963ProviderDetail[] = []
+// The provider the user actually connected through (preferred for signing).
+let selectedProvider: Eip1193Provider | null = null
+
+function requestAnnouncements(): void {
+  if (typeof window === 'undefined') return
+  window.dispatchEvent(new Event('eip6963:requestProvider'))
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('eip6963:announceProvider', (event: Event) => {
+    const detail = (event as CustomEvent<Eip6963ProviderDetail>).detail
+    if (detail?.info?.uuid && !discovered.some((d) => d.info.uuid === detail.info.uuid)) {
+      discovered.push(detail)
+    }
+  })
+  requestAnnouncements()
+}
+
+function legacyProvider(): Eip1193Provider | null {
+  const injected = (window as unknown as { ethereum?: Eip1193Provider }).ethereum
+  return injected || null
+}
+
+function resolveProvider(): Eip1193Provider | null {
+  if (selectedProvider) return selectedProvider
+  if (discovered.length > 0) return discovered[0].provider
+  return legacyProvider()
+}
+
+export const ethereumProvider: WalletProvider = {
+  chain: 'ethereum',
+  label: 'Ethereum',
+
+  isAvailable(): boolean {
+    if (typeof window === 'undefined') return false
+    return discovered.length > 0 || !!legacyProvider()
+  },
+
+  async connect(): Promise<WalletAccount[]> {
+    // Re-poll in case a wallet extension injected after initial load.
+    requestAnnouncements()
+    const provider = resolveProvider()
+    if (!provider) {
+      throw new Error('No Ethereum wallet found. Please install MetaMask or another EIP-6963 wallet.')
+    }
+
+    const addresses = (await provider.request({ method: 'eth_requestAccounts' })) as string[]
+    if (!addresses?.length) {
+      throw new Error('No accounts returned by the Ethereum wallet.')
+    }
+    selectedProvider = provider
+
+    return addresses.map((address) => ({
+      chain: 'ethereum' as const,
+      address,
+      label: `${address.slice(0, 6)}…${address.slice(-4)}`,
+    }))
+  },
+
+  async signIn({ account, statement }: SignParams): Promise<string> {
+    const provider = resolveProvider()
+    if (!provider) {
+      throw new Error('No Ethereum wallet found.')
+    }
+
+    // chainId is informational — the server verifies signature, statement and
+    // domain, not the chain id — so a lookup failure falls back to mainnet.
+    let chainId = 1
+    try {
+      const raw = await provider.request({ method: 'eth_chainId' })
+      const parsed = typeof raw === 'string' ? parseInt(raw, 16) : Number(raw)
+      if (Number.isFinite(parsed) && parsed > 0) chainId = parsed
+    } catch {
+      /* keep default */
+    }
+
+    const message = createSiweMessage({
+      address: getAddress(account.address),
+      chainId,
+      domain: window.location.hostname,
+      nonce: generateSiweNonce(),
+      uri: window.location.origin,
+      version: '1',
+      statement,
+      // Short-lived message — the server rejects expired SIWE messages.
+      expirationTime: new Date(Date.now() + 10 * 60 * 1000),
+    })
+
+    const signature = (await provider.request({
+      method: 'personal_sign',
+      params: [message, account.address],
+    })) as string
+
+    return encodeAuthPayload({
+      chain: 'ethereum',
+      message,
+      signature,
+      address: account.address,
+    })
+  },
+}

--- a/client/src/lib/auth/registry.ts
+++ b/client/src/lib/auth/registry.ts
@@ -1,14 +1,16 @@
 /**
- * Wallet provider registry. The Solana provider is added in Phase C.
+ * Wallet provider registry.
  */
 
 import type { Chain, WalletProvider } from './types'
 import { substrateProvider } from './substrateProvider'
 import { ethereumProvider } from './ethereumProvider'
+import { solanaProvider } from './solanaProvider'
 
 const providers: Partial<Record<Chain, WalletProvider>> = {
   substrate: substrateProvider,
   ethereum: ethereumProvider,
+  solana: solanaProvider,
 }
 
 export function getProvider(chain: Chain): WalletProvider | undefined {
@@ -16,4 +18,4 @@ export function getProvider(chain: Chain): WalletProvider | undefined {
 }
 
 /** Chains offered in the sign-in UI, in display order. */
-export const ALL_CHAINS: Chain[] = ['substrate', 'ethereum']
+export const ALL_CHAINS: Chain[] = ['substrate', 'ethereum', 'solana']

--- a/client/src/lib/auth/registry.ts
+++ b/client/src/lib/auth/registry.ts
@@ -1,0 +1,19 @@
+/**
+ * Wallet provider registry. The Solana provider is added in Phase C.
+ */
+
+import type { Chain, WalletProvider } from './types'
+import { substrateProvider } from './substrateProvider'
+import { ethereumProvider } from './ethereumProvider'
+
+const providers: Partial<Record<Chain, WalletProvider>> = {
+  substrate: substrateProvider,
+  ethereum: ethereumProvider,
+}
+
+export function getProvider(chain: Chain): WalletProvider | undefined {
+  return providers[chain]
+}
+
+/** Chains offered in the sign-in UI, in display order. */
+export const ALL_CHAINS: Chain[] = ['substrate', 'ethereum']

--- a/client/src/lib/auth/solanaProvider.ts
+++ b/client/src/lib/auth/solanaProvider.ts
@@ -1,0 +1,102 @@
+/**
+ * Solana (Sign-In With Solana) wallet provider.
+ *
+ * Uses the injected `window.solana` wallet (Phantom and compatible wallets).
+ * The sign-in message is a fixed SIWE-style plaintext signed via `signMessage`
+ * (ed25519); the server's solana verifier parses the same format.
+ */
+
+import bs58 from 'bs58'
+import type { WalletProvider, WalletAccount, SignParams } from './types'
+import { encodeAuthPayload } from './types'
+
+interface SolanaWallet {
+  isPhantom?: boolean
+  connect(opts?: { onlyIfTrusted?: boolean }): Promise<{ publicKey: { toString(): string } }>
+  signMessage(message: Uint8Array, encoding?: string): Promise<{ signature: Uint8Array }>
+}
+
+function getWallet(): SolanaWallet | null {
+  if (typeof window === 'undefined') return null
+  return (window as unknown as { solana?: SolanaWallet }).solana || null
+}
+
+/**
+ * Build the fixed Solana sign-in message. Must stay byte-for-byte in sync with
+ * `parseSolanaMessage` in server/api/auth/verifiers/solana.verifier.js.
+ */
+function buildSignInMessage(params: {
+  domain: string
+  address: string
+  statement: string
+  uri: string
+  nonce: string
+  issuedAt: string
+  expirationTime: string
+}): string {
+  return [
+    `${params.domain} wants you to sign in with your Solana account:`,
+    params.address,
+    '',
+    params.statement,
+    '',
+    `URI: ${params.uri}`,
+    'Version: 1',
+    `Nonce: ${params.nonce}`,
+    `Issued At: ${params.issuedAt}`,
+    `Expiration Time: ${params.expirationTime}`,
+  ].join('\n')
+}
+
+export const solanaProvider: WalletProvider = {
+  chain: 'solana',
+  label: 'Solana',
+
+  isAvailable(): boolean {
+    return !!getWallet()
+  },
+
+  async connect(): Promise<WalletAccount[]> {
+    const wallet = getWallet()
+    if (!wallet) {
+      throw new Error('No Solana wallet found. Please install Phantom.')
+    }
+    const { publicKey } = await wallet.connect()
+    const address = publicKey.toString()
+    return [
+      {
+        chain: 'solana' as const,
+        address,
+        label: `${address.slice(0, 4)}…${address.slice(-4)}`,
+      },
+    ]
+  },
+
+  async signIn({ account, statement }: SignParams): Promise<string> {
+    const wallet = getWallet()
+    if (!wallet) {
+      throw new Error('No Solana wallet found.')
+    }
+
+    const now = new Date()
+    const message = buildSignInMessage({
+      domain: window.location.hostname,
+      address: account.address,
+      statement,
+      uri: window.location.origin,
+      nonce: Math.random().toString(36).slice(2),
+      issuedAt: now.toISOString(),
+      // Short-lived — the server rejects expired sign-in messages.
+      expirationTime: new Date(now.getTime() + 10 * 60 * 1000).toISOString(),
+    })
+
+    const { signature } = await wallet.signMessage(new TextEncoder().encode(message), 'utf8')
+
+    return encodeAuthPayload({
+      chain: 'solana',
+      message,
+      signature: bs58.encode(signature),
+      address: account.address,
+    })
+  },
+}

--- a/client/src/lib/auth/substrateProvider.ts
+++ b/client/src/lib/auth/substrateProvider.ts
@@ -1,0 +1,75 @@
+/**
+ * Substrate (SIWS — Sign-In With Substrate) wallet provider.
+ *
+ * Wraps the Polkadot-JS extension API. Heavy `@polkadot/*` modules are loaded
+ * dynamically so they stay out of the initial bundle. The injector is
+ * re-acquired on every `signIn` (it does not survive a page reload), so
+ * `WalletAccount` only needs to carry the serializable extension `source` id.
+ */
+
+import type { WalletProvider, WalletAccount, SignParams } from './types'
+import { encodeAuthPayload } from './types'
+
+export const substrateProvider: WalletProvider = {
+  chain: 'substrate',
+  label: 'Polkadot',
+
+  isAvailable() {
+    return (
+      typeof window !== 'undefined' &&
+      !!window.injectedWeb3 &&
+      Object.keys(window.injectedWeb3).length > 0
+    )
+  },
+
+  async connect(): Promise<WalletAccount[]> {
+    const { web3Enable, web3Accounts } = await import('@polkadot/extension-dapp')
+    const extensions = await web3Enable('Stadium')
+    if (!extensions.length) {
+      throw new Error('No Polkadot extension authorization given.')
+    }
+    const accounts = await web3Accounts()
+    if (!accounts.length) {
+      throw new Error('No accounts found in the Polkadot extension.')
+    }
+    return accounts.map((account) => ({
+      chain: 'substrate' as const,
+      address: account.address,
+      label: account.meta.name || undefined,
+      source: account.meta.source,
+    }))
+  },
+
+  async signIn({ account, statement }: SignParams): Promise<string> {
+    const { SiwsMessage } = await import('@talismn/siws')
+    const { web3Enable, web3FromSource } = await import('@polkadot/extension-dapp')
+
+    await web3Enable('Stadium')
+    const injector = await web3FromSource(account.source || 'polkadot-js')
+    const signRaw = injector?.signer?.signRaw
+    if (!signRaw) {
+      throw new Error('Wallet does not support message signing')
+    }
+
+    const siws = new SiwsMessage({
+      domain: window.location.hostname,
+      uri: window.location.origin,
+      address: account.address,
+      nonce: Math.random().toString(36).slice(2),
+      statement,
+    })
+    const message = siws.prepareMessage()
+    const { signature } = await signRaw({
+      address: account.address,
+      data: message,
+      type: 'bytes',
+    })
+
+    return encodeAuthPayload({
+      chain: 'substrate',
+      message,
+      signature,
+      address: account.address,
+    })
+  },
+}

--- a/client/src/lib/auth/types.ts
+++ b/client/src/lib/auth/types.ts
@@ -1,0 +1,53 @@
+/**
+ * Multi-chain sign-in types.
+ *
+ * A `WalletProvider` wraps one wallet ecosystem (Substrate, Ethereum, Solana)
+ * behind a uniform interface. The signed result is the base64 `x-siws-auth`
+ * payload — `base64(JSON.stringify({ chain, message, signature, address }))` —
+ * which the server's per-chain verifier validates.
+ */
+
+export type Chain = 'substrate' | 'ethereum' | 'solana';
+
+export interface WalletAccount {
+  chain: Chain;
+  address: string;
+  /** Human-readable label (extension account name, or a truncated address). */
+  label?: string;
+  /**
+   * Substrate only: the injected extension source id (e.g. "polkadot-js").
+   * Kept so the injector can be re-acquired after a page reload. Serializable
+   * — `WalletAccount` is persisted to sessionStorage.
+   */
+  source?: string;
+}
+
+export interface SignParams {
+  account: WalletAccount;
+  /** The human-readable statement the wallet shows the user (see siwsUtils). */
+  statement: string;
+}
+
+export interface AuthPayload {
+  chain: Chain;
+  message: string;
+  signature: string;
+  address: string;
+}
+
+export interface WalletProvider {
+  chain: Chain;
+  /** Display name for the chain in the picker UI. */
+  label: string;
+  /** Best-effort sync check that the wallet extension is present. */
+  isAvailable(): boolean;
+  /** Trigger the extension authorization prompt; resolve with its accounts. */
+  connect(): Promise<WalletAccount[]>;
+  /** Build the chain's sign-in message, request a signature, return the header. */
+  signIn(params: SignParams): Promise<string>;
+}
+
+/** Encode a signed payload into the base64 `x-siws-auth` header value. */
+export function encodeAuthPayload(payload: AuthPayload): string {
+  return btoa(JSON.stringify(payload));
+}

--- a/client/src/lib/auth/useWalletAuth.ts
+++ b/client/src/lib/auth/useWalletAuth.ts
@@ -1,0 +1,148 @@
+/**
+ * useWalletAuth — multi-chain wallet connection + signing for Stadium.
+ *
+ * Owns the selected chain, the connected account, and session restore. The
+ * connecting page decides what the account is allowed to do (e.g. admin
+ * gating) — this hook is identity-agnostic.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import type { Chain, WalletAccount } from './types'
+import { getProvider } from './registry'
+import { generateSiwsStatement, type SiwsContext } from '@/lib/siwsUtils'
+
+const SESSION_KEY = 'stadium_wallet_session_v2'
+
+export interface WalletAuth {
+  chain: Chain
+  setChain: (chain: Chain) => void
+  account: WalletAccount | null
+  accounts: WalletAccount[]
+  isConnecting: boolean
+  error: string
+  /** Whether the wallet extension for the selected chain is detected. */
+  isAvailable: boolean
+  /** Trigger the extension prompt; resolves with the wallet's accounts. */
+  connect: () => Promise<WalletAccount[]>
+  /** Mark an account as the active session (persists to sessionStorage). */
+  selectAccount: (account: WalletAccount) => void
+  /** Sign an action; resolves with the base64 `x-siws-auth` header value. */
+  signAction: (action: SiwsContext['action'], context?: Partial<SiwsContext>) => Promise<string>
+  disconnect: () => void
+}
+
+export function useWalletAuth(): WalletAuth {
+  const [chain, setChain] = useState<Chain>('substrate')
+  const [account, setAccount] = useState<WalletAccount | null>(null)
+  const [accounts, setAccounts] = useState<WalletAccount[]>([])
+  const [isConnecting, setIsConnecting] = useState(false)
+  const [error, setError] = useState('')
+  const [isAvailable, setIsAvailable] = useState(false)
+
+  // Restore a previous session (survives page reloads within the tab).
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem(SESSION_KEY)
+      if (raw) {
+        const parsed = JSON.parse(raw) as WalletAccount
+        if (parsed?.chain && parsed?.address) {
+          setAccount(parsed)
+          setChain(parsed.chain)
+        } else {
+          sessionStorage.removeItem(SESSION_KEY)
+        }
+      }
+    } catch {
+      sessionStorage.removeItem(SESSION_KEY)
+    }
+  }, [])
+
+  // Poll for the selected chain's wallet — extensions inject asynchronously.
+  useEffect(() => {
+    let cancelled = false
+    let attempts = 0
+    const provider = getProvider(chain)
+
+    const check = () => {
+      if (cancelled) return
+      if (provider?.isAvailable()) {
+        setIsAvailable(true)
+        return
+      }
+      if (++attempts >= 10) {
+        setIsAvailable(false)
+        return
+      }
+      setTimeout(check, 500)
+    }
+
+    setIsAvailable(provider?.isAvailable() ?? false)
+    if (!provider?.isAvailable()) check()
+    return () => {
+      cancelled = true
+    }
+  }, [chain])
+
+  const connect = useCallback(async (): Promise<WalletAccount[]> => {
+    setIsConnecting(true)
+    setError('')
+    try {
+      const provider = getProvider(chain)
+      if (!provider) throw new Error(`Unsupported sign-in chain: ${chain}`)
+      const found = await provider.connect()
+      setAccounts(found)
+      return found
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Wallet connection failed')
+      throw e
+    } finally {
+      setIsConnecting(false)
+    }
+  }, [chain])
+
+  const selectAccount = useCallback((selected: WalletAccount) => {
+    setAccount(selected)
+    setChain(selected.chain)
+    try {
+      sessionStorage.setItem(SESSION_KEY, JSON.stringify(selected))
+    } catch {
+      /* sessionStorage unavailable — session simply won't persist */
+    }
+  }, [])
+
+  const signAction = useCallback(
+    async (action: SiwsContext['action'], context?: Partial<SiwsContext>): Promise<string> => {
+      if (!account) throw new Error('Wallet not connected')
+      const provider = getProvider(account.chain)
+      if (!provider) throw new Error(`Unsupported sign-in chain: ${account.chain}`)
+      const statement = generateSiwsStatement({ action, ...context })
+      return provider.signIn({ account, statement })
+    },
+    [account]
+  )
+
+  const disconnect = useCallback(() => {
+    setAccount(null)
+    setAccounts([])
+    setError('')
+    try {
+      sessionStorage.removeItem(SESSION_KEY)
+    } catch {
+      /* ignore */
+    }
+  }, [])
+
+  return {
+    chain,
+    setChain,
+    account,
+    accounts,
+    isConnecting,
+    error,
+    isAvailable,
+    connect,
+    selectAccount,
+    signAction,
+    disconnect,
+  }
+}

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -1,17 +1,48 @@
-import { addressInList } from './addressUtils'
-
-// Get admin addresses from environment variable
-const adminAddressesEnv = import.meta.env.VITE_ADMIN_ADDRESSES || ''
-
-export const ADMIN_ADDRESSES = adminAddressesEnv
-  .split(',')
-  .map(addr => addr.trim())
-  .filter(addr => addr.length > 0)
+import { addressesEqual, type AddrChain } from './addressUtils'
 
 /**
- * Check if wallet address has admin access.
- * Compares decoded public keys so different SS58 prefixes still match.
+ * Admin wallet configuration.
+ *
+ * `VITE_ADMIN_ADDRESSES` is a comma-separated list. Each entry is either
+ * `chain:address` or a bare address (bare ⇒ substrate, so existing config
+ * keeps working). Example:
+ *   VITE_ADMIN_ADDRESSES=5Grw...,ethereum:0xAbC...
  */
-export const isAdmin = (walletAddress?: string): boolean => {
-  return addressInList(walletAddress, ADMIN_ADDRESSES)
+
+export interface AdminEntry {
+  chain: AddrChain
+  address: string
+}
+
+const CHAINS: AddrChain[] = ['substrate', 'ethereum', 'solana']
+
+function parseEntry(raw: string): AdminEntry | null {
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  const colon = trimmed.indexOf(':')
+  if (colon > 0) {
+    const tag = trimmed.slice(0, colon).toLowerCase() as AddrChain
+    if (CHAINS.includes(tag)) {
+      return { chain: tag, address: trimmed.slice(colon + 1).trim() }
+    }
+  }
+  return { chain: 'substrate', address: trimmed }
+}
+
+const adminAddressesEnv = import.meta.env.VITE_ADMIN_ADDRESSES || ''
+
+export const ADMIN_ADDRESSES: AdminEntry[] = adminAddressesEnv
+  .split(',')
+  .map(parseEntry)
+  .filter((entry): entry is AdminEntry => entry !== null)
+
+/**
+ * Check if a wallet address has admin access on the given chain.
+ * An address only matches an admin entry on the same chain.
+ */
+export const isAdmin = (walletAddress?: string, chain: AddrChain = 'substrate'): boolean => {
+  if (!walletAddress) return false
+  return ADMIN_ADDRESSES.some(
+    entry => entry.chain === chain && addressesEqual(entry.address, walletAddress, chain)
+  )
 }

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -12,21 +12,9 @@ import {
 import {
   Card,
   CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { Label } from "@/components/ui/label";
-import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table";
 import {
   Select,
   SelectContent,
@@ -39,8 +27,9 @@ import { EmptyState } from "@/components/EmptyState";
 import { api } from "@/lib/api";
 import { useMemo } from "react";
 import { isAdmin, ADMIN_ADDRESSES } from "@/lib/constants";
-import { SiwsMessage } from '@talismn/siws';
-import { generateSiwsStatement, type SiwsContext } from '@/lib/siwsUtils';
+import { useWalletAuth } from "@/lib/auth/useWalletAuth";
+import { getProvider } from "@/lib/auth/registry";
+import { ChainPicker } from "@/components/auth/ChainPicker";
 import { M2ProjectsTable } from "@/components/admin/M2ProjectsTable";
 import { WinnersTable } from "@/components/admin/WinnersTable";
 import { ProgramsTable } from "@/components/admin/ProgramsTable";
@@ -52,41 +41,12 @@ import { CreateProjectModal } from "@/components/admin/CreateProjectModal";
 const formatAddress = (address = "") =>
   `${address.slice(0, 6)}...${address.slice(-4)}`;
 
-type M2Project = {
-  id: string;
-  projectName: string;
-  teamMembers?: Array<{
-    name: string;
-    walletAddress?: string;
-    role?: string;
-    twitter?: string;
-    github?: string;
-    linkedin?: string;
-  }>;
-  m2Status?: 'building' | 'under_review' | 'completed';
-  finalSubmission?: {
-    repoUrl: string;
-    demoUrl: string;
-    docsUrl: string;
-    summary?: string;
-    submittedDate: string;
-  };
-  submittedDate?: string;
-};
-
 const AdminPage = () => {
   const BYPASS_ADMIN_CHECK = false;
-  
-  const [walletState, setWalletState] = useState({
-    isExtensionAvailable: false,
-    isConnected: false,
-    isConnecting: false,
-    accounts: [] as any[],
-    selectedAccount: null as any | null,
-    error: "",
-    errorData: null as any | null,
-    injector: null as any | null,
-  });
+
+  const auth = useWalletAuth();
+  // Admin-not-found details (admin gating is page logic, not the wallet hook's).
+  const [errorData, setErrorData] = useState<any | null>(null);
 
   const [isAuthenticated, setIsAuthenticated] = useState(BYPASS_ADMIN_CHECK);
   const [projects, setProjects] = useState<any[]>([]);
@@ -102,7 +62,7 @@ const AdminPage = () => {
   const loadData = async () => {
     setLoading(true);
     try {
-      // Fetch ALL projects from MongoDB via API (no pagination)
+      // Fetch ALL projects from the API (no pagination)
       const response = await api.getProjects({ limit: 1000 });
       const projectsData = response?.data || [];
       setProjects(projectsData);
@@ -118,46 +78,22 @@ const AdminPage = () => {
     }
   };
 
+  // Bypass mode loads data directly without a wallet.
   useEffect(() => {
-    // TESTING MODE: Skip wallet check and directly load data
     if (BYPASS_ADMIN_CHECK) {
       loadData();
-      return;
     }
-
-    checkExtension();
-
-    // Restore session if admin account exists in sessionStorage
-    const restoreSession = async () => {
-      const sessionAccount = sessionStorage.getItem("admin_session_account");
-      if (sessionAccount) {
-        const account = JSON.parse(sessionAccount);
-        if (isAdmin(account.address)) {
-          try {
-            const { web3Enable, web3FromSource } = await import("@polkadot/extension-dapp");
-            await web3Enable("Hackathonia Admin");
-            const injector = await web3FromSource(account.meta.source);
-            setWalletState((prev) => ({
-              ...prev,
-              selectedAccount: account,
-              isConnected: true,
-              injector,
-            }));
-          } catch {
-            // If injector restore fails, still allow read-only session
-            setWalletState((prev) => ({
-              ...prev,
-              selectedAccount: account,
-              isConnected: true,
-            }));
-          }
-          setIsAuthenticated(true);
-        }
-      }
-    };
-    restoreSession();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // Authenticate once an admin wallet is connected (covers restored sessions).
+  useEffect(() => {
+    if (BYPASS_ADMIN_CHECK) return;
+    if (auth.account && isAdmin(auth.account.address, auth.account.chain)) {
+      setIsAuthenticated(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [auth.account]);
 
   useEffect(() => {
     if (isAuthenticated && !BYPASS_ADMIN_CHECK) {
@@ -168,132 +104,30 @@ const AdminPage = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isAuthenticated]);
 
-  const checkExtension = async () => {
-    try {
-      await waitForExtension();
-      setWalletState((prev) => ({
-        ...prev,
-        isExtensionAvailable: true,
-        error: "",
-      }));
-    } catch {
-      setWalletState((prev) => ({
-        ...prev,
-        isExtensionAvailable: false,
-        error: "Polkadot-JS extension not found. Please install it first.",
-      }));
-    }
-  };
-
-  const waitForExtension = () =>
-    new Promise((resolve, reject) => {
-      let attempts = 0;
-      const maxAttempts = 10;
-      const interval = setInterval(() => {
-        if (
-          window.injectedWeb3 &&
-          Object.keys(window.injectedWeb3).length > 0
-        ) {
-          clearInterval(interval);
-          resolve();
-        } else if (++attempts >= maxAttempts) {
-          clearInterval(interval);
-          reject();
-        }
-      }, 500);
-    });
-
   const connectWallet = async () => {
-    if (!walletState.isExtensionAvailable) return;
-
-    setWalletState((prev) => ({ ...prev, isConnecting: true, error: "" }));
-
+    setErrorData(null);
     try {
-      const { web3Enable, web3Accounts } = await import(
-        "@polkadot/extension-dapp"
-      );
-      const extensions = await web3Enable("Hackathonia Admin");
-      if (!extensions.length)
-        throw new Error("No extension authorization given.");
-
-      const allAccounts = await web3Accounts();
-      if (!allAccounts.length)
-        throw new Error("No accounts found in extension.");
-
-      // Check if admin account is available
-      const adminAccount = allAccounts.find(
-        (account) => isAdmin(account.address)
-      );
+      const found = await auth.connect();
+      const adminAccount = found.find((account) => isAdmin(account.address, account.chain));
 
       if (!adminAccount) {
-        // Store structured error data for better formatting
-        const errorData = {
+        setErrorData({
           message: "Admin account not found. Please ensure you have the correct admin account in your wallet.",
-          walletAddresses: allAccounts.map(a => a.address),
-          expectedAddresses: ADMIN_ADDRESSES,
-          isProduction: import.meta.env.PROD
-        };
-        throw errorData;
+          walletAddresses: found.map((a) => a.address),
+          expectedAddresses: ADMIN_ADDRESSES.filter((e) => e.chain === auth.chain).map((e) => e.address),
+          isProduction: import.meta.env.PROD,
+        });
+        return;
       }
 
-      setWalletState((prev) => ({
-        ...prev,
-        accounts: allAccounts,
-        isConnected: true,
-        isConnecting: false,
-      }));
-
-      // Auto-select admin account
-      selectAccount(adminAccount);
-    } catch (err: any) {
-      // Handle structured error data
-      if (err.walletAddresses && Array.isArray(err.walletAddresses)) {
-        setWalletState((prev) => ({
-          ...prev,
-          error: err.message || "Connection failed",
-          errorData: err,
-          isConnecting: false,
-        }));
-      } else {
-        setWalletState((prev) => ({
-          ...prev,
-          error: `Connection failed: ${err.message}`,
-          errorData: null,
-          isConnecting: false,
-        }));
-      }
-    }
-  };
-
-  const selectAccount = async (account) => {
-    try {
-      if (!isAdmin(account.address)) {
-        throw new Error(
-          "Unauthorized: Only admin account can access this panel."
-        );
-      }
-
-      const { web3FromSource } = await import("@polkadot/extension-dapp");
-      const injector = await web3FromSource(account.meta.source);
-
-      sessionStorage.setItem("admin_session_account", JSON.stringify(account));
-
-      setWalletState((prev) => ({
-        ...prev,
-        selectedAccount: account,
-        injector,
-      }));
+      auth.selectAccount(adminAccount);
       setIsAuthenticated(true);
-
       toast({
         title: "Admin Access Granted",
         description: "Successfully connected as admin.",
       });
-    } catch (err) {
-      setWalletState((prev) => ({
-        ...prev,
-        error: `Authentication failed: ${err.message}`,
-      }));
+    } catch {
+      // auth.error is already set by the wallet hook.
     }
   };
 
@@ -307,7 +141,7 @@ const AdminPage = () => {
     if (!selectedProject) return;
 
     try {
-      const authHeader = await signAdminAction('admin-action');
+      const authHeader = await auth.signAction('admin-action');
       const response = await fetch(`/api/m2-program/${selectedProject.id}/confirm-payment`, {
         method: 'POST',
         headers: {
@@ -323,8 +157,8 @@ const AdminPage = () => {
       if (!response.ok) {
         let errorMessage = 'Failed to confirm M1 payout';
         try {
-          const errorData = JSON.parse(responseText);
-          errorMessage = errorData.error || errorData.message || errorMessage;
+          const errData = JSON.parse(responseText);
+          errorMessage = errData.error || errData.message || errorMessage;
         } catch (e) {
           errorMessage = responseText || `HTTP ${response.status}: ${response.statusText}`;
         }
@@ -353,7 +187,7 @@ const AdminPage = () => {
     if (!selectedProject) return;
 
     try {
-      const authHeader = await signAdminAction('admin-action');
+      const authHeader = await auth.signAction('admin-action');
       const response = await fetch(`/api/m2-program/${selectedProject.id}/confirm-payment`, {
         method: 'POST',
         headers: {
@@ -369,8 +203,8 @@ const AdminPage = () => {
       if (!response.ok) {
         let errorMessage = 'Failed to confirm payment';
         try {
-          const errorData = JSON.parse(responseText);
-          errorMessage = errorData.error || errorData.message || errorMessage;
+          const errData = JSON.parse(responseText);
+          errorMessage = errData.error || errData.message || errorMessage;
         } catch (e) {
           // If JSON parsing fails, use the text as error message
           errorMessage = responseText || `HTTP ${response.status}: ${response.statusText}`;
@@ -397,52 +231,9 @@ const AdminPage = () => {
   };
 
   const handleLogout = () => {
-      setWalletState({
-        isExtensionAvailable: true,
-        isConnected: false,
-        isConnecting: false,
-        accounts: [],
-        selectedAccount: null,
-        error: "",
-        errorData: null,
-        injector: null,
-      });
+    auth.disconnect();
     setIsAuthenticated(false);
-    sessionStorage.removeItem("admin_session_account");
-  };
-
-  const signAdminAction = async (action: SiwsContext['action'] = 'admin-action'): Promise<string> => {
-    const account = walletState.selectedAccount;
-    let injector = walletState.injector;
-    if (!account) throw new Error('Wallet not connected');
-
-    // Re-acquire injector if missing (e.g. after session restore)
-    if (!injector) {
-      const { web3Enable, web3FromSource } = await import("@polkadot/extension-dapp");
-      await web3Enable("Hackathonia Admin");
-      injector = await web3FromSource(account.meta.source);
-      setWalletState(prev => ({ ...prev, injector }));
-    }
-
-    const siws = new SiwsMessage({
-      domain: window.location.hostname,
-      uri: window.location.origin,
-      address: account.address,
-      nonce: Math.random().toString(36).slice(2),
-      statement: generateSiwsStatement({ action }),
-    });
-
-    const signRaw = injector?.signer?.signRaw;
-    if (!signRaw) throw new Error('Wallet does not support message signing');
-
-    const message = siws.prepareMessage();
-    const { signature } = await signRaw({
-      address: account.address,
-      data: message,
-      type: 'bytes',
-    });
-
-    return btoa(JSON.stringify({ message, signature, address: account.address }));
+    setErrorData(null);
   };
 
   // Filter projects under review for M2
@@ -450,16 +241,10 @@ const AdminPage = () => {
     return projects.filter((p) => p.m2Status === 'under_review');
   }, [projects]);
 
-  // Filter M2 projects
-  const m2Projects = useMemo(() => 
-    projects.filter(p => p.m2Status),
-    [projects]
-  );
-
   // Sort projects based on selected sort option
   const sortedProjects = useMemo(() => {
     const projectsCopy = [...projects];
-    
+
     switch (sortBy) {
       case 'eventStartedAt':
         return projectsCopy.sort((a, b) => {
@@ -468,7 +253,7 @@ const AdminPage = () => {
           return dateB - dateA; // Newest first
         });
       case 'projectName':
-        return projectsCopy.sort((a, b) => 
+        return projectsCopy.sort((a, b) =>
           (a.projectName || '').localeCompare(b.projectName || '')
         );
       case 'newest':
@@ -489,13 +274,13 @@ const AdminPage = () => {
     }
 
     try {
-      const authHeader = await signAdminAction('approve-project');
+      const authHeader = await auth.signAction('approve-project');
       await api.webzeroApprove(projectId, authHeader);
-      
+
       // Update local state
       setProjects((prev) =>
-        prev.map((p) => 
-          p.id === projectId 
+        prev.map((p) =>
+          p.id === projectId
             ? { ...p, m2Status: 'completed' as const }
             : p
         )
@@ -505,7 +290,7 @@ const AdminPage = () => {
         title: "M2 Approved!",
         description: "Payment will be processed.",
       });
-      
+
       loadData();
     } catch (error) {
       const err = error as Error;
@@ -530,14 +315,14 @@ const AdminPage = () => {
     }
 
     try {
-      const authHeader = await signAdminAction('admin-action');
+      const authHeader = await auth.signAction('admin-action');
       await api.updateProjectStatus(projectId, newStatus, authHeader);
-      
+
       toast({
         title: 'Status Updated',
         description: `Status updated to ${statusLabels[newStatus]}`,
       });
-      
+
       // Refresh projects list
       await loadData();
     } catch (error) {
@@ -574,22 +359,26 @@ const AdminPage = () => {
               Connect your admin wallet to access the management panel.
             </p>
 
-            {walletState.error && (
+            <div className="flex justify-center mb-6">
+              <ChainPicker value={auth.chain} onChange={auth.setChain} />
+            </div>
+
+            {(errorData || auth.error) && (
               <div className="space-y-4 mb-6">
                 <div className="flex items-start gap-3 p-4 rounded-lg bg-destructive/10 border border-destructive/20">
                   <AlertCircle className="w-5 h-5 text-destructive flex-shrink-0 mt-0.5" />
                   <div className="flex-1 space-y-3">
                     <p className="text-destructive text-sm font-medium">
-                      {walletState.error}
+                      {errorData?.message || auth.error}
                     </p>
-                    
-                    {walletState.errorData && (
+
+                    {errorData && (
                       <div className="space-y-3 pt-2 border-t border-destructive/20">
-                        {walletState.errorData.walletAddresses && walletState.errorData.walletAddresses.length > 0 && (
+                        {errorData.walletAddresses && errorData.walletAddresses.length > 0 && (
                           <div>
                             <p className="text-xs font-semibold text-destructive/80 mb-2">Your wallet addresses:</p>
                             <ul className="space-y-1.5">
-                              {walletState.errorData.walletAddresses.map((addr: string, idx: number) => (
+                              {errorData.walletAddresses.map((addr: string, idx: number) => (
                                 <li key={idx} className="text-xs text-destructive/70 font-mono break-all bg-destructive/5 p-2 rounded border border-destructive/10">
                                   {addr}
                                 </li>
@@ -597,12 +386,12 @@ const AdminPage = () => {
                             </ul>
                           </div>
                         )}
-                        
-                        {walletState.errorData.expectedAddresses && walletState.errorData.expectedAddresses.length > 0 ? (
+
+                        {errorData.expectedAddresses && errorData.expectedAddresses.length > 0 ? (
                           <div>
                             <p className="text-xs font-semibold text-destructive/80 mb-2">Expected admin addresses:</p>
                             <ul className="space-y-1.5">
-                              {walletState.errorData.expectedAddresses.map((addr: string, idx: number) => (
+                              {errorData.expectedAddresses.map((addr: string, idx: number) => (
                                 <li key={idx} className="text-xs text-destructive/70 font-mono break-all bg-destructive/5 p-2 rounded border border-destructive/10">
                                   {addr}
                                 </li>
@@ -612,20 +401,20 @@ const AdminPage = () => {
                         ) : (
                           <div className="bg-yellow-500/10 border border-yellow-500/20 rounded p-3">
                             <p className="text-xs text-yellow-600 dark:text-yellow-400 font-medium">
-                              ⚠️ No admin addresses configured
+                              ⚠️ No admin addresses configured for this chain
                             </p>
                             <p className="text-xs text-yellow-600/80 dark:text-yellow-400/80 mt-1">
-                              {walletState.errorData.isProduction 
+                              {errorData.isProduction
                                 ? "Set VITE_ADMIN_ADDRESSES in Vercel environment variables and redeploy."
                                 : "Add VITE_ADMIN_ADDRESSES to your .env file and restart the dev server."}
                             </p>
                           </div>
                         )}
-                        
-                        {walletState.errorData.expectedAddresses && walletState.errorData.expectedAddresses.length > 0 && (
+
+                        {errorData.expectedAddresses && errorData.expectedAddresses.length > 0 && (
                           <div className="bg-muted/50 border border-border rounded p-3 mt-3">
                             <p className="text-xs text-muted-foreground">
-                              {walletState.errorData.isProduction ? (
+                              {errorData.isProduction ? (
                                 <>
                                   <strong>To fix:</strong> Add one of your wallet addresses to <code className="bg-background px-1 py-0.5 rounded text-[10px]">VITE_ADMIN_ADDRESSES</code> in{" "}
                                   <strong>Vercel Dashboard → Settings → Environment Variables</strong> (Production), then redeploy.
@@ -647,12 +436,10 @@ const AdminPage = () => {
 
             <Button
               onClick={connectWallet}
-              disabled={
-                !walletState.isExtensionAvailable || walletState.isConnecting
-              }
+              disabled={!auth.isAvailable || auth.isConnecting}
               className="w-full"
             >
-              {walletState.isConnecting ? (
+              {auth.isConnecting ? (
                 <>
                   <Loader2 className="h-4 w-4 mr-2 animate-spin" />
                   Connecting...
@@ -665,9 +452,9 @@ const AdminPage = () => {
               )}
             </Button>
 
-            {!walletState.isExtensionAvailable && (
+            {!auth.isAvailable && (
               <p className="mt-3 text-sm text-muted-foreground">
-                Polkadot extension not detected
+                {getProvider(auth.chain)?.label || "Wallet"} extension not detected
               </p>
             )}
           </CardContent>
@@ -705,7 +492,7 @@ const AdminPage = () => {
           </p>
         </div>
         <div className="flex items-center gap-4">
-          {isAuthenticated && !!walletState.selectedAccount?.address && (
+          {isAuthenticated && !!auth.account?.address && (
             <Button
               variant="outline"
               size="sm"
@@ -723,8 +510,8 @@ const AdminPage = () => {
             🧪 Test Payment
           </Button>
           <span className="text-sm text-muted-foreground">
-            {walletState.selectedAccount?.meta.name || "Admin"} •{" "}
-            {formatAddress(walletState.selectedAccount?.address || "")}
+            {auth.account?.label || "Admin"} •{" "}
+            {formatAddress(auth.account?.address || "")}
           </span>
           <Button variant="outline" onClick={handleLogout}>
             <LogOut className="h-4 w-4 mr-2" />
@@ -736,7 +523,7 @@ const AdminPage = () => {
       {/* Pending Review Section */}
       <div className="glass-panel rounded-lg p-6 mb-6">
         <h2 className="text-2xl font-heading mb-4">Pending Review</h2>
-        
+
         {projectsUnderReview.length === 0 ? (
           <EmptyState
             title="No projects pending review"
@@ -754,14 +541,14 @@ const AdminPage = () => {
                     </p>
                   </div>
                 </div>
-                
+
                 <div className="space-y-2 mb-4">
                   <h4 className="text-sm font-medium font-heading">Deliverables:</h4>
                   <div className="flex gap-4 text-sm flex-wrap">
                     {project.finalSubmission?.repoUrl && (
-                      <a 
-                        href={project.finalSubmission.repoUrl} 
-                        target="_blank" 
+                      <a
+                        href={project.finalSubmission.repoUrl}
+                        target="_blank"
                         rel="noopener noreferrer"
                         className="text-primary hover:underline"
                       >
@@ -769,9 +556,9 @@ const AdminPage = () => {
                       </a>
                     )}
                     {project.finalSubmission?.demoUrl && (
-                      <a 
-                        href={project.finalSubmission.demoUrl} 
-                        target="_blank" 
+                      <a
+                        href={project.finalSubmission.demoUrl}
+                        target="_blank"
                         rel="noopener noreferrer"
                         className="text-primary hover:underline"
                       >
@@ -779,9 +566,9 @@ const AdminPage = () => {
                       </a>
                     )}
                     {project.finalSubmission?.docsUrl && (
-                      <a 
-                        href={project.finalSubmission.docsUrl} 
-                        target="_blank" 
+                      <a
+                        href={project.finalSubmission.docsUrl}
+                        target="_blank"
                         rel="noopener noreferrer"
                         className="text-primary hover:underline"
                       >
@@ -789,9 +576,9 @@ const AdminPage = () => {
                       </a>
                     )}
                     {!project.finalSubmission && project.gitLink && (
-                      <a 
-                        href={project.gitLink} 
-                        target="_blank" 
+                      <a
+                        href={project.gitLink}
+                        target="_blank"
                         rel="noopener noreferrer"
                         className="text-primary hover:underline"
                       >
@@ -799,9 +586,9 @@ const AdminPage = () => {
                       </a>
                     )}
                     {!project.finalSubmission && project.demoLink && (
-                      <a 
-                        href={project.demoLink} 
-                        target="_blank" 
+                      <a
+                        href={project.demoLink}
+                        target="_blank"
                         rel="noopener noreferrer"
                         className="text-primary hover:underline"
                       >
@@ -810,13 +597,13 @@ const AdminPage = () => {
                     )}
                   </div>
                 </div>
-                
+
                 {project.finalSubmission?.summary && (
                   <p className="text-sm mb-4 whitespace-pre-line leading-relaxed">{project.finalSubmission.summary}</p>
                 )}
-                
+
                 <div className="flex gap-2 flex-wrap">
-                  <Button 
+                  <Button
                     onClick={() => {
                       setSelectedProject(project);
                       setShowPayoutModal(true);
@@ -882,8 +669,8 @@ const AdminPage = () => {
         <WinnersTable
           projects={projects}
           onRefresh={loadData}
-          connectedAddress={BYPASS_ADMIN_CHECK ? ADMIN_ADDRESSES[0] : walletState.selectedAccount?.address}
-          signAdminAction={signAdminAction}
+          connectedAddress={BYPASS_ADMIN_CHECK ? ADMIN_ADDRESSES[0]?.address : auth.account?.address}
+          signAdminAction={auth.signAction}
         />
       </section>
 
@@ -919,7 +706,7 @@ const AdminPage = () => {
       </section>
 
       <section className="mb-8">
-        <ProgramsTable connectedAddress={walletState.selectedAccount?.address} />
+        <ProgramsTable connectedAddress={auth.account?.address} />
       </section>
 
       {/* M1 Payout Modal */}
@@ -952,7 +739,7 @@ const AdminPage = () => {
       <CreateProjectModal
         open={showCreateProjectModal}
         onOpenChange={setShowCreateProjectModal}
-        connectedAddress={walletState.selectedAccount?.address}
+        connectedAddress={auth.account?.address}
         onSaved={(project) => setProjects((prev) => [project, ...prev])}
       />
       </div>

--- a/client/src/pages/ProjectDetailsPage.tsx
+++ b/client/src/pages/ProjectDetailsPage.tsx
@@ -28,9 +28,7 @@ import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import { api } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
-import { web3Enable, web3Accounts, web3FromSource } from '@polkadot/extension-dapp';
-import { SiwsMessage } from '@talismn/siws';
-import { generateSiwsStatement } from '@/lib/siwsUtils';
+import { useWalletAuth } from '@/lib/auth/useWalletAuth';
 import { Navigation } from "@/components/Navigation";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { getCurrentProgramWeek } from "@/lib/projectUtils";
@@ -149,11 +147,10 @@ const ProjectDetailsPage = () => {
   const [notFound, setNotFound] = useState(false);
   const { toast } = useToast();
   const [copied, setCopied] = useState(false);
-  const [connectedAddress, setConnectedAddress] = useState<string | null>(null);
+  const auth = useWalletAuth();
+  const connectedAddress = auth.account?.address ?? null;
   const [editMode, setEditMode] = useState<false | 'updateAddress' | 'edit'>(false);
   const [editFields, setEditFields] = useState<Partial<ApiProject>>({});
-  const [registerAddress, setRegisterAddress] = useState('');
-  const [registerSig, setRegisterSig] = useState('');
   const ALLOWED_CATEGORIES = [
     "Gaming",
     "DeFi",
@@ -371,29 +368,11 @@ const ProjectDetailsPage = () => {
   const saveEdit = async () => {
     try {
       if (project && Array.isArray(editFields.categories)) {
-        // Sign SIWS and persist categories via PATCH (protected route)
-        await web3Enable('Hackathonia');
-        const accounts = await web3Accounts();
-        const account = accounts.find(a => a.address === connectedAddress) || accounts[0];
-        if (!account) throw new Error('No wallet found');
-        const siws = new SiwsMessage({
-          domain: window.location.hostname,
-          uri: window.location.origin,
-          address: account.address,
-          nonce: Math.random().toString(36).slice(2),
-          statement: generateSiwsStatement({
-            action: 'update-project',
-            projectTitle: project.projectName,
-            projectId: project.id
-          }),
+        // Sign in and persist categories via PATCH (protected route)
+        const authHeader = await auth.signAction('update-project', {
+          projectTitle: project.projectName,
+          projectId: project.id,
         });
-        const injector = await web3FromSource(account.meta.source);
-        const signed = await siws.sign(injector) as unknown as { signature: string; message?: string };
-        const messageStr = typeof signed.message === 'string' && signed.message
-          ? signed.message
-          : (siws as unknown as { toString: () => string }).toString();
-        const authHeader = btoa(JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address }));
-
         await api.updateProjectCategories(project.id, editFields.categories as string[], authHeader);
       }
 
@@ -409,44 +388,17 @@ const ProjectDetailsPage = () => {
 
   // Wallet connect logic
   const connectWallet = async () => {
-    await web3Enable('Hackathonia');
-    const accounts = await web3Accounts();
-    if (accounts.length > 0) {
-      // Prefer admin account if available, otherwise use first account
-      const adminAccount = accounts.find(a => checkIsAdmin(a.address));
-      setConnectedAddress(adminAccount ? adminAccount.address : accounts[0].address);
-    } else {
-      toast({ title: 'No wallet found', description: 'Please install Polkadot{.js} extension or Talisman.' });
-    }
-  };
-
-  const handleRegisterTeamAddress = async () => {
-    if (!registerAddress) {
-      toast({ title: 'Enter an address to register.' });
-      return;
-    }
     try {
-      const siws = new SiwsMessage({
-        domain: window.location.hostname,
-        uri: window.location.origin,
-        address: registerAddress,
-        nonce: Math.random().toString(36).slice(2),
-        statement: generateSiwsStatement({
-          action: 'register-address'
-        })
-      });
-      const accounts = await web3Accounts();
-      const account = accounts.find(a => a.address === registerAddress);
-      if (!account) {
-        toast({ title: 'Address not found in wallet.' });
+      const found = await auth.connect();
+      if (!found.length) {
+        toast({ title: 'No wallet found', description: 'Please install a wallet extension for the selected chain.' });
         return;
       }
-      const injector = await web3FromSource(account.meta.source);
-      const signed = await siws.sign(injector);
-      setRegisterSig(signed.signature);
-      toast({ title: 'Address registered (mock)', description: `Signature: ${signed.signature.slice(0, 16)}...` });
-    } catch (err: unknown) {
-      toast({ title: 'Signature failed', description: (err as Error)?.message || String(err) });
+      // Prefer an admin account if present, otherwise use the first account.
+      const adminAccount = found.find(a => checkIsAdmin(a.address, a.chain));
+      auth.selectAccount(adminAccount || found[0]);
+    } catch (e) {
+      toast({ title: 'Connection failed', description: (e as Error)?.message || 'Could not connect wallet.' });
     }
   };
 
@@ -460,14 +412,14 @@ const ProjectDetailsPage = () => {
 
   // Check if connected wallet is a team member
   const isTeamMember = useMemo(() => {
-    if (!connectedAddress || !project?.teamMembers) return false;
-    return addressInList(connectedAddress, project.teamMembers);
-  }, [connectedAddress, project?.teamMembers]);
+    if (!auth.account || !project?.teamMembers) return false;
+    return addressInList(auth.account.address, project.teamMembers, auth.account.chain);
+  }, [auth.account, project?.teamMembers]);
 
   // Check if connected wallet is an admin (use shared constants)
   const isAdmin = useMemo(() => {
-    return checkIsAdmin(connectedAddress);
-  }, [connectedAddress]);
+    return checkIsAdmin(auth.account?.address, auth.account?.chain);
+  }, [auth.account]);
 
   // Check if user can edit (admin or team member)
   const canEdit = isAdmin || isTeamMember;
@@ -490,29 +442,11 @@ const ProjectDetailsPage = () => {
     }
 
     try {
-      // Connect wallet and sign with SIWS
-      await web3Enable('Hackathonia');
-      const accounts = await web3Accounts();
-      const account = accounts.find(a => a.address === connectedAddress) || accounts[0];
-      if (!account) throw new Error("No wallet found");
-      
-      const siws = new SiwsMessage({
-        domain: window.location.hostname,
-        uri: window.location.origin,
-        address: account.address,
-        nonce: Math.random().toString(36).slice(2),
-        statement: generateSiwsStatement({
-          action: 'update-team',
-          projectTitle: project.projectName,
-          projectId: project.id
-        }),
+      // Sign in with the connected wallet
+      const authHeader = await auth.signAction('update-team', {
+        projectTitle: project.projectName,
+        projectId: project.id,
       });
-      const injector = await web3FromSource(account.meta.source);
-      const signed = await siws.sign(injector) as unknown as { signature: string; message?: string };
-      const messageStr = typeof signed.message === 'string' && signed.message
-        ? signed.message
-        : (siws as unknown as { toString: () => string }).toString();
-      const authHeader = btoa(JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address }));
 
       // Update team - convert to new API format
       await api.updateTeam(project.id, {
@@ -593,29 +527,11 @@ const ProjectDetailsPage = () => {
     }
 
     try {
-      // Connect wallet and sign with SIWS
-      await web3Enable('Hackathonia');
-      const accounts = await web3Accounts();
-      const account = accounts.find(a => a.address === connectedAddress) || accounts[0];
-      if (!account) throw new Error("No wallet found");
-      
-      const siws = new SiwsMessage({
-        domain: window.location.hostname,
-        uri: window.location.origin,
-        address: account.address,
-        nonce: Math.random().toString(36).slice(2),
-        statement: generateSiwsStatement({
-          action: 'update-project',
-          projectTitle: project.projectName,
-          projectId: project.id
-        }),
+      // Sign in with the connected wallet
+      const authHeader = await auth.signAction('update-project', {
+        projectTitle: project.projectName,
+        projectId: project.id,
       });
-      const injector = await web3FromSource(account.meta.source);
-      const signed = await siws.sign(injector) as unknown as { signature: string; message?: string };
-      const messageStr = typeof signed.message === 'string' && signed.message
-        ? signed.message
-        : (siws as unknown as { toString: () => string }).toString();
-      const authHeader = btoa(JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address }));
 
       // Update project details
       await api.updateProjectDetails(project.id, data, authHeader);
@@ -685,29 +601,11 @@ const ProjectDetailsPage = () => {
     }
 
     try {
-      // Connect wallet and sign with SIWS
-      await web3Enable('Hackathonia');
-      const accounts = await web3Accounts();
-      const account = accounts.find(a => a.address === connectedAddress) || accounts[0];
-      if (!account) throw new Error("No wallet found");
-      
-      const siws = new SiwsMessage({
-        domain: window.location.hostname,
-        uri: window.location.origin,
-        address: account.address,
-        nonce: Math.random().toString(36).slice(2),
-        statement: generateSiwsStatement({
-          action: 'update-team',
-          projectTitle: project.projectName,
-          projectId: project.id
-        }),
+      // Sign in with the connected wallet
+      const authHeader = await auth.signAction('update-team', {
+        projectTitle: project.projectName,
+        projectId: project.id,
       });
-      const injector = await web3FromSource(account.meta.source);
-      const signed = await siws.sign(injector) as unknown as { signature: string; message?: string };
-      const messageStr = typeof signed.message === 'string' && signed.message
-        ? signed.message
-        : (siws as unknown as { toString: () => string }).toString();
-      const authHeader = btoa(JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address }));
 
       // Update team and payout address via API
       await api.updateTeam(project.id, {
@@ -762,29 +660,11 @@ const ProjectDetailsPage = () => {
     }
 
     try {
-      // Connect wallet and sign with SIWS
-      await web3Enable('Hackathonia');
-      const accounts = await web3Accounts();
-      const account = accounts.find(a => a.address === connectedAddress) || accounts[0];
-      if (!account) throw new Error("No wallet found");
-      
-      const siws = new SiwsMessage({
-        domain: window.location.hostname,
-        uri: window.location.origin,
-        address: account.address,
-        nonce: Math.random().toString(36).slice(2),
-        statement: generateSiwsStatement({
-          action: 'submit-deliverable',
-          projectTitle: project.projectName,
-          projectId: project.id
-        }),
+      // Sign in with the connected wallet
+      const authHeader = await auth.signAction('submit-deliverable', {
+        projectTitle: project.projectName,
+        projectId: project.id,
       });
-      const injector = await web3FromSource(account.meta.source);
-      const signed = await siws.sign(injector) as unknown as { signature: string; message?: string };
-      const messageStr = typeof signed.message === 'string' && signed.message
-        ? signed.message
-        : (siws as unknown as { toString: () => string }).toString();
-      const authHeader = btoa(JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address }));
 
       await api.submitForReview(project.id, {
         repoUrl: ensureSubmissionUrl(data.repoUrl),
@@ -831,32 +711,10 @@ const ProjectDetailsPage = () => {
     }
 
     try {
-      await web3Enable('Hackathonia');
-      const accounts = await web3Accounts();
-      const account = accounts.find((a) => a.address === connectedAddress) || accounts[0];
-      if (!account) throw new Error('No wallet found');
-
-      const siws = new SiwsMessage({
-        domain: window.location.hostname,
-        uri: window.location.origin,
-        address: account.address,
-        nonce: Math.random().toString(36).slice(2),
-        statement: generateSiwsStatement({
-          action: 'submit-deliverable',
-          projectTitle: project.projectName,
-          projectId: project.id,
-        }),
+      const authHeader = await auth.signAction('submit-deliverable', {
+        projectTitle: project.projectName,
+        projectId: project.id,
       });
-      const injector = await web3FromSource(account.meta.source);
-      if (!injector?.signer?.signRaw) throw new Error('Wallet does not support signing');
-      const signed = await siws.sign(injector) as unknown as { signature: string; message?: string };
-      const messageStr =
-        typeof signed.message === 'string' && signed.message
-          ? signed.message
-          : (siws as unknown as { toString: () => string }).toString();
-      const authHeader = btoa(
-        JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address })
-      );
 
       await api.submitForReview(
         project.id,
@@ -891,33 +749,21 @@ const ProjectDetailsPage = () => {
     setFormError("");
     setFormLoading(true);
     try {
-      // Connect wallet and sign with SIWS
-      await web3Enable('Hackathonia');
-      const accounts = await web3Accounts();
-      const account = accounts[0];
-      if (!account) throw new Error("No wallet found");
-      // Require signer to be a team member or admin (server also enforces via SIWS)
+      // Require a connected wallet that is a team member or admin
+      // (the server also enforces this when the signed action is sent).
+      if (!auth.account) throw new Error("No wallet found");
       const isTeamMemberForSubmit = Array.isArray(project.teamMembers) &&
-        addressInList(account.address, project.teamMembers);
-      const isAdminForSubmit = checkIsAdmin(account.address);
+        addressInList(auth.account.address, project.teamMembers, auth.account.chain);
+      const isAdminForSubmit = checkIsAdmin(auth.account.address, auth.account.chain);
       if (!isTeamMemberForSubmit && !isAdminForSubmit) {
         setFormError("You must sign in with a team member or admin wallet to submit deliverables.");
         setFormLoading(false);
         return;
       }
-      const siws = new SiwsMessage({
-        domain: window.location.hostname,
-        uri: window.location.origin,
-        address: account.address,
-        nonce: Math.random().toString(36).slice(2),
-        statement: generateSiwsStatement({
-          action: 'submit-deliverable',
-          projectTitle: project.projectName,
-          projectId: project.id
-        })
+      await auth.signAction('submit-deliverable', {
+        projectTitle: project.projectName,
+        projectId: project.id,
       });
-      const injector = await web3FromSource(account.meta.source);
-      await siws.sign(injector);
       // Mock API call to save milestone
       const newMilestone = `${milestoneName}: ${milestoneDesc}\n${deliverables.map((d, i) => `- ${d}`).join("\n")}`;
       setProject((prev: ApiProject | null) => (
@@ -1355,6 +1201,8 @@ const ProjectDetailsPage = () => {
                 <WalletConnectionBanner
                   onConnect={connectWallet}
                   isConnected={!!connectedAddress}
+                  chain={auth.chain}
+                  onChainChange={auth.setChain}
                 />
 
                 {/* Team & Payment Section */}

--- a/client/src/pages/ProjectDetailsPage.tsx
+++ b/client/src/pages/ProjectDetailsPage.tsx
@@ -84,10 +84,11 @@ function SummaryWithBullets({ text }: { text: string }) {
 const ProjectDetailsPage = () => {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  type ApiTeamMember = { 
-    name: string; 
-    customUrl?: string; 
+  type ApiTeamMember = {
+    name: string;
+    customUrl?: string;
     walletAddress?: string;
+    walletChain?: 'substrate' | 'ethereum' | 'solana';
     role?: string;
     twitter?: string;
     github?: string;
@@ -110,6 +111,7 @@ const ProjectDetailsPage = () => {
     milestones?: ApiMilestone[];
     bountyPrize?: ApiBounty[];
     donationAddress?: string;
+    donationChain?: 'substrate' | 'ethereum' | 'solana';
     winner?: string; // legacy
     hackathon?: { id: string; name: string; endDate: string; eventStartedAt?: string };
     eventStartedAt?: string; // legacy - use hackathon.eventStartedAt instead
@@ -579,17 +581,19 @@ const ProjectDetailsPage = () => {
   };
 
   // Handle inline team & payment save
-  const handleTeamPaymentSave = async (data: { 
+  const handleTeamPaymentSave = async (data: {
     teamMembers: Array<{
       name: string;
       walletAddress?: string;
+      walletChain?: 'substrate' | 'ethereum' | 'solana';
       role?: string;
       twitter?: string;
       github?: string;
       linkedin?: string;
       customUrl?: string;
-    }>; 
-    donationAddress: string 
+    }>;
+    donationAddress: string;
+    donationChain?: 'substrate' | 'ethereum' | 'solana';
   }) => {
     if (!project || !connectedAddress) {
       toast({
@@ -612,6 +616,7 @@ const ProjectDetailsPage = () => {
         teamMembers: data.teamMembers.map(m => ({
           name: m.name,
           walletAddress: m.walletAddress || undefined,
+          walletChain: m.walletChain || 'substrate',
           role: m.role || undefined,
           twitter: m.twitter || undefined,
           github: m.github || undefined,
@@ -619,14 +624,16 @@ const ProjectDetailsPage = () => {
           customUrl: m.customUrl || undefined,
         })),
         donationAddress: data.donationAddress,
+        donationChain: data.donationChain || 'substrate',
       }, authHeader);
-      
+
       // Update local project state
       setProject((prev: ApiProject | null) => (prev ? {
         ...prev,
         teamMembers: data.teamMembers.map(m => ({
           name: m.name.trim(),
           walletAddress: m.walletAddress?.trim() || undefined,
+          walletChain: m.walletChain || 'substrate',
           role: m.role?.trim() || undefined,
           twitter: m.twitter?.trim() || undefined,
           github: m.github?.trim() || undefined,
@@ -634,6 +641,7 @@ const ProjectDetailsPage = () => {
           customUrl: m.customUrl?.trim() || undefined,
         })),
         donationAddress: data.donationAddress.trim(),
+        donationChain: data.donationChain || 'substrate',
       } as ApiProject : prev));
       
       // Toast is shown by TeamPaymentSection
@@ -1209,6 +1217,7 @@ const ProjectDetailsPage = () => {
                 <TeamPaymentSection
                   teamMembers={project.teamMembers || []}
                   donationAddress={project.donationAddress}
+                  donationChain={project.donationChain}
                   totalPaid={project.totalPaid}
                   m2Status={project.m2Status}
                   isTeamMember={isTeamMember}

--- a/server/.env.example
+++ b/server/.env.example
@@ -2,7 +2,11 @@
 SUPABASE_URL=
 SUPABASE_SERVICE_ROLE_KEY=
 
-# SIWS admin auth — comma-separated SS58 addresses allowed to hit admin routes
+# Multi-chain admin auth — comma-separated authorized signers.
+# Each entry is either `chain:address` or a bare address (bare ⇒ substrate).
+# Supported chains: substrate, ethereum. Example:
+#   AUTHORIZED_SIGNERS=5Grw...,ethereum:0xAbC123...
+# ADMIN_WALLETS is the legacy fallback, used only when AUTHORIZED_SIGNERS is empty.
 ADMIN_WALLETS=
 EXPECTED_DOMAIN=
 

--- a/server/api/auth/__tests__/authorizedSigners.test.js
+++ b/server/api/auth/__tests__/authorizedSigners.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { parseAuthorizedSigners, matchSigner } from '../authorizedSigners.js';
+
+// Well-known dev addresses (Alice / Bob) — valid SS58 so normalization succeeds.
+const ALICE = '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY';
+const BOB = '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty';
+const ETH = '0x1111111111111111111111111111111111111111';
+
+describe('parseAuthorizedSigners', () => {
+  it('treats a bare address as a substrate signer', () => {
+    const list = parseAuthorizedSigners(ALICE);
+    expect(list).toHaveLength(1);
+    expect(list[0].chain).toBe('substrate');
+  });
+
+  it('parses chain-tagged entries', () => {
+    const list = parseAuthorizedSigners(`${ALICE}, ethereum:${ETH}`);
+    const chains = list.map((e) => e.chain).sort();
+    expect(chains).toEqual(['ethereum', 'substrate']);
+  });
+
+  it('drops an untagged Ethereum address (it fails substrate normalization)', () => {
+    expect(parseAuthorizedSigners(ETH)).toEqual([]);
+  });
+
+  it('drops entries that fail normalization for their tagged chain', () => {
+    expect(parseAuthorizedSigners('ethereum:not-an-address')).toEqual([]);
+  });
+
+  it('returns an empty list for empty input', () => {
+    expect(parseAuthorizedSigners('')).toEqual([]);
+    expect(parseAuthorizedSigners(undefined)).toEqual([]);
+  });
+});
+
+describe('matchSigner', () => {
+  const list = parseAuthorizedSigners(`${ALICE}, ethereum:${ETH}`);
+
+  it('matches a configured substrate signer', () => {
+    expect(matchSigner(list, 'substrate', ALICE)).toBe(true);
+  });
+
+  it('matches a configured ethereum signer case-insensitively', () => {
+    expect(matchSigner(list, 'ethereum', ETH.toUpperCase().replace('0X', '0x'))).toBe(true);
+  });
+
+  it('rejects an address that is not configured', () => {
+    expect(matchSigner(list, 'substrate', BOB)).toBe(false);
+  });
+
+  it('rejects a configured address presented on the wrong chain', () => {
+    expect(matchSigner(list, 'ethereum', ALICE)).toBe(false);
+    expect(matchSigner(list, 'substrate', ETH)).toBe(false);
+  });
+});

--- a/server/api/auth/__tests__/parsePayload.test.js
+++ b/server/api/auth/__tests__/parsePayload.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { parsePayload, AuthPayloadError } from '../parsePayload.js';
+
+function encode(payload) {
+  return btoa(JSON.stringify(payload));
+}
+
+const VALID = { message: 'msg', signature: '0xsig', address: '5Abc' };
+
+describe('parsePayload', () => {
+  it('decodes a valid payload and defaults chain to substrate', () => {
+    const result = parsePayload(encode(VALID));
+    expect(result).toEqual({ chain: 'substrate', ...VALID });
+  });
+
+  it('preserves an explicit chain field', () => {
+    const result = parsePayload(encode({ ...VALID, chain: 'ethereum' }));
+    expect(result.chain).toBe('ethereum');
+  });
+
+  it('throws AuthPayloadError(400) for invalid base64', () => {
+    expect(() => parsePayload('!!!invalid-base64!!!')).toThrow(AuthPayloadError);
+    try {
+      parsePayload('!!!invalid-base64!!!');
+    } catch (e) {
+      expect(e.status).toBe(400);
+      expect(e.message).toMatch(/Base64/i);
+    }
+  });
+
+  it('throws AuthPayloadError(400) for malformed JSON', () => {
+    try {
+      parsePayload(btoa('not-json'));
+      throw new Error('should have thrown');
+    } catch (e) {
+      expect(e).toBeInstanceOf(AuthPayloadError);
+      expect(e.status).toBe(400);
+      expect(e.message).toMatch(/Malformed/i);
+    }
+  });
+
+  it('throws AuthPayloadError(400) for an incomplete payload', () => {
+    for (const partial of [{ message: 'm' }, { message: 'm', signature: 's' }, {}]) {
+      try {
+        parsePayload(encode(partial));
+        throw new Error('should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(AuthPayloadError);
+        expect(e.message).toMatch(/Incomplete/i);
+      }
+    }
+  });
+});

--- a/server/api/auth/__tests__/statements.test.js
+++ b/server/api/auth/__tests__/statements.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { validateStatement, VALID_STATEMENTS } from '../statements.js';
+
+describe('validateStatement', () => {
+  it('accepts every exact-match statement', () => {
+    for (const statement of VALID_STATEMENTS) {
+      expect(validateStatement(statement)).toBe(true);
+    }
+  });
+
+  it('accepts project-specific statements via pattern match', () => {
+    expect(validateStatement('Update team members for Acme Rocket on Stadium')).toBe(true);
+    expect(validateStatement('Approve project Acme Rocket on Stadium')).toBe(true);
+    expect(validateStatement('Apply project Acme Rocket to program WebZero on Stadium')).toBe(true);
+  });
+
+  it('rejects unknown statements', () => {
+    expect(validateStatement('Some unknown statement')).toBe(false);
+    expect(validateStatement('Drain the treasury on Stadium')).toBe(false);
+    expect(validateStatement('')).toBe(false);
+  });
+
+  it('rejects a statement that omits the trailing " on Stadium"', () => {
+    expect(validateStatement('Update team members for Acme Rocket')).toBe(false);
+  });
+});

--- a/server/api/auth/authorizedSigners.js
+++ b/server/api/auth/authorizedSigners.js
@@ -1,0 +1,85 @@
+/**
+ * Chain-aware authorized-signer (admin) list.
+ *
+ * `AUTHORIZED_SIGNERS` (or legacy `ADMIN_WALLETS`) is a comma-separated list.
+ * Each entry is either `chain:address` or a bare address. A bare address is
+ * treated as `substrate`, so existing `.env` files keep working unchanged.
+ *
+ *   AUTHORIZED_SIGNERS=5Grw...,ethereum:0xAbC...,solana:7Np...
+ *
+ * Authorization compares the normalized form of an address (see normalize.js),
+ * so an admin only matches on the same chain they signed in with — an address
+ * valid on chain X cannot be spoofed via chain Y.
+ */
+
+import { normalizeAddress } from './normalize.js';
+
+const CHAINS = ['substrate', 'ethereum', 'solana'];
+
+/**
+ * Parse one raw entry into `{ chain, address }`. Untagged ⇒ substrate.
+ * @param {string} raw
+ * @returns {{ chain: string, address: string }|null}
+ */
+function parseEntry(raw) {
+  const trimmed = String(raw).trim();
+  if (!trimmed) return null;
+
+  const colon = trimmed.indexOf(':');
+  if (colon > 0) {
+    const tag = trimmed.slice(0, colon).toLowerCase();
+    if (CHAINS.includes(tag)) {
+      return { chain: tag, address: trimmed.slice(colon + 1).trim() };
+    }
+  }
+  return { chain: 'substrate', address: trimmed };
+}
+
+/**
+ * Parse a comma-separated signer list into normalized `{ chain, normalized }`
+ * entries, dropping anything that fails to normalize for its chain.
+ *
+ * @param {string} raw
+ * @returns {Array<{ chain: string, normalized: string }>}
+ */
+export function parseAuthorizedSigners(raw) {
+  return String(raw || '')
+    .split(',')
+    .map(parseEntry)
+    .filter(Boolean)
+    .map(({ chain, address }) => ({ chain, normalized: normalizeAddress(chain, address) }))
+    .filter((entry) => entry.normalized != null);
+}
+
+/**
+ * Whether `(chain, address)` is present in a parsed signer list.
+ * @param {Array<{ chain: string, normalized: string }>} list
+ * @param {string} chain
+ * @param {string} address
+ * @returns {boolean}
+ */
+export function matchSigner(list, chain, address) {
+  const normalized = normalizeAddress(chain, address);
+  if (!normalized) return false;
+  return list.some((entry) => entry.chain === chain && entry.normalized === normalized);
+}
+
+// Built once at module load (matches polkadot-config.js).
+const AUTHORIZED = parseAuthorizedSigners(
+  process.env.AUTHORIZED_SIGNERS || process.env.ADMIN_WALLETS || '',
+);
+
+/**
+ * Whether a signer is an authorized admin on the given chain.
+ * @param {string} chain
+ * @param {string} address
+ * @returns {boolean}
+ */
+export function isAuthorizedSigner(chain, address) {
+  return matchSigner(AUTHORIZED, chain, address);
+}
+
+/** Count of configured authorized signers across all chains. */
+export function authorizedSignerCount() {
+  return AUTHORIZED.length;
+}

--- a/server/api/auth/normalize.js
+++ b/server/api/auth/normalize.js
@@ -1,0 +1,43 @@
+/**
+ * Per-chain address normalization.
+ *
+ * Two addresses identify the same account when their normalized forms are
+ * strictly equal. Each chain has its own canonical form:
+ *   - substrate: decoded public key as hex (cross-prefix safe, e.g. SS58 42 vs 0)
+ *   - ethereum:  lowercased 0x address (added in Phase B)
+ *   - solana:    canonical base58 of the 32-byte public key (added in Phase C)
+ *
+ * Returns `null` when the address cannot be decoded for the given chain.
+ */
+
+import { decodeAddress } from '@polkadot/util-crypto';
+import { u8aToHex } from '@polkadot/util';
+
+/**
+ * @param {string} chain - 'substrate' | 'ethereum' | 'solana'
+ * @param {string} address
+ * @returns {string|null} normalized address, or null if invalid for the chain
+ */
+export function normalizeAddress(chain, address) {
+  if (!address) return null;
+
+  switch (chain) {
+    case 'substrate':
+      // SS58 addresses are base58 — never 0x-prefixed hex. `decodeAddress`
+      // leniently accepts raw hex, so reject it explicitly to avoid an
+      // Ethereum address being mistaken for a Substrate one.
+      if (/^0x/i.test(String(address).trim())) return null;
+      try {
+        return u8aToHex(decodeAddress(address));
+      } catch {
+        return null;
+      }
+    case 'ethereum': {
+      // EIP-55 checksum is display-only; lowercase is the canonical compare form.
+      const eth = String(address).trim();
+      return /^0x[a-fA-F0-9]{40}$/.test(eth) ? eth.toLowerCase() : null;
+    }
+    default:
+      return null;
+  }
+}

--- a/server/api/auth/normalize.js
+++ b/server/api/auth/normalize.js
@@ -12,6 +12,7 @@
 
 import { decodeAddress } from '@polkadot/util-crypto';
 import { u8aToHex } from '@polkadot/util';
+import bs58 from 'bs58';
 
 /**
  * @param {string} chain - 'substrate' | 'ethereum' | 'solana'
@@ -36,6 +37,15 @@ export function normalizeAddress(chain, address) {
       // EIP-55 checksum is display-only; lowercase is the canonical compare form.
       const eth = String(address).trim();
       return /^0x[a-fA-F0-9]{40}$/.test(eth) ? eth.toLowerCase() : null;
+    }
+    case 'solana': {
+      // Canonical base58 of the 32-byte ed25519 public key.
+      try {
+        const decoded = bs58.decode(String(address).trim());
+        return decoded.length === 32 ? bs58.encode(decoded) : null;
+      } catch {
+        return null;
+      }
     }
     default:
       return null;

--- a/server/api/auth/parsePayload.js
+++ b/server/api/auth/parsePayload.js
@@ -1,0 +1,45 @@
+/**
+ * Parsing of the `x-siws-auth` request header.
+ *
+ * The header is `base64(JSON.stringify({ chain?, message, signature, address }))`.
+ * `chain` is optional — absent means `'substrate'`, so clients signing in with
+ * the original SIWS flow keep working unchanged.
+ */
+
+export class AuthPayloadError extends Error {
+  constructor(message, status = 400) {
+    super(message);
+    this.name = 'AuthPayloadError';
+    this.status = status;
+  }
+}
+
+/**
+ * Decode and validate the `x-siws-auth` header value.
+ *
+ * @param {string} authHeader - raw base64 header value
+ * @returns {{ chain: string, message: string, signature: string, address: string }}
+ * @throws {AuthPayloadError} on malformed base64/JSON or missing fields
+ */
+export function parsePayload(authHeader) {
+  let decoded;
+  try {
+    decoded = atob(authHeader);
+  } catch {
+    throw new AuthPayloadError('Invalid Base64 in auth header', 400);
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(decoded);
+  } catch {
+    throw new AuthPayloadError('Malformed SIWS payload in header', 400);
+  }
+
+  const { chain, message, signature, address } = payload || {};
+  if (!message || !signature || !address) {
+    throw new AuthPayloadError('Incomplete SIWS payload', 400);
+  }
+
+  return { chain: chain || 'substrate', message, signature, address };
+}

--- a/server/api/auth/statements.js
+++ b/server/api/auth/statements.js
@@ -1,0 +1,70 @@
+/**
+ * Sign-in statement validation.
+ *
+ * The statement is the human-readable line a wallet shows the user before they
+ * sign. It is chain-agnostic ("... on Stadium") so the same validator covers
+ * Substrate (SIWS), Ethereum (SIWE) and Solana sign-in messages — each chain's
+ * verifier parses its own message format and hands the extracted statement here.
+ */
+
+// Exact-match statements for fixed actions.
+export const VALID_STATEMENTS = [
+  'Submit milestone deliverables for Stadium',
+  'Update team members for project on Stadium',
+  'Update project details for project on Stadium',
+  'Register team address for Stadium',
+  'Perform administrative action on Stadium',
+  'Sign in to Stadium',
+  // Additional context-specific statements
+  'Submit milestone deliverables for project on Stadium',
+  'Update team members for Stadium',
+  'Update project details for Stadium',
+  'Register team address for project on Stadium',
+  // Project-specific statements (these will be generated dynamically)
+  'Create new project on Stadium',
+  'Delete project on Stadium',
+  // Admin action statements
+  'Review project on Stadium',
+  'Approve project on Stadium',
+  'Reject project on Stadium',
+  // Phase 1 revamp statements
+  'Post an update on Stadium',
+  'Update funding signal on Stadium',
+  'Apply to program on Stadium',
+  'Create program on Stadium',
+  'Update program on Stadium',
+  'Review application on Stadium',
+  // Phase 2 revamp: wallet contacts (#67)
+  'Update notification preferences for wallet on Stadium',
+];
+
+// Patterns for project-specific statements that interpolate a project/program name.
+const PROJECT_STATEMENT_PATTERNS = [
+  /^Update team members for .+ on Stadium$/,
+  /^Submit milestone deliverables for .+ on Stadium$/,
+  /^Update project details for .+ on Stadium$/,
+  /^Delete project .+ on Stadium$/,
+  /^Review project .+ on Stadium$/,
+  /^Approve project .+ on Stadium$/,
+  /^Reject project .+ on Stadium$/,
+  // Phase 1 revamp: project updates (#41)
+  /^Post an update to .+ on Stadium$/,
+  // Phase 1 revamp: funding signal (#42)
+  /^Update funding signal for .+ on Stadium$/,
+  // Phase 1 revamp: apply project X to program Y (#44)
+  /^Apply project .+ to program .+ on Stadium$/,
+];
+
+/**
+ * Validate a sign-in statement against the exact-match list and the
+ * project-specific patterns.
+ *
+ * @param {string} statement
+ * @returns {boolean}
+ */
+export function validateStatement(statement) {
+  if (VALID_STATEMENTS.includes(statement)) {
+    return true;
+  }
+  return PROJECT_STATEMENT_PATTERNS.some((pattern) => pattern.test(statement));
+}

--- a/server/api/auth/verifiers/__tests__/ethereum.verifier.test.js
+++ b/server/api/auth/verifiers/__tests__/ethereum.verifier.test.js
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('viem', () => ({
+  recoverMessageAddress: vi.fn(),
+}));
+
+vi.mock('viem/siwe', () => ({
+  parseSiweMessage: vi.fn(),
+}));
+
+import { recoverMessageAddress } from 'viem';
+import { parseSiweMessage } from 'viem/siwe';
+import { ethereumVerifier } from '../ethereum.verifier.js';
+
+const ADDR = '0xAbC0000000000000000000000000000000000001';
+const INPUT = { message: 'siwe-message', signature: '0xsig', address: ADDR };
+
+describe('ethereumVerifier.verify', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns valid:false for a message that omits the address/domain', async () => {
+    parseSiweMessage.mockReturnValue({ statement: 'Sign in to Stadium' });
+
+    const result = await ethereumVerifier.verify(INPUT);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Malformed/i);
+    expect(recoverMessageAddress).not.toHaveBeenCalled();
+  });
+
+  it('returns valid:false when the recovered address does not match the message', async () => {
+    parseSiweMessage.mockReturnValue({ address: ADDR, domain: 'localhost', statement: 'Sign in to Stadium' });
+    recoverMessageAddress.mockResolvedValue('0xDEAd000000000000000000000000000000000002');
+
+    const result = await ethereumVerifier.verify(INPUT);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/does not match/i);
+  });
+
+  it('returns valid:false when signature recovery throws', async () => {
+    parseSiweMessage.mockReturnValue({ address: ADDR, domain: 'localhost', statement: 'Sign in to Stadium' });
+    recoverMessageAddress.mockRejectedValue(new Error('bad signature'));
+
+    const result = await ethereumVerifier.verify(INPUT);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Invalid signature/i);
+  });
+
+  it('returns valid:false for an expired message', async () => {
+    parseSiweMessage.mockReturnValue({
+      address: ADDR,
+      domain: 'localhost',
+      statement: 'Sign in to Stadium',
+      expirationTime: new Date(Date.now() - 60_000),
+    });
+    recoverMessageAddress.mockResolvedValue(ADDR.toLowerCase());
+
+    const result = await ethereumVerifier.verify(INPUT);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/expired/i);
+  });
+
+  it('returns valid:true with parsed message and lowercased normalized address', async () => {
+    parseSiweMessage.mockReturnValue({
+      address: ADDR,
+      domain: 'localhost',
+      statement: 'Perform administrative action on Stadium',
+      nonce: 'abc123',
+      uri: 'https://localhost',
+      expirationTime: new Date(Date.now() + 60_000),
+    });
+    // Recovered address matches but with different casing — must still verify.
+    recoverMessageAddress.mockResolvedValue(ADDR.toLowerCase());
+
+    const result = await ethereumVerifier.verify(INPUT);
+
+    expect(result.valid).toBe(true);
+    expect(result.parsed.statement).toBe('Perform administrative action on Stadium');
+    expect(result.parsed.domain).toBe('localhost');
+    expect(result.normalizedAddress).toBe(ADDR.toLowerCase());
+  });
+});

--- a/server/api/auth/verifiers/__tests__/solana.verifier.test.js
+++ b/server/api/auth/verifiers/__tests__/solana.verifier.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import nacl from 'tweetnacl';
+import bs58 from 'bs58';
+import { solanaVerifier } from '../solana.verifier.js';
+
+function buildMessage({ domain = 'localhost', address, statement = 'Sign in to Stadium', expirationTime }) {
+  return [
+    `${domain} wants you to sign in with your Solana account:`,
+    address,
+    '',
+    statement,
+    '',
+    'URI: https://localhost',
+    'Version: 1',
+    'Nonce: abc123',
+    'Issued At: 2026-01-01T00:00:00.000Z',
+    ...(expirationTime ? [`Expiration Time: ${expirationTime}`] : []),
+  ].join('\n');
+}
+
+describe('solanaVerifier.verify', () => {
+  const keypair = nacl.sign.keyPair();
+  const address = bs58.encode(keypair.publicKey);
+
+  const sign = (message) =>
+    bs58.encode(nacl.sign.detached(new TextEncoder().encode(message), keypair.secretKey));
+
+  it('verifies a correctly signed message', async () => {
+    const message = buildMessage({ address });
+    const result = await solanaVerifier.verify({ message, signature: sign(message), address });
+
+    expect(result.valid).toBe(true);
+    expect(result.parsed.statement).toBe('Sign in to Stadium');
+    expect(result.parsed.domain).toBe('localhost');
+    expect(result.normalizedAddress).toBe(address);
+  });
+
+  it('rejects a tampered message (signature no longer matches)', async () => {
+    const signature = sign(buildMessage({ address }));
+    const tampered = buildMessage({ address, statement: 'Drain the treasury on Stadium' });
+    const result = await solanaVerifier.verify({ message: tampered, signature, address });
+
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects a malformed message', async () => {
+    const result = await solanaVerifier.verify({
+      message: 'not a sign-in message',
+      signature: 'x',
+      address,
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Malformed/i);
+  });
+
+  it('rejects a signature produced by a different key', async () => {
+    const message = buildMessage({ address });
+    const other = nacl.sign.keyPair();
+    const wrongSig = bs58.encode(
+      nacl.sign.detached(new TextEncoder().encode(message), other.secretKey),
+    );
+    const result = await solanaVerifier.verify({ message, signature: wrongSig, address });
+
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects an expired message', async () => {
+    const message = buildMessage({
+      address,
+      expirationTime: new Date(Date.now() - 60_000).toISOString(),
+    });
+    const result = await solanaVerifier.verify({ message, signature: sign(message), address });
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/expired/i);
+  });
+});

--- a/server/api/auth/verifiers/__tests__/substrate.verifier.test.js
+++ b/server/api/auth/verifiers/__tests__/substrate.verifier.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@polkadot/util-crypto', () => ({
+  cryptoWaitReady: vi.fn().mockResolvedValue(true),
+  signatureVerify: vi.fn(),
+  decodeAddress: vi.fn(),
+}));
+
+vi.mock('@talismn/siws', () => ({
+  parseMessage: vi.fn(),
+}));
+
+vi.mock('@polkadot/util', () => ({
+  u8aToHex: vi.fn(),
+}));
+
+import { signatureVerify, decodeAddress } from '@polkadot/util-crypto';
+import { parseMessage } from '@talismn/siws';
+import { u8aToHex } from '@polkadot/util';
+import { substrateVerifier } from '../substrate.verifier.js';
+
+const INPUT = { message: 'siws-message', signature: '0xsig', address: '5Abc' };
+
+describe('substrateVerifier.verify', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns valid:false for an invalid signature and does not parse the message', async () => {
+    signatureVerify.mockReturnValue({ isValid: false });
+
+    const result = await substrateVerifier.verify(INPUT);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/Invalid signature/i);
+    expect(parseMessage).not.toHaveBeenCalled();
+  });
+
+  it('returns valid:true with parsed message and normalized address for a valid signature', async () => {
+    signatureVerify.mockReturnValue({ isValid: true, crypto: 'sr25519' });
+    parseMessage.mockReturnValue({
+      statement: 'Sign in to Stadium',
+      address: '5Abc',
+      domain: 'localhost',
+    });
+    decodeAddress.mockReturnValue(new Uint8Array([0xde, 0xad]));
+    u8aToHex.mockReturnValue('0xdead');
+
+    const result = await substrateVerifier.verify(INPUT);
+
+    expect(result.valid).toBe(true);
+    expect(result.crypto).toBe('sr25519');
+    expect(result.parsed.statement).toBe('Sign in to Stadium');
+    expect(result.normalizedAddress).toBe('0xdead');
+  });
+
+  it('returns normalizedAddress:null when the parsed address cannot be decoded', async () => {
+    signatureVerify.mockReturnValue({ isValid: true, crypto: 'sr25519' });
+    parseMessage.mockReturnValue({ statement: 'Sign in to Stadium', address: 'bad', domain: 'localhost' });
+    decodeAddress.mockImplementation(() => { throw new Error('Invalid SS58'); });
+
+    const result = await substrateVerifier.verify(INPUT);
+
+    expect(result.valid).toBe(true);
+    expect(result.normalizedAddress).toBeNull();
+  });
+});

--- a/server/api/auth/verifiers/ethereum.verifier.js
+++ b/server/api/auth/verifiers/ethereum.verifier.js
@@ -1,0 +1,65 @@
+/**
+ * Ethereum (SIWE — Sign-In With Ethereum, EIP-4361) signature verifier.
+ *
+ * The wallet signs the EIP-4361 message with `personal_sign` (EIP-191). We
+ * parse the message with viem's SIWE utilities and recover the signing address
+ * offline with `recoverMessageAddress` — no RPC/chain access is needed for
+ * externally-owned accounts (the only accounts a browser extension exposes).
+ */
+
+import { recoverMessageAddress } from 'viem';
+import { parseSiweMessage } from 'viem/siwe';
+import { normalizeAddress } from '../normalize.js';
+
+export const ethereumVerifier = {
+  chain: 'ethereum',
+
+  /**
+   * @param {{ message: string, signature: string, address: string }} input
+   * @returns {Promise<import('./substrate.verifier.js').VerifyResult>}
+   */
+  async verify({ message, signature }) {
+    const fields = parseSiweMessage(message);
+    if (!fields?.address || !fields?.domain) {
+      return { valid: false, error: 'Malformed SIWE message' };
+    }
+
+    let recovered;
+    try {
+      recovered = await recoverMessageAddress({ message, signature });
+    } catch (e) {
+      return { valid: false, error: `Invalid signature: ${e.message}` };
+    }
+
+    if (recovered.toLowerCase() !== fields.address.toLowerCase()) {
+      return { valid: false, error: 'Signature does not match the message address' };
+    }
+
+    // Reject stale / not-yet-valid messages (partial replay mitigation).
+    const now = Date.now();
+    if (fields.expirationTime && fields.expirationTime.getTime() < now) {
+      return { valid: false, error: 'Sign-in message has expired' };
+    }
+    if (fields.notBefore && fields.notBefore.getTime() > now) {
+      return { valid: false, error: 'Sign-in message is not yet valid' };
+    }
+
+    const parsed = {
+      statement: fields.statement,
+      address: fields.address,
+      domain: fields.domain,
+      nonce: fields.nonce,
+      uri: fields.uri,
+      issuedAt: fields.issuedAt,
+      expirationTime: fields.expirationTime,
+    };
+
+    return {
+      valid: true,
+      parsed,
+      normalizedAddress: normalizeAddress('ethereum', fields.address),
+    };
+  },
+};
+
+export default ethereumVerifier;

--- a/server/api/auth/verifiers/index.js
+++ b/server/api/auth/verifiers/index.js
@@ -2,17 +2,18 @@
  * Sign-in verifier registry.
  *
  * Each verifier exposes `verify({ message, signature, address })` resolving to
- * `{ valid, parsed, normalizedAddress, ... }`. The Solana verifier is added in
- * Phase C — until then `getVerifier('solana')` returns `null` and the caller
- * responds 400.
+ * `{ valid, parsed, normalizedAddress, ... }`. `getVerifier` returns `null` for
+ * an unsupported chain and the caller responds 400.
  */
 
 import { substrateVerifier } from './substrate.verifier.js';
 import { ethereumVerifier } from './ethereum.verifier.js';
+import { solanaVerifier } from './solana.verifier.js';
 
 const verifiers = {
   substrate: substrateVerifier,
   ethereum: ethereumVerifier,
+  solana: solanaVerifier,
 };
 
 /**

--- a/server/api/auth/verifiers/index.js
+++ b/server/api/auth/verifiers/index.js
@@ -1,0 +1,26 @@
+/**
+ * Sign-in verifier registry.
+ *
+ * Each verifier exposes `verify({ message, signature, address })` resolving to
+ * `{ valid, parsed, normalizedAddress, ... }`. The Solana verifier is added in
+ * Phase C — until then `getVerifier('solana')` returns `null` and the caller
+ * responds 400.
+ */
+
+import { substrateVerifier } from './substrate.verifier.js';
+import { ethereumVerifier } from './ethereum.verifier.js';
+
+const verifiers = {
+  substrate: substrateVerifier,
+  ethereum: ethereumVerifier,
+};
+
+/**
+ * @param {string} chain
+ * @returns {object|null} the verifier, or null if the chain is unsupported
+ */
+export function getVerifier(chain) {
+  return verifiers[chain] || null;
+}
+
+export const SUPPORTED_CHAINS = Object.keys(verifiers);

--- a/server/api/auth/verifiers/solana.verifier.js
+++ b/server/api/auth/verifiers/solana.verifier.js
@@ -1,0 +1,113 @@
+/**
+ * Solana (Sign-In With Solana) signature verifier.
+ *
+ * The wallet signs a SIWE-style plaintext message with `signMessage`, which
+ * produces an ed25519 signature over the UTF-8 message bytes. We verify it
+ * offline with tweetnacl — no RPC access is needed.
+ *
+ * The message format is fixed (see solanaProvider.ts on the client):
+ *
+ *   {domain} wants you to sign in with your Solana account:
+ *   {address}
+ *
+ *   {statement}
+ *
+ *   URI: {uri}
+ *   Version: 1
+ *   Nonce: {nonce}
+ *   Issued At: {issuedAt}
+ *   Expiration Time: {expirationTime}
+ */
+
+import nacl from 'tweetnacl';
+import bs58 from 'bs58';
+import { normalizeAddress } from '../normalize.js';
+
+const HEADER_RE = /^(.+) wants you to sign in with your Solana account:$/;
+
+/**
+ * Parse the fixed Solana sign-in message format.
+ * @param {string} message
+ * @returns {{ domain, address, statement, uri?, nonce?, issuedAt?, expirationTime? }|null}
+ */
+function parseSolanaMessage(message) {
+  const lines = String(message).split('\n');
+  const header = HEADER_RE.exec(lines[0] || '');
+  if (!header) return null;
+
+  const address = (lines[1] || '').trim();
+  if (!address) return null;
+
+  // lines[2] is blank, lines[3] is the statement, lines[4] is blank.
+  const statement = (lines[3] || '').trim();
+
+  const fields = {};
+  for (const line of lines.slice(4)) {
+    const sep = line.indexOf(': ');
+    if (sep > 0) {
+      fields[line.slice(0, sep).trim()] = line.slice(sep + 2).trim();
+    }
+  }
+
+  return {
+    domain: header[1],
+    address,
+    statement,
+    uri: fields.URI,
+    nonce: fields.Nonce,
+    issuedAt: fields['Issued At'],
+    expirationTime: fields['Expiration Time'],
+  };
+}
+
+export const solanaVerifier = {
+  chain: 'solana',
+
+  /**
+   * @param {{ message: string, signature: string, address: string }} input
+   * @returns {Promise<import('./substrate.verifier.js').VerifyResult>}
+   */
+  async verify({ message, signature }) {
+    const parsed = parseSolanaMessage(message);
+    if (!parsed) {
+      return { valid: false, error: 'Malformed Solana sign-in message' };
+    }
+
+    let pubkey;
+    let sigBytes;
+    try {
+      pubkey = bs58.decode(parsed.address);
+      sigBytes = bs58.decode(signature);
+    } catch {
+      return { valid: false, error: 'Invalid base58 in address or signature' };
+    }
+    if (pubkey.length !== 32) {
+      return { valid: false, error: 'Invalid Solana public key' };
+    }
+
+    let ok = false;
+    try {
+      ok = nacl.sign.detached.verify(new TextEncoder().encode(message), sigBytes, pubkey);
+    } catch {
+      return { valid: false, error: 'Invalid signature' };
+    }
+    if (!ok) {
+      return { valid: false, error: 'Invalid signature' };
+    }
+
+    if (parsed.expirationTime) {
+      const exp = new Date(parsed.expirationTime).getTime();
+      if (Number.isFinite(exp) && exp < Date.now()) {
+        return { valid: false, error: 'Sign-in message has expired' };
+      }
+    }
+
+    return {
+      valid: true,
+      parsed,
+      normalizedAddress: normalizeAddress('solana', parsed.address),
+    };
+  },
+};
+
+export default solanaVerifier;

--- a/server/api/auth/verifiers/substrate.verifier.js
+++ b/server/api/auth/verifiers/substrate.verifier.js
@@ -1,0 +1,46 @@
+/**
+ * Substrate (SIWS — Sign-In With Substrate) signature verifier.
+ *
+ * Verifies an sr25519/ed25519 signature over a SIWS message using
+ * `@polkadot/util-crypto`, and parses the message with `@talismn/siws`.
+ */
+
+import { cryptoWaitReady, signatureVerify } from '@polkadot/util-crypto';
+import { parseMessage } from '@talismn/siws';
+import { normalizeAddress } from '../normalize.js';
+
+/**
+ * @typedef {Object} VerifyResult
+ * @property {boolean} valid
+ * @property {string} [error]
+ * @property {string} [crypto]
+ * @property {object} [parsed]            parsed message { statement, address, domain, ... }
+ * @property {string|null} [normalizedAddress]
+ */
+
+export const substrateVerifier = {
+  chain: 'substrate',
+
+  /**
+   * @param {{ message: string, signature: string, address: string }} input
+   * @returns {Promise<VerifyResult>}
+   */
+  async verify({ message, signature, address }) {
+    await cryptoWaitReady();
+
+    const result = signatureVerify(message, signature, address);
+    if (!result?.isValid) {
+      return { valid: false, error: 'Invalid signature' };
+    }
+
+    const parsed = parseMessage(message);
+    return {
+      valid: true,
+      crypto: result.crypto,
+      parsed,
+      normalizedAddress: normalizeAddress('substrate', parsed.address),
+    };
+  },
+};
+
+export default substrateVerifier;

--- a/server/api/controllers/__tests__/wallet-contact.controller.test.js
+++ b/server/api/controllers/__tests__/wallet-contact.controller.test.js
@@ -11,13 +11,13 @@ vi.mock('../../utils/validation.js', async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
-    validateSS58: vi.fn(),
+    validateAddress: vi.fn(),
     validateEmail: vi.fn(),
   };
 });
 
 const walletContactService = (await import('../../services/wallet-contact.service.js')).default;
-const { validateSS58, validateEmail } = await import('../../utils/validation.js');
+const { validateAddress, validateEmail } = await import('../../utils/validation.js');
 const controller = (await import('../wallet-contact.controller.js')).default;
 
 function mockRes() {
@@ -30,9 +30,9 @@ function mockRes() {
 describe('walletContactController.getContact', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('returns 400 when the address is not valid SS58', async () => {
-    validateSS58.mockReturnValue(false);
-    const req = { params: { address: 'bad-addr' } };
+  it('returns 400 when the address is invalid for its chain', async () => {
+    validateAddress.mockReturnValue(false);
+    const req = { params: { address: 'bad-addr' }, query: {} };
     const res = mockRes();
 
     await controller.getContact(req, res);
@@ -41,13 +41,24 @@ describe('walletContactController.getContact', () => {
     expect(res.json).toHaveBeenCalledWith({ status: 'error', message: 'Invalid wallet address' });
   });
 
+  it('returns 400 for an unsupported chain', async () => {
+    validateAddress.mockReturnValue(true);
+    const req = { params: { address: '5Alice' }, query: { chain: 'bitcoin' } };
+    const res = mockRes();
+
+    await controller.getContact(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ status: 'error', message: 'Invalid chain' });
+  });
+
   it('returns 200 with default shape for unknown wallet and no email key', async () => {
-    validateSS58.mockReturnValue(true);
+    validateAddress.mockReturnValue(true);
     walletContactService.getPublicContact.mockResolvedValue({
       emailSet: false,
       notificationsEnabled: true,
     });
-    const req = { params: { address: '5Alice' } };
+    const req = { params: { address: '5Alice' }, query: {} };
     const res = mockRes();
 
     await controller.getContact(req, res);
@@ -58,15 +69,17 @@ describe('walletContactController.getContact', () => {
     expect(body.data.email_set).toBe(false);
     expect(body.data.notifications_enabled).toBe(true);
     expect(body.data).not.toHaveProperty('email');
+    // chain defaults to substrate when no ?chain= is given
+    expect(walletContactService.getPublicContact).toHaveBeenCalledWith('5Alice', 'substrate');
   });
 
   it('returns 200 with emailSet: true for existing wallet and no email key', async () => {
-    validateSS58.mockReturnValue(true);
+    validateAddress.mockReturnValue(true);
     walletContactService.getPublicContact.mockResolvedValue({
       emailSet: true,
       notificationsEnabled: false,
     });
-    const req = { params: { address: '5Alice' } };
+    const req = { params: { address: '5Alice' }, query: {} };
     const res = mockRes();
 
     await controller.getContact(req, res);
@@ -77,13 +90,23 @@ describe('walletContactController.getContact', () => {
     expect(body.data.notifications_enabled).toBe(false);
     expect(body.data).not.toHaveProperty('email');
   });
+
+  it('passes an explicit ?chain= through to the service', async () => {
+    validateAddress.mockReturnValue(true);
+    walletContactService.getPublicContact.mockResolvedValue({ emailSet: false, notificationsEnabled: true });
+    const req = { params: { address: '0xabc' }, query: { chain: 'ethereum' } };
+    const res = mockRes();
+
+    await controller.getContact(req, res);
+
+    expect(walletContactService.getPublicContact).toHaveBeenCalledWith('0xabc', 'ethereum');
+  });
 });
 
 describe('walletContactController.updateContact', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns 200 with public shape for valid email PUT', async () => {
-    validateSS58.mockReturnValue(true);
     validateEmail.mockReturnValue({ valid: true, normalised: 'alice@example.com' });
     walletContactService.updateContact.mockResolvedValue({
       emailSet: true,
@@ -91,6 +114,7 @@ describe('walletContactController.updateContact', () => {
     });
     const req = {
       params: { address: '5Alice' },
+      user: { address: '5Alice', chain: 'substrate' },
       body: { email: 'Alice@Example.com', notifications_enabled: true },
     };
     const res = mockRes();
@@ -103,16 +127,37 @@ describe('walletContactController.updateContact', () => {
     expect(body.data.email_set).toBe(true);
     expect(body.data.notifications_enabled).toBe(true);
     expect(body.data).not.toHaveProperty('email');
-    expect(walletContactService.updateContact).toHaveBeenCalledWith('5Alice', {
-      email: 'alice@example.com',
-      notificationsEnabled: true,
-    });
+    expect(walletContactService.updateContact).toHaveBeenCalledWith(
+      '5Alice',
+      { email: 'alice@example.com', notificationsEnabled: true },
+      'substrate',
+    );
+  });
+
+  it('uses the signer chain from req.user', async () => {
+    validateEmail.mockReturnValue({ valid: true, normalised: 'a@b.com' });
+    walletContactService.updateContact.mockResolvedValue({ emailSet: true, notificationsEnabled: true });
+    const req = {
+      params: { address: '0xabc' },
+      user: { address: '0xabc', chain: 'ethereum' },
+      body: { email: 'a@b.com' },
+    };
+    const res = mockRes();
+
+    await controller.updateContact(req, res);
+
+    expect(walletContactService.updateContact).toHaveBeenCalledWith(
+      '0xabc',
+      expect.any(Object),
+      'ethereum',
+    );
   });
 
   it('returns 422 for malformed email', async () => {
     validateEmail.mockReturnValue({ valid: false, error: 'email must be a valid email address' });
     const req = {
       params: { address: '5Alice' },
+      user: { address: '5Alice', chain: 'substrate' },
       body: { email: 'not-an-email' },
     };
     const res = mockRes();
@@ -132,6 +177,7 @@ describe('walletContactController.updateContact', () => {
     });
     const req = {
       params: { address: '5Alice' },
+      user: { address: '5Alice', chain: 'substrate' },
       body: { notifications_enabled: false },
     };
     const res = mockRes();
@@ -140,9 +186,11 @@ describe('walletContactController.updateContact', () => {
 
     expect(res.status).toHaveBeenCalledWith(200);
     // email was not in req.body so it must not appear in the fields passed to service
-    expect(walletContactService.updateContact).toHaveBeenCalledWith('5Alice', {
-      notificationsEnabled: false,
-    });
+    expect(walletContactService.updateContact).toHaveBeenCalledWith(
+      '5Alice',
+      { notificationsEnabled: false },
+      'substrate',
+    );
     expect(walletContactService.updateContact.mock.calls[0][1]).not.toHaveProperty('email');
     // validateEmail must not have been called when email is absent from the body
     expect(validateEmail).not.toHaveBeenCalled();
@@ -151,6 +199,7 @@ describe('walletContactController.updateContact', () => {
   it('returns 422 when notifications_enabled is not boolean', async () => {
     const req = {
       params: { address: '5Alice' },
+      user: { address: '5Alice', chain: 'substrate' },
       body: { notifications_enabled: 'yes' },
     };
     const res = mockRes();
@@ -170,6 +219,7 @@ describe('walletContactController.updateContact', () => {
     });
     const req = {
       params: { address: '5Alice' },
+      user: { address: '5Alice', chain: 'substrate' },
       body: { email: 'new@example.com' },
     };
     const res = mockRes();

--- a/server/api/controllers/project.controller.js
+++ b/server/api/controllers/project.controller.js
@@ -4,7 +4,7 @@ import fundingSignalService from '../services/funding-signal.service.js';
 import paymentService from '../services/payment.service.js';
 import notificationService from '../services/notification.service.js';
 import { ALLOWED_CATEGORIES } from '../constants/allowedTech.js';
-import { validateSS58, validateM2Submission, validateSimpleUrl, validateProjectUpdate, validateFundingSignal, validateProject } from '../utils/validation.js';
+import { validateM2Submission, validateSimpleUrl, validateProjectUpdate, validateFundingSignal, validateProject, validateAddress, ALLOWED_WALLET_CHAINS } from '../utils/validation.js';
 import { canEditM2Agreement, isSubmissionWindowOpen } from '../utils/dateHelpers.js';
 import logger from '../utils/logger.js';
 import { getAuthorizedAddresses } from '../../config/polkadot-config.js';
@@ -35,7 +35,9 @@ class ProjectController {
             if (!address || typeof address !== 'string') {
                 return res.status(400).json({ status: 'error', message: 'Address is required' });
             }
-            const projects = await projectService.findByTeamWallet(address);
+            // Optional ?chain= selects the wallet ecosystem; defaults to substrate.
+            const chain = typeof req.query.chain === 'string' ? req.query.chain : 'substrate';
+            const projects = await projectService.findByTeamWallet(address, chain);
             res.status(200).json({ status: 'success', data: projects });
         } catch (error) {
             console.error('❌ Error fetching projects by wallet:', error);
@@ -202,6 +204,7 @@ class ProjectController {
         try {
             const { projectId } = req.params;
             const { donationAddress } = req.body;
+            const donationChain = req.body.donationChain || 'substrate';
             const userWallet = req.user?.address;
 
             // Validation
@@ -212,11 +215,18 @@ class ProjectController {
                 });
             }
 
-            // Validate SS58 format
-            if (!validateSS58(donationAddress)) {
+            if (!ALLOWED_WALLET_CHAINS.includes(donationChain)) {
                 return res.status(400).json({
                     status: "error",
-                    message: "Invalid SS58 address format. Must be a valid Polkadot/Substrate address (47-48 characters)."
+                    message: `Invalid donationChain. Must be one of: ${ALLOWED_WALLET_CHAINS.join(', ')}`
+                });
+            }
+
+            // Validate the address for its chain
+            if (!validateAddress(donationChain, donationAddress)) {
+                return res.status(400).json({
+                    status: "error",
+                    message: `Invalid ${donationChain} payout address format.`
                 });
             }
 
@@ -233,7 +243,7 @@ class ProjectController {
             logger.security(`  By: ${userWallet}`);
 
             // Update payout address
-            const updated = await projectService.updateProject(projectId, { donationAddress });
+            const updated = await projectService.updateProject(projectId, { donationAddress, donationChain });
 
             if (!updated) {
                 return res.status(404).json({ status: "error", message: "Project not found" });

--- a/server/api/controllers/wallet-contact.controller.js
+++ b/server/api/controllers/wallet-contact.controller.js
@@ -1,12 +1,19 @@
 import walletContactService from '../services/wallet-contact.service.js';
-import { validateSS58, validateEmail } from '../utils/validation.js';
+import { validateAddress, validateEmail, ALLOWED_WALLET_CHAINS } from '../utils/validation.js';
 
 const getContact = async (req, res) => {
   const { address } = req.params;
-  if (!validateSS58(address)) {
+  // Optional ?chain= selects the wallet ecosystem; defaults to substrate.
+  const chain = typeof req.query.chain === 'string' ? req.query.chain : 'substrate';
+
+  if (!ALLOWED_WALLET_CHAINS.includes(chain)) {
+    return res.status(400).json({ status: 'error', message: 'Invalid chain' });
+  }
+  if (!validateAddress(chain, address)) {
     return res.status(400).json({ status: 'error', message: 'Invalid wallet address' });
   }
-  const data = await walletContactService.getPublicContact(address);
+
+  const data = await walletContactService.getPublicContact(address, chain);
   return res.status(200).json({
     status: 'success',
     data: {
@@ -18,6 +25,8 @@ const getContact = async (req, res) => {
 
 const updateContact = async (req, res) => {
   const { address } = req.params;
+  // requireOwnWallet verified the signer owns this address on this chain.
+  const chain = req.user?.chain || 'substrate';
 
   const fields = {};
 
@@ -42,7 +51,7 @@ const updateContact = async (req, res) => {
     fields.notificationsEnabled = notifications_enabled;
   }
 
-  const data = await walletContactService.updateContact(address, fields);
+  const data = await walletContactService.updateContact(address, fields, chain);
 
   return res.status(200).json({
     status: 'success',

--- a/server/api/middleware/__tests__/auth.middleware.test.js
+++ b/server/api/middleware/__tests__/auth.middleware.test.js
@@ -31,9 +31,13 @@ vi.mock('dotenv', () => ({
 
 vi.mock('../../../config/polkadot-config.js', () => ({
   getAuthorizedAddresses: () => ['5FakeAdmin1'],
-  isAuthorizedSigner: vi.fn(),
   CURRENT_MULTISIG: '5FakeMultisig',
   NETWORK_CONFIG: { networkName: 'testnet', environment: 'development' },
+}));
+
+vi.mock('../../auth/authorizedSigners.js', () => ({
+  isAuthorizedSigner: vi.fn(),
+  authorizedSignerCount: () => 1,
 }));
 
 vi.mock('../../services/project.service.js', () => ({
@@ -46,7 +50,7 @@ vi.mock('../../services/project.service.js', () => ({
 import { verifySIWS, parseMessage } from '@talismn/siws';
 import { signatureVerify, decodeAddress } from '@polkadot/util-crypto';
 import { u8aToHex } from '@polkadot/util';
-import { isAuthorizedSigner } from '../../../config/polkadot-config.js';
+import { isAuthorizedSigner } from '../../auth/authorizedSigners.js';
 import projectService from '../../services/project.service.js';
 
 // Import middleware under test

--- a/server/api/middleware/__tests__/wallet-contact.middleware.test.js
+++ b/server/api/middleware/__tests__/wallet-contact.middleware.test.js
@@ -99,7 +99,7 @@ describe('requireOwnWallet', () => {
     await requireOwnWallet(req, res, next);
 
     expect(next).toHaveBeenCalled();
-    expect(req.user).toEqual({ address: '5Alice' });
+    expect(req.user).toEqual({ address: '5Alice', chain: 'substrate' });
   });
 
   it('returns 400 for invalid base64', async () => {
@@ -154,7 +154,7 @@ describe('requireOwnWallet', () => {
     await requireOwnWallet(req, res, next);
 
     expect(next).toHaveBeenCalled();
-    expect(req.user).toEqual({ address: '5Alice' });
+    expect(req.user).toEqual({ address: '5Alice', chain: 'substrate' });
   });
 
   it('returns 403 with reason not-your-wallet when signer does not match target', async () => {

--- a/server/api/middleware/auth.middleware.js
+++ b/server/api/middleware/auth.middleware.js
@@ -272,7 +272,7 @@ export const requireOwnWallet = async (req, res, next) => {
   // DEV MODE BYPASS
   if (process.env.NODE_ENV !== 'production' && authHeader === 'dev-bypass') {
     log(chalk.yellow('⚠️  DEV MODE: Bypassing SIWS authentication for own-wallet'));
-    req.user = { address: req.params.address };
+    req.user = { address: req.params.address, chain: 'substrate' };
     return next();
   }
 
@@ -309,7 +309,7 @@ export const requireOwnWallet = async (req, res, next) => {
   }
 
   logSuccess(`Signer ${auth.parsed.address} matches target wallet ${req.params.address}`);
-  req.user = { address: auth.parsed.address };
+  req.user = { address: auth.parsed.address, chain: auth.chain };
   return next();
 };
 

--- a/server/api/middleware/auth.middleware.js
+++ b/server/api/middleware/auth.middleware.js
@@ -1,53 +1,37 @@
+/**
+ * Authentication middleware.
+ *
+ * Verifies a wallet-signed `x-siws-auth` header. The verification pipeline is
+ * chain-agnostic: `parsePayload` reads the optional `chain` field (default
+ * `'substrate'`), a per-chain verifier checks the signature, and the shared
+ * `validateStatement` / domain checks run identically for every chain. Each
+ * middleware then applies its own authorization rule.
+ */
+
 import dotenv from 'dotenv';
-import { verifySIWS, parseMessage } from '@talismn/siws';
-import { SiwsMessage } from '@talismn/siws';
 import chalk from 'chalk';
-import { cryptoWaitReady, decodeAddress, signatureVerify } from '@polkadot/util-crypto';
-import { u8aToHex } from '@polkadot/util';
 import projectService from '../services/project.service.js';
-import { getAuthorizedAddresses, isAuthorizedSigner, CURRENT_MULTISIG, NETWORK_CONFIG } from '../../config/polkadot-config.js';
+import {
+  getAuthorizedAddresses,
+  CURRENT_MULTISIG,
+  NETWORK_CONFIG,
+} from '../../config/polkadot-config.js';
+import { isAuthorizedSigner } from '../auth/authorizedSigners.js';
+import { parsePayload } from '../auth/parsePayload.js';
+import { getVerifier } from '../auth/verifiers/index.js';
+import { validateStatement } from '../auth/statements.js';
+import { normalizeAddress } from '../auth/normalize.js';
 
 dotenv.config();
 
 // --- Configuration ---
-// Use authorized signers from network config (multisig signers)
+// Authorized signers (multisig signers) used for admin authorization.
 const ADMIN_WALLETS = getAuthorizedAddresses();
 
 console.log(chalk.cyan('[AuthMiddleware] Configuration:'));
 console.log(chalk.cyan(`  Network: ${NETWORK_CONFIG.networkName}`));
 console.log(chalk.cyan(`  Multisig: ${CURRENT_MULTISIG}`));
 console.log(chalk.cyan(`  Authorized Signers: ${ADMIN_WALLETS.length}`));
-
-// Multiple valid statements for different actions
-const VALID_STATEMENTS = [
-  "Submit milestone deliverables for Stadium",
-  "Update team members for project on Stadium",
-  "Update project details for project on Stadium",
-  "Register team address for Stadium",
-  "Perform administrative action on Stadium",
-  "Sign in to Stadium",
-  // Additional context-specific statements
-  "Submit milestone deliverables for project on Stadium",
-  "Update team members for Stadium",
-  "Update project details for Stadium",
-  "Register team address for project on Stadium",
-  // Project-specific statements (these will be generated dynamically)
-  "Create new project on Stadium",
-  "Delete project on Stadium",
-  // Admin action statements
-  "Review project on Stadium",
-  "Approve project on Stadium",
-  "Reject project on Stadium",
-  // Phase 1 revamp statements
-  "Post an update on Stadium",
-  "Update funding signal on Stadium",
-  "Apply to program on Stadium",
-  "Create program on Stadium",
-  "Update program on Stadium",
-  "Review application on Stadium",
-  // Phase 2 revamp: wallet contacts (#67)
-  "Update notification preferences for wallet on Stadium"
-];
 
 const EXPECTED_DOMAIN = process.env.EXPECTED_DOMAIN || 'localhost';
 const DISABLE_SIWS_DOMAIN_CHECK = process.env.DISABLE_SIWS_DOMAIN_CHECK === 'true';
@@ -57,40 +41,103 @@ const logError = (message) => console.log(chalk.red(`[AuthMiddleware] ${message}
 const logSuccess = (message) => console.log(chalk.green(`[AuthMiddleware] ${message}`));
 
 /**
- * Validate SIWS statement with support for context-aware and project-specific statements
+ * Shared auth pipeline: parse the header, pick the chain verifier, verify the
+ * signature, then validate the statement and (optionally) the domain.
+ *
+ * @param {string} authHeader - raw `x-siws-auth` header value
+ * @param {{ checkDomain: boolean }} options
+ * @returns {Promise<
+ *   | { ok: true, chain: string, parsed: object, normalizedAddress: string|null }
+ *   | { ok: false, status: number, body: object }
+ * >}
  */
-function validateSiwsStatement(statement) {
-  // Check exact matches first
-  if (VALID_STATEMENTS.includes(statement)) {
-    return true;
+async function authenticateRequest(authHeader, { checkDomain }) {
+  let payload;
+  try {
+    payload = parsePayload(authHeader);
+  } catch (e) {
+    return { ok: false, status: e.status || 400, body: { status: 'error', message: e.message } };
   }
-  
-  // Pattern match for project-specific statements
-  const projectPatterns = [
-    /^Update team members for .+ on Stadium$/,
-    /^Submit milestone deliverables for .+ on Stadium$/,
-    /^Update project details for .+ on Stadium$/,
-    /^Delete project .+ on Stadium$/,
-    /^Review project .+ on Stadium$/,
-    /^Approve project .+ on Stadium$/,
-    /^Reject project .+ on Stadium$/,
-    // Phase 1 revamp: project updates (#41)
-    /^Post an update to .+ on Stadium$/,
-    // Phase 1 revamp: funding signal (#42)
-    /^Update funding signal for .+ on Stadium$/,
-    // Phase 1 revamp: apply project X to program Y (#44)
-    /^Apply project .+ to program .+ on Stadium$/
-  ];
-  
-  return projectPatterns.some(pattern => pattern.test(statement));
+
+  const { chain, message, signature, address } = payload;
+
+  const verifier = getVerifier(chain);
+  if (!verifier) {
+    logError(`Unsupported sign-in chain: ${chain}`);
+    return {
+      ok: false,
+      status: 400,
+      body: { status: 'error', message: `Unsupported sign-in chain: ${chain}` },
+    };
+  }
+
+  let result;
+  try {
+    log(`Verifying ${chain} sign-in for address: ${address}`);
+    result = await verifier.verify({ message, signature, address });
+  } catch (e) {
+    logError(`Signature verification threw. Error: ${e.message}`);
+    return {
+      ok: false,
+      status: 403,
+      body: { status: 'error', message: 'SIWS signature verification failed', error: e.message },
+    };
+  }
+
+  if (!result.valid) {
+    logError(`Signature invalid for ${chain} address ${address}.`);
+    return {
+      ok: false,
+      status: 403,
+      body: {
+        status: 'error',
+        message: 'SIWS signature verification failed',
+        error: result.error || 'Invalid signature',
+      },
+    };
+  }
+
+  const { parsed, normalizedAddress } = result;
+
+  if (!validateStatement(parsed.statement)) {
+    logError(`Invalid statement. Received: "${parsed.statement}"`);
+    return {
+      ok: false,
+      status: 403,
+      body: { status: 'error', message: 'Invalid statement in SIWS message.' },
+    };
+  }
+
+  if (checkDomain && !DISABLE_SIWS_DOMAIN_CHECK) {
+    if (parsed.domain !== EXPECTED_DOMAIN) {
+      logError(`Invalid domain. Received: "${parsed.domain}". Expected: "${EXPECTED_DOMAIN}"`);
+      return {
+        ok: false,
+        status: 403,
+        body: {
+          status: 'error',
+          message: `Invalid domain. Expected '${EXPECTED_DOMAIN}'.`,
+          error: `Domain mismatch: got '${parsed.domain}'`,
+        },
+      };
+    }
+  }
+
+  logSuccess(`${chain} sign-in verified for ${parsed.address}.`);
+  return { ok: true, chain, parsed, normalizedAddress };
 }
 
 // --- Middleware ---
+
+/**
+ * Admin-only: the signer must be an authorized multisig signer.
+ */
 export const requireAdmin = async (req, res, next) => {
   log(`Initiating admin verification for ${req.method} ${req.originalUrl}`);
 
-  // DEV MODE BYPASS: Skip auth in development when header contains 'dev-bypass'
   const authHeader = req.headers['x-siws-auth'];
+
+  // DEV MODE BYPASS: skip auth in development when header is 'dev-bypass'.
   if (process.env.NODE_ENV !== 'production' && authHeader === 'dev-bypass') {
     log(chalk.yellow('⚠️  DEV MODE: Bypassing SIWS authentication'));
     req.adminAddress = ADMIN_WALLETS[0] || 'dev-admin';
@@ -101,100 +148,35 @@ export const requireAdmin = async (req, res, next) => {
     logError('Verification failed: Missing x-siws-auth header.');
     return res.status(401).json({ status: 'error', message: 'Missing SIWS auth header' });
   }
-  log('Found x-siws-auth header.');
 
-  let decodedString;
-  try {
-    decodedString = atob(authHeader);
-    log('Successfully decoded Base64 header.');
-  } catch (e) {
-    logError(`Verification failed: Could not decode Base64. Error: ${e.message}`);
-    logError(`Received value: ${authHeader}`);
-    return res.status(400).json({ status: 'error', message: 'Invalid Base64 in auth header' });
+  const auth = await authenticateRequest(authHeader, { checkDomain: true });
+  if (!auth.ok) {
+    return res.status(auth.status).json(auth.body);
   }
 
-  let signedPayload;
-  try {
-    signedPayload = JSON.parse(decodedString);
-    log('Successfully parsed JSON from decoded string.');
-  } catch (e) {
-    logError(`Verification failed: Could not parse JSON. Error: ${e.message}`);
-    logError(`Decoded string content: ${decodedString}`);
-    return res.status(400).json({ status: 'error', message: 'Malformed SIWS payload in header' });
-  }
-
-  const { message, signature, address } = signedPayload;
-  if (!message || !signature || !address) {
-    logError('Verification failed: Payload is missing message, signature, or address.');
-    logError(`Received payload: ${JSON.stringify(signedPayload)}`);
-    return res.status(400).json({ status: 'error', message: 'Incomplete SIWS payload' });
-  }
-
-  try {
-    log(`Verifying SIWS for address: ${address}`);
-
-    await cryptoWaitReady();
-    const verification = signatureVerify(message, signature, address);
-    if (!verification?.isValid) {
-      logError(`Signature invalid. crypto: ${verification?.crypto}, isWrapped: ${verification?.isWrapped}`);
-      logError(`Message length: ${message.length}, Signature length: ${signature.length}`);
-      logError(`Message starts with: ${message.substring(0, 80)}`);
-      return res.status(403).json({ status: 'error', message: 'SIWS signature verification failed', error: 'Invalid signature' });
-    }
-    logSuccess(`SIWS signature verified (crypto: ${verification.crypto}).`);
-
-    const siwsMessage = parseMessage(message);
-
-    log(`Checking statement. Received: "${siwsMessage.statement}"`);
-    if (!validateSiwsStatement(siwsMessage.statement)) {
-      logError(`Invalid statement. Received: "${siwsMessage.statement}"`);
-      logError(`Valid statements: ${VALID_STATEMENTS.join(', ')}`);
-      return res.status(403).json({ status: 'error', message: 'Invalid statement in SIWS message.' });
-    }
-    logSuccess('Statement is valid.');
-
-    // Check domain if not disabled
-    if (!DISABLE_SIWS_DOMAIN_CHECK) {
-      log(`Checking domain. Expected: "${EXPECTED_DOMAIN}"`);
-      if (siwsMessage.domain !== EXPECTED_DOMAIN) {
-        logError(`Invalid domain. Received: "${siwsMessage.domain}". Expected: "${EXPECTED_DOMAIN}"`);
-        return res.status(403).json({ status: 'error', message: `Invalid domain. Expected '${EXPECTED_DOMAIN}'.`, error: `Domain mismatch: got '${siwsMessage.domain}'` });
-      }
-      logSuccess('Domain matches.');
-    } else {
-      log('Domain check disabled (DISABLE_SIWS_DOMAIN_CHECK=true)');
-    }
-
-    const signerAddress = siwsMessage.address;
-    log(`Checking if signer address can sign for multisig. Address: ${signerAddress}`);
-
-    if (!isAuthorizedSigner(signerAddress)) {
-      logError(`Authorization failed: Address ${signerAddress} is not authorized to sign for multisig ${CURRENT_MULTISIG}`);
-      logError(`Authorized signers: ${ADMIN_WALLETS.join(', ')}`);
-      return res.status(403).json({
-        status: 'error',
-        message: 'Address is not authorized to sign for the multisig',
-        multisig: CURRENT_MULTISIG,
-        network: NETWORK_CONFIG.networkName
-      });
-    }
-
-    logSuccess(`Authorized signer ${signerAddress} can sign for multisig ${CURRENT_MULTISIG}`);
-    req.user = {
-      address: siwsMessage.address,
+  const signerAddress = auth.parsed.address;
+  if (!isAuthorizedSigner(auth.chain, signerAddress)) {
+    logError(`Authorization failed: ${signerAddress} is not authorized for multisig ${CURRENT_MULTISIG}`);
+    return res.status(403).json({
+      status: 'error',
+      message: 'Address is not authorized to sign for the multisig',
       multisig: CURRENT_MULTISIG,
-      network: NETWORK_CONFIG.environment
-    };
-    next();
-
-  } catch (e) {
-    logError(`SIWS signature verification failed. Error: ${e.message}`);
-    logError(`Stack: ${e.stack}`);
-    logError(`Received payload for debugging: ${JSON.stringify(signedPayload)}`);
-    return res.status(403).json({ status: "error", message: "SIWS signature verification failed", error: e.message });
+      network: NETWORK_CONFIG.networkName,
+    });
   }
+
+  logSuccess(`Authorized signer ${signerAddress} can sign for multisig ${CURRENT_MULTISIG}`);
+  req.user = {
+    address: signerAddress,
+    multisig: CURRENT_MULTISIG,
+    network: NETWORK_CONFIG.environment,
+  };
+  return next();
 };
 
+/**
+ * Admin OR a team member of the project identified by `req.params.projectId`.
+ */
 export const requireTeamMemberOrAdmin = async (req, res, next) => {
   log(`Initiating team member or admin verification for ${req.method} ${req.originalUrl}`);
   const { projectId } = req.params;
@@ -205,114 +187,74 @@ export const requireTeamMemberOrAdmin = async (req, res, next) => {
   }
 
   const authHeader = req.headers['x-siws-auth'];
-  
-  // DEV MODE BYPASS: Skip auth in development when header contains 'dev-bypass'
+
+  // DEV MODE BYPASS
   if (process.env.NODE_ENV !== 'production' && authHeader === 'dev-bypass') {
     log(chalk.yellow('⚠️  DEV MODE: Bypassing SIWS authentication for team/admin'));
     req.auth = { address: ADMIN_WALLETS[0] || 'dev-admin', isAdmin: true };
     return next();
   }
-  
+
   if (!authHeader) {
     logError('Verification failed: Missing x-siws-auth header.');
     return res.status(401).json({ status: 'error', message: 'Missing SIWS auth header' });
   }
-  
-  let decodedString, signedPayload, siwsMessage;
 
-  try {
-    decodedString = atob(authHeader);
-    signedPayload = JSON.parse(decodedString);
-    const { message, signature, address } = signedPayload;
-    
-    if (!message || !signature || !address) {
-      logError('Verification failed: Payload is missing message, signature, or address.');
-      return res.status(400).json({ status: 'error', message: 'Incomplete SIWS payload' });
-    }
-
-    log(`Verifying SIWS for address: ${address}`);
-
-    // Inline verification with granular error reporting
-    await cryptoWaitReady();
-    const verification = signatureVerify(message, signature, address);
-    if (!verification?.isValid) {
-      logError(`Signature invalid. crypto: ${verification?.crypto}, isWrapped: ${verification?.isWrapped}`);
-      logError(`Message length: ${message.length}, Signature length: ${signature.length}`);
-      logError(`Message starts with: ${message.substring(0, 80)}`);
-      return res.status(403).json({ status: 'error', message: 'SIWS verification failed', error: 'Invalid signature' });
-    }
-    logSuccess(`SIWS signature verified (crypto: ${verification.crypto}).`);
-
-    siwsMessage = parseMessage(message);
-
-    // Validate statement with context-aware validation
-    log(`Checking statement. Received: "${siwsMessage.statement}"`);
-    if (!validateSiwsStatement(siwsMessage.statement)) {
-      logError(`Invalid statement. Received: "${siwsMessage.statement}"`);
-      logError(`Valid statements: ${VALID_STATEMENTS.join(', ')}`);
-      return res.status(403).json({ status: 'error', message: 'Invalid statement in SIWS message.' });
-    }
-    logSuccess('Statement is valid.');
-
-  } catch (e) {
-    logError(`SIWS verification failed. Error: ${e.message}`);
-    logError(`Stack: ${e.stack}`);
-    logError(`Decoded string for debugging: ${decodedString}`);
-    return res.status(403).json({ status: "error", message: "SIWS verification failed", error: e.message });
+  // Domain is intentionally NOT checked here (preserves prior behavior — team
+  // members may sign from preview/staging origins).
+  const auth = await authenticateRequest(authHeader, { checkDomain: false });
+  if (!auth.ok) {
+    return res.status(auth.status).json(auth.body);
   }
 
-  const signerAddress = siwsMessage.address;
-  log(`Checking authorization for signer: ${signerAddress}`);
+  const signerAddress = auth.parsed.address;
 
-  if (isAuthorizedSigner(signerAddress)) {
+  // Authorized multisig signers are always allowed.
+  if (isAuthorizedSigner(auth.chain, signerAddress)) {
     logSuccess(`Signer ${signerAddress} is authorized for multisig. Granting access.`);
     req.user = {
-      address: siwsMessage.address,
+      address: signerAddress,
       multisig: CURRENT_MULTISIG,
-      network: NETWORK_CONFIG.environment
+      network: NETWORK_CONFIG.environment,
     };
     return next();
   }
-  log(`Signer ${signerAddress} is not a multisig signer. Checking project team membership...`);
 
+  // Otherwise the signer must be a team member of the project.
   try {
     const project = await projectService.getProjectById(projectId);
-
     if (!project) {
       logError(`Authorization failed: Project with ID ${projectId} not found.`);
       return res.status(404).json({ status: 'error', message: 'Project not found' });
     }
 
-    let signerPubkey;
-    try {
-      signerPubkey = u8aToHex(decodeAddress(signerAddress));
-    } catch {
-      logError(`Invalid SS58 address: ${signerAddress}`);
+    const signerNormalized = auth.normalizedAddress;
+    if (!signerNormalized) {
+      logError(`Invalid wallet address: ${signerAddress}`);
       return res.status(400).json({ status: 'error', message: 'Invalid wallet address' });
     }
 
-    const isTeamMember = (project.teamMembers || []).some(member => {
+    const isTeamMember = (project.teamMembers || []).some((member) => {
       if (!member.walletAddress) return false;
-      try {
-        return u8aToHex(decodeAddress(member.walletAddress)) === signerPubkey;
-      } catch { return false; }
+      const memberChain = member.walletChain || 'substrate';
+      const memberNormalized = normalizeAddress(memberChain, member.walletAddress);
+      return memberNormalized != null && memberNormalized === signerNormalized;
     });
 
     if (isTeamMember) {
       logSuccess(`Signer ${signerAddress} is a team member of project ${projectId}. Granting access.`);
-      req.user = { address: siwsMessage.address };
+      req.user = { address: signerAddress };
       return next();
     }
 
-    logError(`Authorization failed: Signer ${signerAddress} is not a team member of project ${projectId}.`);
+    logError(`Authorization failed: ${signerAddress} is not a team member of project ${projectId}.`);
     return res.status(403).json({
       status: 'error',
       message: 'User is not authorized to perform this action',
       detail: ADMIN_WALLETS.length === 0
         ? 'No authorized signers configured on server. Set AUTHORIZED_SIGNERS env var.'
-        : 'Address is not an authorized signer or team member of this project.'
+        : 'Address is not an authorized signer or team member of this project.',
     });
-
   } catch (error) {
     logError(`Database error while checking team membership: ${error.message}`);
     return res.status(500).json({ status: 'error', message: 'Internal server error during authorization' });
@@ -320,13 +262,7 @@ export const requireTeamMemberOrAdmin = async (req, res, next) => {
 };
 
 /**
- * Variant of requireTeamMemberOrAdmin that reads the project id from the
- * request body instead of the URL param. Used by routes whose URL is keyed
- * to a different resource (e.g. POST /api/programs/:slug/applications, where
- * :slug identifies the program and body.project_id identifies the project).
- *
- * Reuses requireTeamMemberOrAdmin unchanged — it just sets req.params.projectId
- * so the downstream logic works.
+ * The signer must match the wallet identified by `req.params.address`.
  */
 export const requireOwnWallet = async (req, res, next) => {
   log(`Initiating own-wallet verification for ${req.method} ${req.originalUrl}`);
@@ -345,96 +281,44 @@ export const requireOwnWallet = async (req, res, next) => {
     return res.status(401).json({ status: 'error', message: 'Missing SIWS auth header' });
   }
 
-  let decodedString;
-  try {
-    decodedString = atob(authHeader);
-  } catch (e) {
-    logError(`Verification failed: Could not decode Base64. Error: ${e.message}`);
-    return res.status(400).json({ status: 'error', message: 'Invalid Base64 in auth header' });
+  const auth = await authenticateRequest(authHeader, { checkDomain: true });
+  if (!auth.ok) {
+    return res.status(auth.status).json(auth.body);
   }
 
-  let signedPayload;
-  try {
-    signedPayload = JSON.parse(decodedString);
-  } catch (e) {
-    logError(`Verification failed: Could not parse JSON. Error: ${e.message}`);
-    return res.status(400).json({ status: 'error', message: 'Malformed SIWS payload in header' });
+  // The signer's chain governs how the target route param is interpreted.
+  const targetNormalized = normalizeAddress(auth.chain, req.params.address);
+  if (!targetNormalized) {
+    logError(`Invalid address in route param: ${req.params.address}`);
+    return res.status(400).json({ status: 'error', message: 'Invalid wallet address' });
   }
 
-  const { message, signature, address } = signedPayload;
-  if (!message || !signature || !address) {
-    logError('Verification failed: Payload is missing message, signature, or address.');
-    return res.status(400).json({ status: 'error', message: 'Incomplete SIWS payload' });
+  const signerNormalized = auth.normalizedAddress;
+  if (!signerNormalized) {
+    logError(`Invalid signer address: ${auth.parsed.address}`);
+    return res.status(400).json({ status: 'error', message: 'Invalid wallet address' });
   }
 
-  try {
-    await cryptoWaitReady();
-    const verification = signatureVerify(message, signature, address);
-    if (!verification?.isValid) {
-      logError(`Signature invalid. crypto: ${verification?.crypto}, isWrapped: ${verification?.isWrapped}`);
-      return res.status(403).json({ status: 'error', message: 'SIWS signature verification failed', error: 'Invalid signature' });
-    }
-    logSuccess(`SIWS signature verified (crypto: ${verification.crypto}).`);
-
-    const siwsMessage = parseMessage(message);
-
-    log(`Checking statement. Received: "${siwsMessage.statement}"`);
-    if (!validateSiwsStatement(siwsMessage.statement)) {
-      logError(`Invalid statement. Received: "${siwsMessage.statement}"`);
-      return res.status(403).json({ status: 'error', message: 'Invalid statement in SIWS message.' });
-    }
-    logSuccess('Statement is valid.');
-
-    // Check domain if not disabled
-    if (!DISABLE_SIWS_DOMAIN_CHECK) {
-      log(`Checking domain. Expected: "${EXPECTED_DOMAIN}"`);
-      if (siwsMessage.domain !== EXPECTED_DOMAIN) {
-        logError(`Invalid domain. Received: "${siwsMessage.domain}". Expected: "${EXPECTED_DOMAIN}"`);
-        return res.status(403).json({ status: 'error', message: `Invalid domain. Expected '${EXPECTED_DOMAIN}'.`, error: `Domain mismatch: got '${siwsMessage.domain}'` });
-      }
-      logSuccess('Domain matches.');
-    } else {
-      log('Domain check disabled (DISABLE_SIWS_DOMAIN_CHECK=true)');
-    }
-
-    const signerAddress = siwsMessage.address;
-
-    // Validate the target address in the route param
-    let targetPubkey;
-    try {
-      targetPubkey = u8aToHex(decodeAddress(req.params.address));
-    } catch {
-      logError(`Invalid SS58 in route param: ${req.params.address}`);
-      return res.status(400).json({ status: 'error', message: 'Invalid wallet address' });
-    }
-
-    let signerPubkey;
-    try {
-      signerPubkey = u8aToHex(decodeAddress(signerAddress));
-    } catch {
-      logError(`Invalid SS58 signer address: ${signerAddress}`);
-      return res.status(400).json({ status: 'error', message: 'Invalid wallet address' });
-    }
-
-    if (signerPubkey !== targetPubkey) {
-      logError(`Signer ${signerAddress} does not match target wallet ${req.params.address}`);
-      return res.status(403).json({
-        status: 'error',
-        message: 'Signer does not match the target wallet',
-        reason: 'not-your-wallet',
-      });
-    }
-
-    logSuccess(`Signer ${signerAddress} matches target wallet ${req.params.address}`);
-    req.user = { address: signerAddress };
-    return next();
-
-  } catch (e) {
-    logError(`SIWS verification failed. Error: ${e.message}`);
-    return res.status(403).json({ status: 'error', message: 'SIWS signature verification failed', error: e.message });
+  if (signerNormalized !== targetNormalized) {
+    logError(`Signer ${auth.parsed.address} does not match target wallet ${req.params.address}`);
+    return res.status(403).json({
+      status: 'error',
+      message: 'Signer does not match the target wallet',
+      reason: 'not-your-wallet',
+    });
   }
+
+  logSuccess(`Signer ${auth.parsed.address} matches target wallet ${req.params.address}`);
+  req.user = { address: auth.parsed.address };
+  return next();
 };
 
+/**
+ * Variant of requireTeamMemberOrAdmin that reads the project id from the
+ * request body instead of the URL param. Used by routes whose URL is keyed
+ * to a different resource (e.g. POST /api/programs/:slug/applications, where
+ * :slug identifies the program and body.project_id identifies the project).
+ */
 export const requireTeamMemberOrAdminByBodyProject = async (req, res, next) => {
   const projectId = req.body?.project_id;
   if (!projectId || typeof projectId !== 'string') {

--- a/server/api/repositories/__tests__/wallet-contact.repository.test.js
+++ b/server/api/repositories/__tests__/wallet-contact.repository.test.js
@@ -57,6 +57,7 @@ describe('WalletContactRepository.findByWallet', () => {
     const result = await repo.findByWallet('5Alice');
     expect(result).toEqual({
       walletAddress: '5Alice',
+      walletChain: 'substrate',
       email: 'alice@example.com',
       notificationsEnabled: true,
       createdAt: '2026-04-23T00:00:00Z',
@@ -106,7 +107,7 @@ describe('WalletContactRepository.upsertByWallet', () => {
         notifications_enabled: true,
         updated_at: expect.any(String),
       }),
-      { onConflict: 'wallet_address' },
+      { onConflict: 'wallet_chain,wallet_address' },
     );
     const row = upsertFn.mock.calls[0][0];
     expect(() => new Date(row.updated_at)).not.toThrow();
@@ -126,6 +127,7 @@ describe('WalletContactRepository.upsertByWallet', () => {
     const result = await repo.upsertByWallet('5Alice', { email: 'alice@example.com', notificationsEnabled: false });
     expect(result).toEqual({
       walletAddress: '5Alice',
+      walletChain: 'substrate',
       email: 'alice@example.com',
       notificationsEnabled: false,
       createdAt: '2026-04-23T00:00:00Z',
@@ -159,7 +161,7 @@ describe('WalletContactRepository.upsertByWallet', () => {
         email: 'new@x.com',
         notifications_enabled: false,
       }),
-      { onConflict: 'wallet_address' },
+      { onConflict: 'wallet_chain,wallet_address' },
     );
     expect(result.notificationsEnabled).toBe(false);
     expect(result.email).toBe('new@x.com');
@@ -188,7 +190,7 @@ describe('WalletContactRepository.upsertByWallet', () => {
         email: 'keep@x.com',
         notifications_enabled: false,
       }),
-      { onConflict: 'wallet_address' },
+      { onConflict: 'wallet_chain,wallet_address' },
     );
   });
 });

--- a/server/api/repositories/project.repository.js
+++ b/server/api/repositories/project.repository.js
@@ -16,6 +16,7 @@ const transformProject = (row) => {
         techStack: row.tech_stack || [],
         categories: row.categories || [],
         donationAddress: row.donation_address,
+        donationChain: row.donation_chain || 'substrate',
         projectState: row.project_state,
         bountiesProcessed: row.bounties_processed,
         hackathon: {
@@ -54,6 +55,7 @@ const transformProject = (row) => {
         teamMembers: (row.team_members || []).map(m => ({
             name: m.name,
             walletAddress: m.wallet_address,
+            walletChain: m.wallet_chain || 'substrate',
             customUrl: m.custom_url,
             role: m.role,
             twitter: m.twitter,
@@ -97,6 +99,7 @@ const toSupabaseProject = (data) => {
     if (data.techStack !== undefined) row.tech_stack = data.techStack;
     if (data.categories !== undefined) row.categories = data.categories;
     if (data.donationAddress !== undefined) row.donation_address = data.donationAddress;
+    if (data.donationChain !== undefined) row.donation_chain = data.donationChain;
     if (data.projectState !== undefined) row.project_state = data.projectState;
     if (data.bountiesProcessed !== undefined) row.bounties_processed = data.bountiesProcessed;
 
@@ -233,6 +236,7 @@ class ProjectRepository {
                     project_id: projectId,
                     name: m.name,
                     wallet_address: m.walletAddress,
+                    wallet_chain: m.walletChain || 'substrate',
                     custom_url: m.customUrl,
                     role: m.role,
                     twitter: m.twitter,
@@ -297,6 +301,7 @@ class ProjectRepository {
                         project_id: projectId,
                         name: m.name,
                         wallet_address: m.walletAddress,
+                        wallet_chain: m.walletChain || 'substrate',
                         custom_url: m.customUrl,
                         role: m.role,
                         twitter: m.twitter,
@@ -442,6 +447,7 @@ class ProjectRepository {
                         project_id: projectId,
                         name: m.name,
                         wallet_address: m.walletAddress,
+                        wallet_chain: m.walletChain || 'substrate',
                         custom_url: m.customUrl,
                         role: m.role,
                         twitter: m.twitter,
@@ -503,13 +509,14 @@ class ProjectRepository {
      * so "the most-recently-updated project" is the default selection in the
      * Apply modal.
      */
-    async findByTeamWallet(walletAddress) {
+    async findByTeamWallet(walletAddress, chain = 'substrate') {
         if (!walletAddress) return [];
         // Two-step: first, get project ids where the wallet is a team member.
         const { data: teamRows, error: teamErr } = await supabase
             .from('team_members')
             .select('project_id')
-            .eq('wallet_address', walletAddress);
+            .eq('wallet_address', walletAddress)
+            .eq('wallet_chain', chain);
         if (teamErr) throw teamErr;
         const projectIds = [...new Set((teamRows || []).map((r) => r.project_id))];
         if (projectIds.length === 0) return [];

--- a/server/api/repositories/wallet-contact.repository.js
+++ b/server/api/repositories/wallet-contact.repository.js
@@ -4,6 +4,7 @@ const transformContact = (row) => {
   if (!row) return null;
   return {
     walletAddress: row.wallet_address,
+    walletChain: row.wallet_chain || 'substrate',
     email: row.email,
     notificationsEnabled: row.notifications_enabled,
     createdAt: row.created_at,
@@ -12,22 +13,34 @@ const transformContact = (row) => {
 };
 
 class WalletContactRepository {
-  async findByWallet(address) {
+  /**
+   * @param {string} address
+   * @param {string} [chain='substrate']
+   */
+  async findByWallet(address, chain = 'substrate') {
     const { data, error } = await supabase
       .from('wallet_contacts')
       .select('*')
       .eq('wallet_address', address)
+      .eq('wallet_chain', chain)
       .maybeSingle();
     if (error) throw error;
     return transformContact(data);
   }
 
-  async upsertByWallet(walletAddress, fields) {
-    // fields shape: { email?: string|null, notificationsEnabled?: boolean }
-    // Only the keys present in fields are updated; absent keys retain the existing value.
-    const existing = await this.findByWallet(walletAddress);
+  /**
+   * @param {string} walletAddress
+   * @param {{ email?: string|null, notificationsEnabled?: boolean }} fields
+   * @param {string} [chain='substrate']
+   *
+   * Only the keys present in fields are updated; absent keys retain the
+   * existing value. The primary key is composite (wallet_chain, wallet_address).
+   */
+  async upsertByWallet(walletAddress, fields, chain = 'substrate') {
+    const existing = await this.findByWallet(walletAddress, chain);
     const next = {
       wallet_address: walletAddress,
+      wallet_chain: chain,
       email: 'email' in fields ? fields.email : (existing?.email ?? null),
       notifications_enabled:
         'notificationsEnabled' in fields
@@ -37,7 +50,7 @@ class WalletContactRepository {
     };
     const { data, error } = await supabase
       .from('wallet_contacts')
-      .upsert(next, { onConflict: 'wallet_address' })
+      .upsert(next, { onConflict: 'wallet_chain,wallet_address' })
       .select('*')
       .single();
     if (error) throw error;

--- a/server/api/services/project.service.js
+++ b/server/api/services/project.service.js
@@ -5,8 +5,8 @@ class ProjectService {
         return await projectRepository.getProjectById(projectId);
     }
 
-    async findByTeamWallet(walletAddress) {
-        return await projectRepository.findByTeamWallet(walletAddress);
+    async findByTeamWallet(walletAddress, chain = 'substrate') {
+        return await projectRepository.findByTeamWallet(walletAddress, chain);
     }
 
     async createProject(projectData) {

--- a/server/api/services/wallet-contact.service.js
+++ b/server/api/services/wallet-contact.service.js
@@ -6,16 +6,16 @@ const toPublic = (contact) => ({
 });
 
 class WalletContactService {
-  async getPublicContact(address) {
-    const contact = await walletContactRepository.findByWallet(address);
+  async getPublicContact(address, chain = 'substrate') {
+    const contact = await walletContactRepository.findByWallet(address, chain);
     if (!contact) {
       return { emailSet: false, notificationsEnabled: true };
     }
     return toPublic(contact);
   }
 
-  async updateContact(address, fields) {
-    const contact = await walletContactRepository.upsertByWallet(address, fields);
+  async updateContact(address, fields, chain = 'substrate') {
+    const contact = await walletContactRepository.upsertByWallet(address, fields, chain);
     return toPublic(contact);
   }
 }

--- a/server/api/utils/validation.js
+++ b/server/api/utils/validation.js
@@ -18,6 +18,30 @@ export const validateSS58 = (address) => {
   return ss58Regex.test(address);
 };
 
+/** Wallet chains supported for sign-in and address storage. */
+export const ALLOWED_WALLET_CHAINS = ['substrate', 'ethereum', 'solana'];
+
+/**
+ * Validate a wallet address for a given chain.
+ * @param {string} chain - 'substrate' | 'ethereum' | 'solana'
+ * @param {string} address
+ * @returns {boolean} - True if the address is valid for the chain
+ */
+export const validateAddress = (chain, address) => {
+  if (!address || typeof address !== 'string') return false;
+  const trimmed = address.trim();
+  switch (chain) {
+    case 'ethereum':
+      return /^0x[a-fA-F0-9]{40}$/.test(trimmed);
+    case 'solana':
+      // base58 public key — 32-byte keys encode to 32-44 base58 characters.
+      return /^[1-9A-HJ-NP-Za-km-z]{32,44}$/.test(trimmed);
+    case 'substrate':
+    default:
+      return validateSS58(trimmed);
+  }
+};
+
 /**
  * Validate URL format
  * @param {string} url - URL to validate
@@ -96,8 +120,12 @@ export const validateTeamMember = (member) => {
     return { valid: false, error: 'Team member name must be 1-100 characters' };
   }
   
-  if (member.walletAddress && !validateSS58(member.walletAddress)) {
-    return { valid: false, error: `Invalid SS58 address format: ${member.walletAddress}` };
+  if (member.walletChain !== undefined && !ALLOWED_WALLET_CHAINS.includes(member.walletChain)) {
+    return { valid: false, error: `Invalid walletChain: ${member.walletChain}` };
+  }
+  const memberWalletChain = member.walletChain || 'substrate';
+  if (member.walletAddress && !validateAddress(memberWalletChain, member.walletAddress)) {
+    return { valid: false, error: `Invalid ${memberWalletChain} address format: ${member.walletAddress}` };
   }
   
   if (member.role && !validateLength(member.role, 0, 50)) {
@@ -322,9 +350,13 @@ export const validateProject = (data) => {
     }
   }
 
+  if (data.donationChain !== undefined && !ALLOWED_WALLET_CHAINS.includes(data.donationChain)) {
+    errors.donationChain = `donationChain must be one of: ${ALLOWED_WALLET_CHAINS.join(', ')}`;
+  }
   if (data.donationAddress !== undefined && data.donationAddress !== null && data.donationAddress !== '') {
-    if (!validateSS58(data.donationAddress)) {
-      errors.donationAddress = 'donationAddress must be a valid SS58 address';
+    const donationChain = data.donationChain || 'substrate';
+    if (!validateAddress(donationChain, data.donationAddress)) {
+      errors.donationAddress = `donationAddress must be a valid ${donationChain} address`;
     }
   }
 

--- a/server/config/polkadot-config.js
+++ b/server/config/polkadot-config.js
@@ -48,6 +48,9 @@ export const AUTHORIZED_SIGNERS = (process.env.AUTHORIZED_SIGNERS || '')
   .filter(Boolean);
 
 AUTHORIZED_SIGNERS.forEach((addr, i) => {
+  // Chain-tagged entries (e.g. "ethereum:0x..", "solana:..") are validated
+  // per-chain by server/api/auth/authorizedSigners.js — skip them here.
+  if (/^(ethereum|solana|substrate):/i.test(addr)) return;
   try {
     decodeAddress(addr);
   } catch (e) {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -20,6 +20,7 @@
         "mongoose": "^8.16.1",
         "polkadot-api": "^1.13.1",
         "resend": "^6.12.3",
+        "viem": "^2.50.3",
         "ws": "^8.19.0"
       },
       "devDependencies": {
@@ -36,6 +37,12 @@
       "peerDependencies": {
         "polkadot-api": ">=1.11.2"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.1.tgz",
+      "integrity": "sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==",
+      "license": "MIT"
     },
     "node_modules/@azns/resolver-core": {
       "version": "1.7.0",
@@ -1317,6 +1324,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@noble/ciphers": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
+      "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/curves": {
@@ -4131,6 +4150,33 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@scure/bip32": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
+      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "~1.9.0",
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
+      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "~1.8.0",
+        "@scure/base": "~1.2.5"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@scure/sr25519": {
       "version": "0.2.0",
       "license": "MIT",
@@ -4508,6 +4554,27 @@
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.2.3.tgz",
+      "integrity": "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3.22.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/accepts": {
@@ -5694,6 +5761,21 @@
       "version": "2.0.0",
       "license": "ISC"
     },
+    "node_modules/isows": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.7.tgz",
+      "integrity": "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
     "node_modules/jest-diff": {
       "version": "29.7.0",
       "license": "MIT",
@@ -6723,6 +6805,57 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/ox": {
+      "version": "0.14.22",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.22.tgz",
+      "integrity": "sha512-nb5msL8qWbPglhIfZbGJAfw3cqiJjFMiWmACt7kgyWtLib12tcctbHufMT9Hb0Lr6Pt4k9I3dbpueTpbhvbqvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ox/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ox/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/parse-json": {
       "version": "8.3.0",
@@ -7970,6 +8103,51 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/viem": {
+      "version": "2.50.3",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.50.3.tgz",
+      "integrity": "sha512-xJ4XlnkKM2Of0A0TPS4KZNZU1YLYM8+mMirkNA+atTg6Crjg0YqWvSIckszSEmlQ4qH/5lhZ/DILgmNlepbV5A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "1.8.0",
+        "@scure/bip32": "1.7.0",
+        "@scure/bip39": "1.6.0",
+        "abitype": "1.2.3",
+        "isows": "1.0.7",
+        "ox": "0.14.22",
+        "ws": "8.20.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/viem/node_modules/@noble/curves": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
+      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/vitest": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
@@ -8790,8 +8968,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.19.0",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -12,6 +12,7 @@
         "@polkadot-api/descriptors": "file:.papi/descriptors",
         "@supabase/supabase-js": "^2.93.2",
         "@talismn/siws": "^1.0.0",
+        "bs58": "^6.0.0",
         "chalk": "^5.6.0",
         "cors": "^2.8.5",
         "csv-parser": "^3.0.0",
@@ -20,6 +21,7 @@
         "mongoose": "^8.16.1",
         "polkadot-api": "^1.13.1",
         "resend": "^6.12.3",
+        "tweetnacl": "^1.0.3",
         "viem": "^2.50.3",
         "ws": "^8.19.0"
       },
@@ -4653,6 +4655,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base-x": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
+      "integrity": "sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==",
+      "license": "MIT"
+    },
     "node_modules/bech32": {
       "version": "1.1.4",
       "license": "MIT"
@@ -4716,6 +4724,15 @@
     "node_modules/brorand": {
       "version": "1.1.0",
       "license": "MIT"
+    },
+    "node_modules/bs58": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-6.0.0.tgz",
+      "integrity": "sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==",
+      "license": "MIT",
+      "dependencies": {
+        "base-x": "^5.0.0"
+      }
     },
     "node_modules/bson": {
       "version": "6.10.4",
@@ -8009,6 +8026,12 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
     },
     "node_modules/type-fest": {
       "version": "5.4.2",

--- a/server/package.json
+++ b/server/package.json
@@ -27,6 +27,7 @@
     "@polkadot-api/descriptors": "file:.papi/descriptors",
     "@supabase/supabase-js": "^2.93.2",
     "@talismn/siws": "^1.0.0",
+    "bs58": "^6.0.0",
     "chalk": "^5.6.0",
     "cors": "^2.8.5",
     "csv-parser": "^3.0.0",
@@ -35,6 +36,7 @@
     "mongoose": "^8.16.1",
     "polkadot-api": "^1.13.1",
     "resend": "^6.12.3",
+    "tweetnacl": "^1.0.3",
     "viem": "^2.50.3",
     "ws": "^8.19.0"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -35,6 +35,7 @@
     "mongoose": "^8.16.1",
     "polkadot-api": "^1.13.1",
     "resend": "^6.12.3",
+    "viem": "^2.50.3",
     "ws": "^8.19.0"
   },
   "devDependencies": {

--- a/supabase/migrations/20260520000000_multichain_addresses.sql
+++ b/supabase/migrations/20260520000000_multichain_addresses.sql
@@ -1,0 +1,50 @@
+-- Stadium multi-chain sign-in (Phase D).
+--
+-- Adds a `chain` discriminator to every address-bearing table so team members
+-- and payout addresses can be Substrate, Ethereum or Solana. Every existing
+-- row is Substrate; the `DEFAULT 'substrate'` backfills them in place before
+-- any new constraint is applied.
+
+-- ── team_members ──────────────────────────────────────────────────────────
+-- Which chain a member's wallet_address belongs to.
+ALTER TABLE team_members
+  ADD COLUMN IF NOT EXISTS wallet_chain TEXT NOT NULL DEFAULT 'substrate';
+
+ALTER TABLE team_members
+  DROP CONSTRAINT IF EXISTS team_members_wallet_chain_check;
+ALTER TABLE team_members
+  ADD CONSTRAINT team_members_wallet_chain_check
+  CHECK (wallet_chain IN ('substrate', 'ethereum', 'solana'));
+
+-- Team-member lookups now filter on (chain, address) — see findByTeamWallet.
+DROP INDEX IF EXISTS idx_team_members_wallet_address;
+CREATE INDEX IF NOT EXISTS idx_team_members_chain_wallet
+  ON team_members (wallet_chain, wallet_address);
+
+-- ── projects ──────────────────────────────────────────────────────────────
+-- Which chain the donation / payout address belongs to.
+ALTER TABLE projects
+  ADD COLUMN IF NOT EXISTS donation_chain TEXT NOT NULL DEFAULT 'substrate';
+
+ALTER TABLE projects
+  DROP CONSTRAINT IF EXISTS projects_donation_chain_check;
+ALTER TABLE projects
+  ADD CONSTRAINT projects_donation_chain_check
+  CHECK (donation_chain IN ('substrate', 'ethereum', 'solana'));
+
+-- ── wallet_contacts ───────────────────────────────────────────────────────
+-- A raw address is no longer globally unique (the same string could exist on
+-- two chains), so the primary key becomes composite. The new column backfills
+-- every existing row to 'substrate' BEFORE the primary key is recreated, so
+-- there are no key collisions.
+ALTER TABLE wallet_contacts
+  ADD COLUMN IF NOT EXISTS wallet_chain TEXT NOT NULL DEFAULT 'substrate';
+
+ALTER TABLE wallet_contacts
+  DROP CONSTRAINT IF EXISTS wallet_contacts_wallet_chain_check;
+ALTER TABLE wallet_contacts
+  ADD CONSTRAINT wallet_contacts_wallet_chain_check
+  CHECK (wallet_chain IN ('substrate', 'ethereum', 'solana'));
+
+ALTER TABLE wallet_contacts DROP CONSTRAINT IF EXISTS wallet_contacts_pkey;
+ALTER TABLE wallet_contacts ADD PRIMARY KEY (wallet_chain, wallet_address);


### PR DESCRIPTION
## Summary

Adds **multi-chain sign-in** to Stadium. Anyone — admins and team members — can authenticate with the wallet ecosystem they use: **Substrate (SIWS)**, **Ethereum (SIWE / EIP-4361)**, or **Solana (Sign-In With Solana)**. Team-member and payout addresses become multi-chain too.

Backward-compatible throughout: the `x-siws-auth` payload gains an optional `chain` field defaulting to `substrate`, and every new DB column / address field defaults to `substrate`, so existing flows are unchanged.

Shipped in four phases (one logical commit group each):

- **Phase A** — server verifier abstraction (`server/api/auth/`): per-chain verifier registry, shared statement validation, payload parsing, address normalization. `auth.middleware.js` refactored to one chain-aware pipeline.
- **Phase B** — Ethereum (SIWE) end-to-end: viem-based verifier (`parseSiweMessage` + offline `recoverMessageAddress`), chain-tagged `AUTHORIZED_SIGNERS`, client wallet-provider abstraction (`client/src/lib/auth/`), EIP-6963 discovery, `useWalletAuth` hook, `ChainPicker`. `AdminPage` + `ProjectDetailsPage` migrated off the Polkadot-only wallet code.
- **Phase C** — Solana (Sign-In With Solana): tweetnacl/bs58 verifier, `window.solana` provider.
- **Phase D** — multi-chain addresses: migration adds `team_members.wallet_chain`, `projects.donation_chain`, and a composite PK on `wallet_contacts`; repository / validation / `wallet_contacts` API are chain-aware; `TeamPaymentSection` gains chain selectors on team wallets and the payout address.

## Test plan

- ✅ Server: `npm test` — **161 tests pass** (21 files), including new verifier / `authorizedSigners` / `parsePayload` / `statements` suites and updated `auth.middleware` + `wallet-contact` suites.
- ✅ Client: `npm run build` (tsc) — green.
- ✅ Client: `npm run lint` (`--max-warnings 0`) — green.
- ⚠️ **Interactive wallet flows not automatable here** — MetaMask / Phantom / Polkadot-JS popups need a manual local run. Verify all three sign-in paths + a multi-chain payout-address save.

## ⚠️ Requires a human before merge

1. **Apply the migration** `supabase/migrations/20260520000000_multichain_addresses.sql` to Supabase per `docs/PRODUCTION_DEPLOYMENT.md`. The `wallet_contacts` composite-PK swap is the highest-risk DDL — run on a Supabase branch first. All existing rows backfill to `substrate` via column defaults before any constraint is applied.
2. **Add test signers** — to use a non-Substrate admin, add `ethereum:0x…` / `solana:…` entries to `AUTHORIZED_SIGNERS` (server) and `VITE_ADMIN_ADDRESSES` (client).

## Notes / follow-ups

- Admins can authenticate on any chain, but the treasury **multisig is Polkadot** — co-signing treasury transactions still requires a Substrate signer.
- Automated payout *execution* stays Substrate-only; ETH/SOL payout addresses can be registered/recorded but are settled manually. A follow-up issue should cover automated multi-chain payout execution.
- Display-only admin views (`TeamAddressList`, `ConfirmPaymentModal`) render multi-chain addresses but don't yet badge the chain. Legacy unused modals (`UpdatePayoutModal`, `EditTeamModal`, `UpdateTeamModal`) were left as-is.
- Pre-existing weakness, not introduced here: the server does not track nonces, so a captured auth header is replayable. SIWE/Solana messages now carry `expirationTime` (10-min) as partial mitigation; a server-side nonce store is recommended as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
