### PR TITLE
feat: single-use sign-in nonces + message expiry (#88)

### DIFF
--- a/client/src/lib/auth/substrateProvider.ts
+++ b/client/src/lib/auth/substrateProvider.ts
@@ -57,6 +57,8 @@ export const substrateProvider: WalletProvider = {
       address: account.address,
       nonce: Math.random().toString(36).slice(2),
       statement,
+      // Short-lived — the server rejects expired / nonce-replayed messages.
+      expirationTime: Date.now() + 10 * 60 * 1000,
     })
     const message = siws.prepareMessage()
     const { signature } = await signRaw({

--- a/server/api/auth/__tests__/nonceStore.test.js
+++ b/server/api/auth/__tests__/nonceStore.test.js
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../db.js', () => ({
+  supabase: { from: vi.fn() },
+}));
+
+const { supabase } = await import('../../../db.js');
+const { consumeNonce } = await import('../nonceStore.js');
+
+// from() -> supports insert(...) and delete().lt(...) (opportunistic cleanup).
+function mockTable(insertResult) {
+  return {
+    insert: vi.fn(() => Promise.resolve(insertResult)),
+    delete: vi.fn(() => ({ lt: vi.fn(() => Promise.resolve({ error: null })) })),
+  };
+}
+
+const FUTURE = Date.now() + 600_000;
+
+describe('consumeNonce', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns missing-nonce when the nonce is absent', async () => {
+    const result = await consumeNonce('', FUTURE);
+    expect(result).toEqual({ ok: false, reason: 'missing-nonce' });
+    expect(supabase.from).not.toHaveBeenCalled();
+  });
+
+  it('returns ok the first time a nonce is consumed', async () => {
+    supabase.from.mockReturnValue(mockTable({ error: null }));
+    const result = await consumeNonce('nonce-abc', FUTURE);
+    expect(result).toEqual({ ok: true });
+  });
+
+  it('returns replay on a unique-violation (Postgres 23505)', async () => {
+    supabase.from.mockReturnValue(mockTable({ error: { code: '23505' } }));
+    const result = await consumeNonce('nonce-abc', FUTURE);
+    expect(result).toEqual({ ok: false, reason: 'replay' });
+  });
+
+  it('rethrows a non-unique-violation database error', async () => {
+    supabase.from.mockReturnValue(mockTable({ error: { code: '500', message: 'db down' } }));
+    await expect(consumeNonce('nonce-abc', FUTURE)).rejects.toEqual({ code: '500', message: 'db down' });
+  });
+});

--- a/server/api/auth/nonceStore.js
+++ b/server/api/auth/nonceStore.js
@@ -1,0 +1,49 @@
+/**
+ * Single-use sign-in nonce store — anti-replay (issue #88).
+ *
+ * Each `x-siws-auth` message carries a client-generated nonce. The first time a
+ * nonce is presented it is recorded; any later presentation is a replay and is
+ * rejected. Rows expire with the owning message, so the table self-prunes.
+ */
+
+import { supabase } from '../../db.js';
+
+// Fraction of consume calls that also sweep expired rows.
+const CLEANUP_PROBABILITY = 0.05;
+
+/**
+ * Record a nonce as used.
+ *
+ * @param {string} nonce
+ * @param {number|string|Date} expiresAt - when the owning message expires
+ * @returns {Promise<{ ok: boolean, reason?: 'missing-nonce'|'replay' }>}
+ *   `{ ok: true }` the first time a nonce is seen; `{ ok: false, reason }`
+ *   if the nonce is absent or has already been used.
+ */
+export async function consumeNonce(nonce, expiresAt) {
+  if (!nonce || typeof nonce !== 'string') {
+    return { ok: false, reason: 'missing-nonce' };
+  }
+
+  const { error } = await supabase
+    .from('auth_nonces')
+    .insert({ nonce, expires_at: new Date(expiresAt).toISOString() });
+
+  if (error) {
+    // 23505 = unique_violation — the nonce has already been used.
+    if (error.code === '23505') {
+      return { ok: false, reason: 'replay' };
+    }
+    throw error;
+  }
+
+  if (Math.random() < CLEANUP_PROBABILITY) {
+    try {
+      await supabase.from('auth_nonces').delete().lt('expires_at', new Date().toISOString());
+    } catch {
+      // Best-effort cleanup — never fail a request over it.
+    }
+  }
+
+  return { ok: true };
+}

