### PR TITLE
feat(programs): backfill canonical event/track entity (Phase 1)

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -116,6 +116,21 @@ export type ApiProject = {
   submittedDate?: string;
   updatedAt?: string;
   hackathon?: { id: string; name: string; endDate: string; eventStartedAt?: string };
+  /**
+   * Canonical event/track row (Phase 1 #93). Populated when the project's
+   * `program_id` resolves to a row in `programs`. `hackathon` above stays
+   * around as the legacy flat-column view for callers not yet migrated.
+   */
+  program?: {
+    id: string;
+    name: string;
+    slug: string;
+    programType: ApiProgram["programType"];
+    status: ApiProgram["status"];
+    eventStartsAt?: string | null;
+    eventEndsAt?: string | null;
+    location?: string | null;
+  } | null;
   finalSubmission?: {
     repoUrl?: string;
     demoUrl?: string;

--- a/client/src/lib/mockPrograms.ts
+++ b/client/src/lib/mockPrograms.ts
@@ -2,14 +2,120 @@
  * Mock fixture for the `programs` table. Read in preview mode when
  * VITE_USE_MOCK_DATA=true. Real data comes from Supabase via /api/programs.
  *
- * Extended across Block A of the Phase 1 revamp:
+ * Extended across the Phase 1 revamp:
  *   - Issue #36 — fixture introduced (empty).
- *   - Issue #37 — Dogfooding 2026 added for public /programs surface.
+ *   - Issue #37 — Dogfooding 2026 cohort added for public /programs surface.
+ *   - Issue #93 — historical hackathons + Bitrefill + singleton tracks added
+ *     so previews mirror the canonical-events backfill migration.
  */
 
 import type { ApiProgram } from "./api";
 
 export const mockPrograms: ApiProgram[] = [
+  {
+    id: "symbiosis-2025",
+    name: "Symbiosis 2025",
+    slug: "symbiosis-2025",
+    programType: "hackathon",
+    description: "WebZero Symbiosis 2025 hackathon.",
+    status: "completed",
+    owner: "webzero",
+    applicationsOpenAt: null,
+    applicationsCloseAt: null,
+    eventStartsAt: null,
+    eventEndsAt: "2025-11-19T23:00:00Z",
+    location: null,
+    maxApplicants: null,
+    createdAt: "2025-09-01T00:00:00Z",
+    updatedAt: "2025-11-20T00:00:00Z",
+  },
+  {
+    id: "symmetry-2024",
+    name: "Symmetry 2024",
+    slug: "symmetry-2024",
+    programType: "hackathon",
+    description: "WebZero Symmetry 2024 hackathon.",
+    status: "completed",
+    owner: "webzero",
+    applicationsOpenAt: null,
+    applicationsCloseAt: null,
+    eventStartsAt: null,
+    eventEndsAt: "2024-08-22T04:55:00Z",
+    location: null,
+    maxApplicants: null,
+    createdAt: "2024-06-01T00:00:00Z",
+    updatedAt: "2024-08-23T00:00:00Z",
+  },
+  {
+    id: "synergy-2025",
+    name: "Synergy 2025",
+    slug: "synergy-2025",
+    programType: "hackathon",
+    description: "WebZero Synergy 2025 hackathon.",
+    status: "completed",
+    owner: "webzero",
+    applicationsOpenAt: null,
+    applicationsCloseAt: null,
+    eventStartsAt: null,
+    eventEndsAt: "2025-07-18T23:00:00Z",
+    location: null,
+    maxApplicants: null,
+    createdAt: "2025-05-01T00:00:00Z",
+    updatedAt: "2025-07-19T00:00:00Z",
+  },
+  {
+    id: "bitrefill-2026",
+    name: "Bitrefill 2026",
+    slug: "bitrefill-2026",
+    programType: "hackathon",
+    description: "WebZero hackathon hosted with Bitrefill in Berlin.",
+    status: "draft",
+    owner: "webzero",
+    applicationsOpenAt: null,
+    applicationsCloseAt: null,
+    eventStartsAt: "2026-06-17T00:00:00Z",
+    eventEndsAt: null,
+    location: "Berlin",
+    maxApplicants: null,
+    createdAt: "2026-05-20T00:00:00Z",
+    updatedAt: "2026-05-20T00:00:00Z",
+  },
+  {
+    id: "m2-incubator",
+    name: "M2 Incubator",
+    slug: "m2-incubator",
+    programType: "m2_incubator",
+    description:
+      "Continuation track for event winners — focused build sprint with a mentor.",
+    status: "open",
+    owner: "webzero",
+    applicationsOpenAt: null,
+    applicationsCloseAt: null,
+    eventStartsAt: null,
+    eventEndsAt: null,
+    location: null,
+    maxApplicants: null,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+  },
+  {
+    id: "dogfooding",
+    name: "Dogfooding",
+    slug: "dogfooding",
+    programType: "dogfooding",
+    description:
+      "Continuation track where past winners trade structured feedback by using each other's products.",
+    status: "open",
+    owner: "webzero",
+    applicationsOpenAt: null,
+    applicationsCloseAt: null,
+    eventStartsAt: null,
+    eventEndsAt: null,
+    location: null,
+    maxApplicants: null,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+  },
   {
     id: "dogfooding-2026-berlin",
     name: "Dogfooding 2026",

--- a/server/api/repositories/__tests__/project.repository.test.js
+++ b/server/api/repositories/__tests__/project.repository.test.js
@@ -129,3 +129,132 @@ describe('ProjectRepository.updateProject — bounty_prizes handling', () => {
     expect(allFromCalls).not.toContain('bounty_prizes');
   });
 });
+
+// Phase 1 multi-event reframe — #93. The transform exposes the joined
+// `programs` row as `project.program`, alongside the legacy `hackathon`
+// flat-column view.
+describe('ProjectRepository — program / program_id (issue #93)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('surfaces project.program from the joined programs row', async () => {
+    const chain = makeChain({
+      single: vi.fn(() =>
+        Promise.resolve({
+          data: {
+            id: 'proj-1',
+            project_name: 'Test',
+            description: 'desc',
+            hackathon_id: 'symbiosis-2025',
+            hackathon_name: 'Symbiosis 2025',
+            hackathon_end_date: '2025-11-19T23:00:00Z',
+            program_id: 'symbiosis-2025',
+            program: {
+              id: 'symbiosis-2025',
+              name: 'Symbiosis 2025',
+              slug: 'symbiosis-2025',
+              program_type: 'hackathon',
+              status: 'completed',
+              event_starts_at: null,
+              event_ends_at: '2025-11-19T23:00:00Z',
+              location: null,
+            },
+            team_members: [],
+            bounty_prizes: [],
+            milestones: [],
+            payments: [],
+          },
+          error: null,
+        })
+      ),
+    });
+    supabase.from.mockReturnValueOnce(chain);
+
+    const project = await repo.getProjectById('proj-1');
+
+    expect(project.program).toEqual({
+      id: 'symbiosis-2025',
+      name: 'Symbiosis 2025',
+      slug: 'symbiosis-2025',
+      programType: 'hackathon',
+      status: 'completed',
+      eventStartsAt: null,
+      eventEndsAt: '2025-11-19T23:00:00Z',
+      location: null,
+    });
+    // Legacy hackathon shape is preserved for callers not yet migrated.
+    expect(project.hackathon).toEqual({
+      id: 'symbiosis-2025',
+      name: 'Symbiosis 2025',
+      endDate: '2025-11-19T23:00:00Z',
+      eventStartedAt: undefined,
+    });
+  });
+
+  it('returns project.program as null when no programs row is joined', async () => {
+    const chain = makeChain({
+      single: vi.fn(() =>
+        Promise.resolve({
+          data: {
+            id: 'proj-2',
+            project_name: 'Legacy',
+            description: 'desc',
+            hackathon_id: 'symbiosis-2025',
+            hackathon_name: 'Symbiosis 2025',
+            hackathon_end_date: '2025-11-19T23:00:00Z',
+            program_id: null,
+            program: null,
+            team_members: [],
+            bounty_prizes: [],
+            milestones: [],
+            payments: [],
+          },
+          error: null,
+        })
+      ),
+    });
+    supabase.from.mockReturnValueOnce(chain);
+
+    const project = await repo.getProjectById('proj-2');
+
+    expect(project.program).toBeNull();
+    // Legacy hackathon view still works.
+    expect(project.hackathon.id).toBe('symbiosis-2025');
+  });
+
+  it('maps incoming program.id to program_id when updating a project', async () => {
+    // Chain 1: exists check
+    const existsChain = makeChain({
+      single: vi.fn(() => Promise.resolve({ data: { id: 'proj-3' }, error: null })),
+    });
+    // Chain 2: the update — capture the row passed to .update()
+    const updateChain = makeChain();
+    // Chain 3: re-fetch
+    const refetchChain = makeChain({
+      single: vi.fn(() =>
+        Promise.resolve({
+          data: {
+            id: 'proj-3',
+            project_name: 'X',
+            description: 'desc',
+            program_id: 'bitrefill-2026',
+            program: null,
+            team_members: [],
+            bounty_prizes: [],
+            milestones: [],
+            payments: [],
+          },
+          error: null,
+        })
+      ),
+    });
+
+    supabase.from
+      .mockReturnValueOnce(existsChain)
+      .mockReturnValueOnce(updateChain)
+      .mockReturnValueOnce(refetchChain);
+
+    await repo.updateProject('proj-3', { program: { id: 'bitrefill-2026' } });
+
+    expect(updateChain.update).toHaveBeenCalledWith({ program_id: 'bitrefill-2026' });
+  });
+});

