### PR TITLE
fix: enforce SIWS domain check in requireTeamMemberOrAdmin

### DIFF
--- a/server/api/middleware/__tests__/auth.middleware.test.js
+++ b/server/api/middleware/__tests__/auth.middleware.test.js
@@ -349,4 +349,26 @@ describe('requireTeamMemberOrAdmin', () => {
     expect(res.statusCode).toBe(403);
     expect(next).not.toHaveBeenCalled();
   });
+
+  it('returns 403 on domain mismatch', async () => {
+    signatureVerify.mockReturnValue({ isValid: true, crypto: 'sr25519' });
+    parseMessage.mockReturnValue({
+      statement: 'Perform administrative action on Stadium',
+      address: '5FakeAdmin1',
+      domain: 'evil.com',
+    });
+
+    const req = makeReq({
+      params: { projectId: 'proj-1' },
+      headers: { 'x-siws-auth': encodePayload(VALID_PAYLOAD) },
+    });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireTeamMemberOrAdmin(req, res, next);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.message).toMatch(/Invalid domain/i);
+    expect(next).not.toHaveBeenCalled();
+  });
 });

--- a/server/api/middleware/auth.middleware.js
+++ b/server/api/middleware/auth.middleware.js
@@ -200,9 +200,10 @@ export const requireTeamMemberOrAdmin = async (req, res, next) => {
     return res.status(401).json({ status: 'error', message: 'Missing SIWS auth header' });
   }
 
-  // Domain is intentionally NOT checked here (preserves prior behavior — team
-  // members may sign from preview/staging origins).
-  const auth = await authenticateRequest(authHeader, { checkDomain: false });
+  // Domain is verified here too, consistent with requireAdmin / requireOwnWallet.
+  // Preview/staging origins are handled by DISABLE_SIWS_DOMAIN_CHECK, not by
+  // skipping the check.
+  const auth = await authenticateRequest(authHeader, { checkDomain: true });
   if (!auth.ok) {
     return res.status(auth.status).json(auth.body);
   }


### PR DESCRIPTION
## Summary

Security hardening. `requireAdmin` and `requireOwnWallet` verify the sign-in message `domain` against `EXPECTED_DOMAIN` (skippable via `DISABLE_SIWS_DOMAIN_CHECK`), but `requireTeamMemberOrAdmin` skipped that check entirely — a sign-in message produced for a different origin would still be accepted on team-gated routes.

This enables the same check there, so all three middleware are consistent. Preview/staging origins are handled the intended way — `DISABLE_SIWS_DOMAIN_CHECK=true` — rather than by omitting the check.

Addresses the backlog item *"`requireTeamMemberOrAdmin` missing SIWS domain check"* (`docs/improvement-backlog.md`, 2026-04-23).

## Changes

- `server/api/middleware/auth.middleware.js` — `requireTeamMemberOrAdmin` calls `authenticateRequest(..., { checkDomain: true })`.
- `auth.middleware.test.js` — adds a 403-on-domain-mismatch test for `requireTeamMemberOrAdmin`.

## Test plan

- ✅ `cd server && npm test` — **162 tests pass** (21 files), including the new domain-mismatch case; all existing `requireTeamMemberOrAdmin` cases (which sign on `localhost`) still pass.

## Note

Live deployments must have `EXPECTED_DOMAIN` set correctly (or `DISABLE_SIWS_DOMAIN_CHECK=true` for previews) — same requirement the other two middleware already had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