--- a/server/api/middleware/__tests__/auth.middleware.test.js
+++ b/server/api/middleware/__tests__/auth.middleware.test.js
@@ -46,12 +46,17 @@ vi.mock('../../services/project.service.js', () => ({
   },
 }));
 
+vi.mock('../../auth/nonceStore.js', () => ({
+  consumeNonce: vi.fn(),
+}));
+
 // Now import what we need
 import { verifySIWS, parseMessage } from '@talismn/siws';
 import { signatureVerify, decodeAddress } from '@polkadot/util-crypto';
 import { u8aToHex } from '@polkadot/util';
 import { isAuthorizedSigner } from '../../auth/authorizedSigners.js';
 import projectService from '../../services/project.service.js';
+import { consumeNonce } from '../../auth/nonceStore.js';
 
 // Import middleware under test
 const { requireAdmin, requireTeamMemberOrAdmin } = await import('../auth.middleware.js');
@@ -95,6 +100,7 @@ describe('requireAdmin', () => {
     // Default: non-production
     process.env.NODE_ENV = 'test';
     process.env.DISABLE_SIWS_DOMAIN_CHECK = 'true';
+    consumeNonce.mockResolvedValue({ ok: true });
   });
 
   it('returns 401 when auth header is missing', async () => {
@@ -184,6 +190,7 @@ describe('requireAdmin', () => {
       statement: 'Perform administrative action on Stadium',
       address: '5FakeAdmin1',
       domain: 'localhost',
+      expirationTime: new Date(Date.now() + 600000).toISOString(),
     });
     isAuthorizedSigner.mockReturnValue(false);
 
@@ -206,6 +213,7 @@ describe('requireAdmin', () => {
       statement: 'Perform administrative action on Stadium',
       address: '5FakeAdmin1',
       domain: 'localhost',
+      expirationTime: new Date(Date.now() + 600000).toISOString(),
     });
     isAuthorizedSigner.mockReturnValue(true);
 
@@ -224,6 +232,49 @@ describe('requireAdmin', () => {
       network: 'development',
     });
   });
+
+  it('returns 403 when the sign-in message has expired', async () => {
+    signatureVerify.mockReturnValue({ isValid: true, crypto: 'sr25519' });
+    parseMessage.mockReturnValue({
+      statement: 'Perform administrative action on Stadium',
+      address: '5FakeAdmin1',
+      domain: 'localhost',
+      expirationTime: new Date(Date.now() - 60000).toISOString(),
+    });
+    isAuthorizedSigner.mockReturnValue(true);
+
+    const req = makeReq({ headers: { 'x-siws-auth': encodePayload(VALID_PAYLOAD) } });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireAdmin(req, res, next);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.message).toMatch(/expired/i);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when the nonce has already been used (replay)', async () => {
+    signatureVerify.mockReturnValue({ isValid: true, crypto: 'sr25519' });
+    parseMessage.mockReturnValue({
+      statement: 'Perform administrative action on Stadium',
+      address: '5FakeAdmin1',
+      domain: 'localhost',
+      expirationTime: new Date(Date.now() + 600000).toISOString(),
+    });
+    isAuthorizedSigner.mockReturnValue(true);
+    consumeNonce.mockResolvedValue({ ok: false, reason: 'replay' });
+
+    const req = makeReq({ headers: { 'x-siws-auth': encodePayload(VALID_PAYLOAD) } });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireAdmin(req, res, next);
+
+    expect(res.statusCode).toBe(403);
+    expect(res.body.message).toMatch(/already been used/i);
+    expect(next).not.toHaveBeenCalled();
+  });
 });
 
 // ─── requireTeamMemberOrAdmin ────────────────────────────────