--- a/server/api/repositories/project.repository.js
+++ b/server/api/repositories/project.repository.js
@@ -25,6 +25,19 @@ const transformProject = (row) => {
             endDate: row.hackathon_end_date,
             eventStartedAt: row.hackathon_event_started_at
         },
+        // Phase 1 multi-event reframe (#93): the canonical event/track row.
+        // `hackathon` above is the legacy flat-column view, kept for callers
+        // not yet migrated; `program` is the joined `programs` row.
+        program: row.program ? {
+            id: row.program.id,
+            name: row.program.name,
+            slug: row.program.slug,
+            programType: row.program.program_type,
+            status: row.program.status,
+            eventStartsAt: row.program.event_starts_at,
+            eventEndsAt: row.program.event_ends_at,
+            location: row.program.location
+        } : null,
         m2Status: row.m2_status,
         m2Agreement: row.m2_status ? {
             mentorName: row.m2_mentor_name,
@@ -109,13 +122,14 @@ const toSupabaseProject = (data) => {
     if (data.projectState !== undefined) row.project_state = data.projectState;
     if (data.bountiesProcessed !== undefined) row.bounties_processed = data.bountiesProcessed;
 
-    // Hackathon fields
+    // Hackathon fields (legacy; superseded by `program_id` — see #93).
     if (data.hackathon) {
         if (data.hackathon.id !== undefined) row.hackathon_id = data.hackathon.id;
         if (data.hackathon.name !== undefined) row.hackathon_name = data.hackathon.name;
         if (data.hackathon.endDate !== undefined) row.hackathon_end_date = data.hackathon.endDate;
         if (data.hackathon.eventStartedAt !== undefined) row.hackathon_event_started_at = data.hackathon.eventStartedAt;
     }
+    if (data.program?.id !== undefined) row.program_id = data.program.id;
 
     // M2 fields
     if (data.m2Status !== undefined) row.m2_status = data.m2Status;
@@ -173,7 +187,8 @@ class ProjectRepository {
                 team_members(*),
                 bounty_prizes(*),
                 milestones(*),
-                payments(*)
+                payments(*),
+                program:programs(*)
             `)
             .eq('id', projectId)
             .single();
@@ -190,7 +205,8 @@ class ProjectRepository {
                 team_members(*),
                 bounty_prizes(*),
                 milestones(*),
-                payments(*)
+                payments(*),
+                program:programs(*)
             `)
             .eq('donation_address', projectId)
             .single());
@@ -211,7 +227,8 @@ class ProjectRepository {
                         team_members(*),
                         bounty_prizes(*),
                         milestones(*),
-                        payments(*)
+                        payments(*),
+                        program:programs(*)
                     `)
                     .ilike('project_name', `%${searchPattern}%`)
                     .limit(1)
@@ -338,7 +355,8 @@ class ProjectRepository {
                 team_members(*),
                 bounty_prizes(*),
                 milestones(*),
-                payments(*)
+                payments(*),
+                program:programs(*)
             `, { count: 'exact' });
 
         // Apply filters
@@ -535,7 +553,7 @@ class ProjectRepository {
         // Second: fetch the projects with their joined relations.
         const { data, error } = await supabase
             .from('projects')
-            .select('*, team_members(*), bounty_prizes(*), milestones(*), payments(*)')
+            .select('*, team_members(*), bounty_prizes(*), milestones(*), payments(*), program:programs(*)')
             .in('id', projectIds)
             .order('updated_at', { ascending: false });
         if (error) throw error;

--- a/supabase/migrations/20260520300000_programs_as_canonical_events.sql
+++ b/supabase/migrations/20260520300000_programs_as_canonical_events.sql
@@ -1,0 +1,41 @@
+-- Stadium multi-event reframe — Phase 1 (closes #93).
+-- Promotes `programs` to the canonical entity for every event and continuation
+-- track: backfills the historical hackathons, seeds the upcoming Bitrefill
+-- event, and adds singleton rows for the M2 and Dogfooding tracks. Adds a
+-- nullable `program_id` FK on `projects` and backfills it from `hackathon_id`.
+--
+-- Additive and idempotent — safe to re-run. Legacy `hackathon_*` columns on
+-- `projects` are untouched; their removal is Phase 4.
+
+INSERT INTO programs (id, name, slug, program_type, description, status, owner, event_starts_at, event_ends_at, location)
+VALUES
+  ('symbiosis-2025', 'Symbiosis 2025', 'symbiosis-2025', 'hackathon',
+    'WebZero Symbiosis 2025 hackathon.',
+    'completed', 'webzero', NULL, '2025-11-19T23:00:00Z', NULL),
+  ('symmetry-2024', 'Symmetry 2024', 'symmetry-2024', 'hackathon',
+    'WebZero Symmetry 2024 hackathon.',
+    'completed', 'webzero', NULL, '2024-08-22T04:55:00Z', NULL),
+  ('synergy-2025', 'Synergy 2025', 'synergy-2025', 'hackathon',
+    'WebZero Synergy 2025 hackathon.',
+    'completed', 'webzero', NULL, '2025-07-18T23:00:00Z', NULL),
+  ('bitrefill-2026', 'Bitrefill 2026', 'bitrefill-2026', 'hackathon',
+    'WebZero hackathon hosted with Bitrefill in Berlin.',
+    'draft', 'webzero', '2026-06-17T00:00:00Z', NULL, 'Berlin'),
+  ('m2-incubator', 'M2 Incubator', 'm2-incubator', 'm2_incubator',
+    'Continuation track for event winners — focused build sprint with a mentor.',
+    'open', 'webzero', NULL, NULL, NULL),
+  ('dogfooding', 'Dogfooding', 'dogfooding', 'dogfooding',
+    'Continuation track where past winners trade structured feedback by using each other''s products.',
+    'open', 'webzero', NULL, NULL, NULL)
+ON CONFLICT (slug) DO NOTHING;
+
+ALTER TABLE projects
+  ADD COLUMN IF NOT EXISTS program_id TEXT REFERENCES programs(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_projects_program_id ON projects(program_id);
+
+UPDATE projects
+SET program_id = hackathon_id
+WHERE program_id IS NULL
+  AND hackathon_id IS NOT NULL
+  AND EXISTS (SELECT 1 FROM programs WHERE programs.id = projects.hackathon_id);


### PR DESCRIPTION
Closes #93. First of three phases in the multi-event reframe (Phase 2 = copy/IA, Phase 3 = per-event admins).

## Summary
- New migration `supabase/migrations/20260520300000_programs_as_canonical_events.sql`: inserts `programs` rows for the historical hackathons (Symbiosis 2025, Symmetry 2024, Synergy 2025), the upcoming Bitrefill 2026 (June 17 Berlin, status `draft`), and singleton continuation-track rows for M2 Incubator and Dogfooding. Adds a nullable `program_id` FK on `projects` and backfills it from `hackathon_id`. Idempotent (`ON CONFLICT DO NOTHING`, `ADD COLUMN IF NOT EXISTS`).
- `server/api/repositories/project.repository.js`: all 5 `select` callsites now join `program:programs(*)`; `transformProject` surfaces a `program` sub-object; `toSupabaseProject` maps `program.id → program_id`. Legacy `hackathon` view stays untouched for callers not yet migrated (Phase 4 removes it).
- `client/src/lib/api.ts`: `ApiProject` gains the optional `program` field with the same shape.
- `client/src/lib/mockPrograms.ts`: mirror the 6 new rows so Vercel previews match prod after the migration runs.
- 3 new repository tests covering the joined program path, the null-program fallback, and the `program.id → program_id` write path. Full server suite passes (171/171), client build clean, lint clean.

## Out of scope (later)
- All user-facing copy still says "hackathon" — Phase 2 (#94).
- `ADMIN_WALLETS` is still the only admin check — Phase 3 (#95).
- Legacy `hackathon_*` columns stay around — Phase 4 (not opened yet).

## Test plan
- [ ] On `/`, project cards render correctly (regression — no UI change expected).
- [ ] On `/winners/symbiosis-2025`, the winners page loads.
- [ ] On `/project/:id`, the existing hackathon info still displays.
- [ ] On `/programs`, the existing Dogfooding 2026 cohort still appears in the open list.
- [ ] On `/admin/programs`, the six new program rows (Symbiosis 2025, Symmetry 2024, Synergy 2025, Bitrefill 2026, M2 Incubator, Dogfooding) appear in the table.

`stadium-tester` report will be pasted below after running against the Vercel preview.