### PR TITLE
fix: store M2 program entitlement per project (#26)

### DIFF
--- a/client/src/components/admin/WinnersTable.tsx
+++ b/client/src/components/admin/WinnersTable.tsx
@@ -29,12 +29,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import {
   Tabs,
   TabsContent,
   TabsList,
@@ -515,7 +509,7 @@ export function WinnersTable({ projects, onRefresh, connectedAddress, signAdminA
                 <TableHead className={connectedAddress ? "w-[18%]" : "w-[22%]"}>Project</TableHead>
                 <TableHead className={connectedAddress ? "w-[12%]" : "w-[15%]"}>Event</TableHead>
                 <TableHead className={connectedAddress ? "w-[20%]" : "w-[24%]"}>Track/Bounty</TableHead>
-                <TableHead className={connectedAddress ? "w-[10%]" : "w-[12%]"}>Bounty amount</TableHead>
+                <TableHead className={connectedAddress ? "w-[10%]" : "w-[12%]"}>Amount</TableHead>
                 <TableHead className={connectedAddress ? "w-[10%]" : "w-[12%]"}>M2 Status</TableHead>
                 <TableHead className={connectedAddress ? "w-[10%]" : "w-[15%]"}>Payment</TableHead>
                 {connectedAddress && <TableHead className="w-[20%] text-right">Actions</TableHead>}
@@ -524,6 +518,12 @@ export function WinnersTable({ projects, onRefresh, connectedAddress, signAdminA
             <TableBody>
               {sortedProjects.map((project) => {
                 const totalBounty = getTotalBounty(project);
+                // M2 program grant (issue #26) — schema-backed entitlement,
+                // only present on M2 projects.
+                const m2Grant = project.m2Entitlement
+                  ? (project.m2Entitlement.milestone1Amount || 0) + (project.m2Entitlement.milestone2Amount || 0)
+                  : 0;
+                const totalAmount = totalBounty + m2Grant;
                 const isSaving = saving === project.id;
 
                 return (
@@ -552,35 +552,20 @@ export function WinnersTable({ projects, onRefresh, connectedAddress, signAdminA
                       </div>
                     </TableCell>
 
-                    {/* Bounty amount (sum of bountyPrize[].amount from schema).
-                        M2 program grant is NOT included here — entitlement is not
-                        stored in the schema yet. See issue #26. */}
+                    {/* Amount — bounty sum + M2 program grant. The M2
+                        entitlement is schema-backed per project (issue #26). */}
                     <TableCell>
                       <div className="space-y-1">
-                        <p className="font-semibold">{formatAmount(totalBounty, getProjectCurrency(project))}</p>
-                        {project.bountyPrize.length > 1 && (
+                        <p className="font-semibold">{formatAmount(totalAmount, getProjectCurrency(project))}</p>
+                        {(project.bountyPrize.length > 1 || m2Grant > 0) && (
                           <div className="text-xs text-muted-foreground">
                             {project.bountyPrize.map((b: BountyPrize, idx: number) => (
-                              <div key={idx}>{formatAmount(b.amount, b.currency)}</div>
+                              <div key={idx}>Bounty: {formatAmount(b.amount, b.currency)}</div>
                             ))}
+                            {m2Grant > 0 && (
+                              <div>M2 grant: {formatAmount(m2Grant, project.m2Entitlement?.currency)}</div>
+                            )}
                           </div>
-                        )}
-                        {project.m2Status && (
-                          <TooltipProvider delayDuration={100}>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Badge variant="outline" className="text-[10px] font-normal cursor-help">
-                                  + M2 grant
-                                </Badge>
-                              </TooltipTrigger>
-                              <TooltipContent className="max-w-xs">
-                                <p className="text-xs">
-                                  This team is in the M2 program and is owed an additional grant beyond the bounty shown.
-                                  The M2 entitlement is not yet stored in the schema per project — tracked in issue #26.
-                                </p>
-                              </TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
                         )}
                       </div>
                     </TableCell>

--- a/server/api/repositories/project.repository.js
+++ b/server/api/repositories/project.repository.js
@@ -35,6 +35,12 @@ const transformProject = (row) => {
             lastUpdatedBy: row.m2_last_updated_by,
             lastUpdatedDate: row.m2_last_updated_date
         } : undefined,
+        // Planned M2 program grant (issue #26) — only meaningful for M2 projects.
+        m2Entitlement: row.m2_status ? {
+            milestone1Amount: row.m2_milestone_1_amount,
+            milestone2Amount: row.m2_milestone_2_amount,
+            currency: row.m2_currency
+        } : undefined,
         finalSubmission: row.final_submission_repo_url ? {
             repoUrl: row.final_submission_repo_url,
             demoUrl: row.final_submission_demo_url,
@@ -121,6 +127,11 @@ const toSupabaseProject = (data) => {
         if (data.m2Agreement.successCriteria !== undefined) row.m2_success_criteria = data.m2Agreement.successCriteria;
         if (data.m2Agreement.lastUpdatedBy !== undefined) row.m2_last_updated_by = data.m2Agreement.lastUpdatedBy;
         if (data.m2Agreement.lastUpdatedDate !== undefined) row.m2_last_updated_date = data.m2Agreement.lastUpdatedDate;
+    }
+    if (data.m2Entitlement) {
+        if (data.m2Entitlement.milestone1Amount !== undefined) row.m2_milestone_1_amount = data.m2Entitlement.milestone1Amount;
+        if (data.m2Entitlement.milestone2Amount !== undefined) row.m2_milestone_2_amount = data.m2Entitlement.milestone2Amount;
+        if (data.m2Entitlement.currency !== undefined) row.m2_currency = data.m2Entitlement.currency;
     }
 
     // Final submission

--- a/supabase/migrations/20260520100000_m2_entitlement.sql
+++ b/supabase/migrations/20260520100000_m2_entitlement.sql
@@ -1,0 +1,19 @@
+-- Stadium #26 — store each M2 project's planned grant entitlement.
+--
+-- The projects table held M2 metadata (status, mentor, features) but no
+-- amounts, so the admin Winners table could only sum bounty_prizes and had no
+-- schema-backed way to show the M1 + M2 program grant. Hardcoding the amount
+-- in client code was rejected — these columns make the entitlement schema
+-- truth instead.
+--
+-- The column DEFAULT (2500 / 2500 / USDC) backfills every existing row and
+-- applies to new rows automatically. transformProject only surfaces the
+-- entitlement for projects actually in the M2 program (m2_status set), so a
+-- bounty-only project carrying the default values never displays them.
+
+ALTER TABLE projects
+  ADD COLUMN IF NOT EXISTS m2_milestone_1_amount NUMERIC NOT NULL DEFAULT 2500;
+ALTER TABLE projects
+  ADD COLUMN IF NOT EXISTS m2_milestone_2_amount NUMERIC NOT NULL DEFAULT 2500;
+ALTER TABLE projects
+  ADD COLUMN IF NOT EXISTS m2_currency TEXT NOT NULL DEFAULT 'USDC';


### PR DESCRIPTION
Closes #26.

## Summary

The `projects` table had M2 metadata (status, mentor, features) but **no amounts**, so the admin Winners table could only sum `bounty_prizes` — it had no schema-backed way to show the M1 + M2 program grant. A temporary `+ M2 grant` badge papered over it.

This stores the entitlement as schema truth.

## Changes

- **Migration `20260520100000_m2_entitlement.sql`** — adds `m2_milestone_1_amount`, `m2_milestone_2_amount` (`NUMERIC`) and `m2_currency` (`TEXT`) to `projects`, each with a column `DEFAULT` (2500 / 2500 / `USDC`). The default backfills every existing row and applies to new rows automatically.
- **`project.repository.js`** — `transformProject` exposes a nested `m2Entitlement: { milestone1Amount, milestone2Amount, currency }`, gated on `m2_status` (same pattern as `m2Agreement`) so a bounty-only project carrying the default values never surfaces them. `toSupabaseProject` maps it back.
- **`WinnersTable.tsx`** — column renamed `"Bounty amount"` → `"Amount"`; the cell now renders `bounty sum + M2 entitlement` with a per-line breakdown (`Bounty: …` / `M2 grant: …`). The temporary `+ M2 grant` badge/tooltip and its now-unused `Tooltip` imports are removed.

## Decisions

- **Population:** the entitlement defaults to **$2,500 / $2,500 USDC** at the DB level (per maintainer decision) — schema truth, no client hardcode, every M2 project gets it automatically. An admin-editable UI for per-project amounts can be a follow-up if needed.
- **Backfill of historical non-default values** is out of scope per the issue — the column `DEFAULT` sets all existing M2 projects to the standard $5,000.

## Test plan

- ✅ `cd server && npm test` — 161 tests pass.
- ✅ `cd client && npm run build` (tsc) — green.
- ✅ `cd client && npm run lint` — green.
- ⚠️ Migration `20260520100000_m2_entitlement.sql` must be applied to Supabase (per `docs/PRODUCTION_DEPLOYMENT.md`) — additive, low-risk (`ADD COLUMN … DEFAULT`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