@@ -233,6 +284,7 @@ describe('requireTeamMemberOrAdmin', () => {
     vi.clearAllMocks();
     process.env.NODE_ENV = 'test';
     process.env.DISABLE_SIWS_DOMAIN_CHECK = 'true';
+    consumeNonce.mockResolvedValue({ ok: true });
   });
 
   it('returns 400 when projectId is missing', async () => {
@@ -269,6 +321,7 @@ describe('requireTeamMemberOrAdmin', () => {
       statement: 'Perform administrative action on Stadium',
       address: '5FakeAdmin1',
       domain: 'localhost',
+      expirationTime: new Date(Date.now() + 600000).toISOString(),
     });
     isAuthorizedSigner.mockReturnValue(true);
 
@@ -296,6 +349,7 @@ describe('requireTeamMemberOrAdmin', () => {
       statement: 'Perform administrative action on Stadium',
       address: '5TeamMember1',
       domain: 'localhost',
+      expirationTime: new Date(Date.now() + 600000).toISOString(),
     });
     isAuthorizedSigner.mockReturnValue(false);
     decodeAddress.mockReturnValue(new Uint8Array([0xab, 0xcd]));
@@ -323,6 +377,7 @@ describe('requireTeamMemberOrAdmin', () => {
       statement: 'Perform administrative action on Stadium',
       address: '5Stranger',
       domain: 'localhost',
+      expirationTime: new Date(Date.now() + 600000).toISOString(),
     });
     isAuthorizedSigner.mockReturnValue(false);
     decodeAddress.mockImplementation((addr) => {

--- a/server/api/middleware/__tests__/wallet-contact.middleware.test.js
+++ b/server/api/middleware/__tests__/wallet-contact.middleware.test.js
@@ -37,9 +37,14 @@ vi.mock('../../services/project.service.js', () => ({
   default: { getProjectById: vi.fn() },
 }));
 
+vi.mock('../../auth/nonceStore.js', () => ({
+  consumeNonce: vi.fn(),
+}));
+
 import { parseMessage, verifySIWS } from '@talismn/siws';
 import { signatureVerify, decodeAddress } from '@polkadot/util-crypto';
 import { u8aToHex } from '@polkadot/util';
+import { consumeNonce } from '../../auth/nonceStore.js';
 
 const { requireOwnWallet } = await import('../auth.middleware.js');
 
@@ -78,6 +83,7 @@ describe('requireOwnWallet', () => {
     vi.clearAllMocks();
     process.env.NODE_ENV = 'test';
     process.env.DISABLE_SIWS_DOMAIN_CHECK = 'true';
+    consumeNonce.mockResolvedValue({ ok: true });
   });
 
   it('returns 401 when x-siws-auth header is missing', async () => {
@@ -140,6 +146,7 @@ describe('requireOwnWallet', () => {
       statement: 'Update notification preferences for wallet on Stadium',
       address: '5Alice',
       domain: 'localhost',
+      expirationTime: new Date(Date.now() + 600000).toISOString(),
     });
     decodeAddress.mockReturnValue(new Uint8Array([0xab, 0xcd]));
     u8aToHex.mockReturnValue(pubkey);
@@ -163,6 +170,7 @@ describe('requireOwnWallet', () => {
       statement: 'Update notification preferences for wallet on Stadium',
       address: '5Bob',
       domain: 'localhost',
+      expirationTime: new Date(Date.now() + 600000).toISOString(),
     });
     decodeAddress.mockImplementation((addr) => {
       if (addr === '5Alice') return new Uint8Array([0x01]);
@@ -215,6 +223,7 @@ describe('requireOwnWallet', () => {
       statement: 'Update notification preferences for wallet on Stadium',
       address: '5Alice',
       domain: 'localhost',
+      expirationTime: new Date(Date.now() + 600000).toISOString(),
     });
     decodeAddress.mockImplementation((addr) => {
       if (addr === 'not-a-wallet') throw new Error('Invalid SS58 address');

--- a/server/api/middleware/auth.middleware.js
+++ b/server/api/middleware/auth.middleware.js
@@ -21,6 +21,7 @@ import { parsePayload } from '../auth/parsePayload.js';
 import { getVerifier } from '../auth/verifiers/index.js';
 import { validateStatement } from '../auth/statements.js';
 import { normalizeAddress } from '../auth/normalize.js';
+import { consumeNonce } from '../auth/nonceStore.js';
 
 dotenv.config();
 
@@ -121,6 +122,50 @@ async function authenticateRequest(authHeader, { checkDomain }) {
         },
       };
     }
+  }
+
+  // Reject stale messages and consume the nonce — single-use, anti-replay (#88).
+  const expiresAtMs = parsed.expirationTime ? new Date(parsed.expirationTime).getTime() : NaN;
+  if (!Number.isFinite(expiresAtMs)) {
+    logError('Sign-in message has no expiration time.');
+    return {
+      ok: false,
+      status: 403,
+      body: { status: 'error', message: 'Sign-in message must include an expiration time' },
+    };
+  }
+  if (expiresAtMs <= Date.now()) {
+    logError('Sign-in message has expired.');
+    return {
+      ok: false,
+      status: 403,
+      body: { status: 'error', message: 'Sign-in message has expired' },
+    };
+  }
+
+  let nonceResult;
+  try {
+    nonceResult = await consumeNonce(parsed.nonce, expiresAtMs);
+  } catch (e) {
+    logError(`Nonce store error: ${e.message}`);
+    return {
+      ok: false,
+      status: 500,
+      body: { status: 'error', message: 'Internal error during authentication' },
+    };
+  }
+  if (!nonceResult.ok) {
+    logError(`Nonce rejected (${nonceResult.reason}).`);
+    return {
+      ok: false,
+      status: 403,
+      body: {
+        status: 'error',
+        message: nonceResult.reason === 'replay'
+          ? 'Sign-in message has already been used'
+          : 'Sign-in message must include a nonce',
+      },
+    };
   }
 
   logSuccess(`${chain} sign-in verified for ${parsed.address}.`);

--- a/supabase/migrations/20260520200000_auth_nonces.sql
+++ b/supabase/migrations/20260520200000_auth_nonces.sql
@@ -1,0 +1,14 @@
+-- Stadium #88 — single-use sign-in nonces (anti-replay).
+--
+-- Every x-siws-auth message carries a client-generated nonce. Recording each
+-- nonce the first time it is presented and rejecting repeats makes a captured
+-- auth header non-replayable. A row is only needed until the owning message
+-- expires, so expires_at drives opportunistic cleanup.
+
+CREATE TABLE IF NOT EXISTS auth_nonces (
+  nonce       TEXT PRIMARY KEY,
+  expires_at  TIMESTAMPTZ NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_nonces_expires_at ON auth_nonces (expires_at);


### PR DESCRIPTION
Closes #88.

## Summary

A captured `x-siws-auth` header was **replayable** — `authenticateRequest` verified the signature, statement and domain but never the nonce, and Substrate `SiwsMessage`s carried no expiry at all. This makes nonces single-use and requires a hard expiry on every chain.

## Changes

- **Migration `20260520200000_auth_nonces.sql`** — `auth_nonces` table (`nonce` PK, `expires_at`, `created_at`), indexed on `expires_at`.
- **`server/api/auth/nonceStore.js`** — `consumeNonce(nonce, expiresAt)` inserts the nonce; a unique-violation (Postgres `23505`) means it was already used → reports a replay. Expired rows are swept opportunistically (~5% of calls).
- **`auth.middleware.js`** — `authenticateRequest` now, after signature/statement/domain checks: requires a **future `expirationTime`** and **consumes the nonce**. A stale or reused message → `403`.
- **`substrateProvider.ts`** — the `SiwsMessage` now carries a 10-minute `expirationTime`, matching the Ethereum/Solana providers (which already did).

## ⚠️ Behaviour change

A sign-in message with **no / past `expirationTime` is now rejected on all three chains**. Every client sign-in builds its message through the `lib/auth/` providers, so a current build always sets it — the only edge case is a *stale browser tab* loaded before this deploys, which a refresh fixes.

## Test plan

- ✅ `cd server && npm test` — **167 tests pass** (22 files): new `nonceStore` suite (ok / replay / missing-nonce / db-error) + `requireAdmin` replay & expired-message cases; `auth.middleware` and `wallet-contact.middleware` suites updated for the required `expirationTime`.
- ✅ `cd client && npm run build` (tsc) — green; `npm run lint` — green.
- ⚠️ Migration `20260520200000_auth_nonces.sql` must be applied to Supabase (per `docs/PRODUCTION_DEPLOYMENT.md`) — additive, low-risk.

## Not included (noted on #88)

A full server-issued challenge/response (server hands out the nonce) would be stronger but is a larger flow change. Seen-nonce tracking + expiry is the proportionate fix and closes the practical replay window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
