### PR TITLE
feat(copy): reframe Stadium as multi-event builder showcase (Phase 2)

### DIFF
--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -61,28 +61,46 @@ const HomePage = () => {
   const [isFiltersOpen, setIsFiltersOpen] = useState(false);
   const { toast } = useToast();
 
-  // Load the hackathon list (once) and the stats cohort.
+  // Load the event filter list and the project stats in parallel.
+  // Phase 2 #94: events come from `programs` (program_type='hackathon'), not
+  // from aggregating `project.hackathon.id` — so upcoming events surface
+  // even when they have zero projects yet.
   useEffect(() => {
-    const loadHackathons = async () => {
+    const loadEventsAndStats = async () => {
       try {
-        const response = await api.getProjects({ limit: 2000, sortBy: "updatedAt", sortOrder: "desc" });
-        const apiProjects: ApiProject[] = Array.isArray(response?.data) ? response.data : [];
+        const [projectsResp, programsResp] = await Promise.all([
+          api.getProjects({ limit: 2000, sortBy: "updatedAt", sortOrder: "desc" }),
+          api.listPrograms().catch(() => null),
+        ]);
+        const apiProjects: ApiProject[] = Array.isArray(projectsResp?.data) ? projectsResp.data : [];
         setAllProjects(apiProjects);
         setStatsLoading(false);
-        const unique = new Map<string, string>();
-        for (const p of apiProjects) {
-          if (p.hackathon?.id) unique.set(p.hackathon.id, p.hackathon.name || p.hackathon.id);
+        const eventPrograms = (programsResp?.data ?? []).filter(
+          (p) => p.programType === "hackathon",
+        );
+        if (eventPrograms.length > 0) {
+          setHackathons(eventPrograms.map((p) => ({ id: p.slug, name: p.name })));
+        } else {
+          // Fallback for environments where programs aren't seeded yet —
+          // derive the list from project rows so the filter still works.
+          const unique = new Map<string, string>();
+          for (const p of apiProjects) {
+            if (p.hackathon?.id) {
+              unique.set(p.hackathon.id, p.hackathon.name || p.hackathon.id);
+            }
+          }
+          setHackathons(Array.from(unique.entries()).map(([id, name]) => ({ id, name })));
         }
-        setHackathons(Array.from(unique.entries()).map(([id, name]) => ({ id, name })));
       } catch {
         toast({
           title: "Error",
-          description: "Failed to load hackathon list. Event filtering may be unavailable.",
+          description: "Failed to load event list. Event filtering may be unavailable.",
           variant: "destructive",
         });
       }
     };
-    loadHackathons();
+    loadEventsAndStats();
+    // Run once on mount; `toast` is stable across renders.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -238,7 +256,7 @@ const HomePage = () => {
             Stadium
           </h1>
           <p className="text-body text-base md:text-lg max-w-xl leading-relaxed">
-            Hackathon projects that didn't stop when the event ended. Winners featured first.
+            Builders showcase what they ship at WebZero events — and keep building between them.
           </p>
 
           <div className="pt-8">

--- a/client/src/pages/M2ProgramPage.tsx
+++ b/client/src/pages/M2ProgramPage.tsx
@@ -154,12 +154,12 @@ const M2ProgramPage = () => {
 
       <main className="container mx-auto px-4 py-6">
         <div className="mb-4">
-          <div className="label-hw-dim mb-2">·M2 INCUBATOR / PROGRAM OVERVIEW</div>
+          <div className="label-hw-dim mb-2">·M2 INCUBATOR / POST-EVENT TRACK</div>
           <h1 className="font-display text-4xl md:text-5xl uppercase tracking-tight text-display leading-[0.95] mb-2">
-            M2 Program
+            M2 Incubator
           </h1>
           <p className="text-[13px] text-body leading-relaxed max-w-2xl">
-            Six-week incubator for hackathon winners. Teams confirm milestone plans, get matched with mentors, and ship.
+            The post-event track for WebZero winners — keep building what you shipped, with a mentor and a defined Milestone 2.
           </p>
         </div>
 

--- a/client/src/pages/ProgramsPage.tsx
+++ b/client/src/pages/ProgramsPage.tsx
@@ -37,7 +37,7 @@ const ProgramsPage = () => {
             Programs
           </h1>
           <p className="text-body text-base max-w-2xl leading-relaxed">
-            Programs currently open for applications from past WebZero winners.
+            Open opportunities to build with WebZero — continuation tracks for past winners and upcoming events.
           </p>
         </div>
 
@@ -81,6 +81,14 @@ const PROGRAM_TYPE_LABEL: Record<ApiProgram["programType"], string> = {
   m2_incubator: "M2 INCUBATOR",
 };
 
+// Phase 2 #94: M2 has its own custom destination page. Future custom pages
+// (e.g. /dogfooding) can plug in here; other types fall through to the
+// generic /programs/:slug detail.
+const customRouteForProgramType = (type: ApiProgram["programType"]): string | null => {
+  if (type === "m2_incubator") return "/m2-program";
+  return null;
+};
+
 function ProgramRackCard({ program, number }: { program: ApiProgram; number: string }) {
   const date = (iso?: string | null) => {
     if (!iso) return null;
@@ -94,9 +102,11 @@ function ProgramRackCard({ program, number }: { program: ApiProgram; number: str
   const closes = date(program.applicationsCloseAt);
   const startsAt = date(program.eventStartsAt);
 
+  const href = customRouteForProgramType(program.programType) ?? `/programs/${program.slug}`;
+
   return (
     <Link
-      to={`/programs/${program.slug}`}
+      to={href}
       className="lcd block px-4 py-4 transition-transform duration-150 hover:-translate-y-[1px] relative"
     >
       <div className="absolute top-3 right-3 flex items-center gap-1">

--- a/client/src/pages/ProjectDetailsPage.tsx
+++ b/client/src/pages/ProjectDetailsPage.tsx
@@ -114,6 +114,7 @@ const ProjectDetailsPage = () => {
     donationChain?: 'substrate' | 'ethereum' | 'solana';
     winner?: string; // legacy
     hackathon?: { id: string; name: string; endDate: string; eventStartedAt?: string };
+    program?: { id: string; name: string; slug: string } | null;
     eventStartedAt?: string; // legacy - use hackathon.eventStartedAt instead
     m2Status?: 'building' | 'under_review' | 'completed';
     finalSubmission?: {
@@ -887,11 +888,12 @@ const ProjectDetailsPage = () => {
                 </span>
                 <span>·</span>
                 <span>
-                  {(project.hackathon?.eventStartedAt === "funkhaus-2024"
-                    ? "Symmetry 2024"
-                    : project.hackathon?.eventStartedAt === "synergy-hack-2024"
-                    ? "Synergy 2025"
-                    : project.hackathon?.name || "Hackathon").toUpperCase()}
+                  {(project.program?.name
+                    ?? (project.hackathon?.eventStartedAt === "funkhaus-2024"
+                      ? "Symmetry 2024"
+                      : project.hackathon?.eventStartedAt === "synergy-hack-2024"
+                      ? "Synergy 2025"
+                      : project.hackathon?.name || "Event")).toUpperCase()}
                 </span>
                 {project.teamMembers && project.teamMembers.length > 0 && (
                   <>

--- a/client/src/pages/WinnersPage.tsx
+++ b/client/src/pages/WinnersPage.tsx
@@ -24,6 +24,7 @@ type ApiProject = {
   categories?: string[];
   m2Status?: "building" | "under_review" | "completed";
   hackathon?: { id: string; name: string; endDate: string };
+  program?: { id: string; name: string; slug: string } | null;
 };
 
 type Unit = {
@@ -44,7 +45,7 @@ type Unit = {
 const WinnersPage = () => {
   const { hackathon } = useParams<{ hackathon: string }>();
   const [winners, setWinners] = useState<Unit[]>([]);
-  const [hackathonName, setHackathonName] = useState<string>("");
+  const [programName, setProgramName] = useState<string>("");
   const [loading, setLoading] = useState(true);
   const [selected, setSelected] = useState<Unit | null>(null);
   const { toast } = useToast();
@@ -66,14 +67,20 @@ const WinnersPage = () => {
         });
         const apiProjects: ApiProject[] = Array.isArray(response?.data) ? response.data : [];
 
-        if (apiProjects[0]?.hackathon?.name) {
-          setHackathonName(apiProjects[0].hackathon.name);
+        // Phase 2 #94: prefer the canonical program name, then fall back to
+        // the legacy hackathon name, then to a slug-cased pretty-print.
+        const fromProgram = apiProjects.find((p) => p.program?.name)?.program?.name;
+        const fromHackathon = apiProjects.find((p) => p.hackathon?.name)?.hackathon?.name;
+        if (fromProgram) {
+          setProgramName(fromProgram);
+        } else if (fromHackathon) {
+          setProgramName(fromHackathon);
         } else {
           const formatted = hackathon
             .split("-")
             .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
             .join(" ");
-          setHackathonName(formatted);
+          setProgramName(formatted);
         }
 
         setWinners(
@@ -111,8 +118,8 @@ const WinnersPage = () => {
 
   const handleClose = useCallback(() => setSelected(null), []);
 
-  // Drop a "Blockspace" prefix if present — fits the rack-label aesthetic.
-  const displayName = hackathonName.replace(/^Blockspace\s+/i, "");
+  // "Blockspace" was a stale prefix on older event names — strip if present.
+  const displayProgramName = programName.replace(/^Blockspace\s+/i, "");
 
   return (
     <div className="min-h-screen scanlines">
@@ -131,10 +138,10 @@ const WinnersPage = () => {
         <div className="mb-6">
           <div className="label-hw-dim mb-2">·WINNERS / {hackathon?.toUpperCase()}</div>
           <h1 className="font-display text-5xl md:text-6xl uppercase tracking-tight text-display leading-[0.95] mb-2">
-            {displayName || "Winners"}
+            {displayProgramName || "Winners"}
           </h1>
           <p className="text-body text-base max-w-2xl leading-relaxed">
-            Congratulations to the winners of the {hackathonName || "this"} hackathon.
+            Congratulations to the winners of {programName || "this event"}.
           </p>
         </div>
 


### PR DESCRIPTION
Closes #94. Sequentially after #96 (Phase 1 schema). Phase 3 follows.

## Summary
- **HomePage** — hero subtitle reframed to multi-event; event filter dropdown now driven by `api.listPrograms({ programType: 'hackathon' })` so upcoming events (e.g. Bitrefill 2026) surface even with zero projects. Falls back to legacy project-row aggregation if `programs` isn't seeded.
- **WinnersPage** — title parameterized as `{programName} Winners`, picked from `project.program?.name` then `project.hackathon?.name` then a slug pretty-print fallback.
- **ProjectDetailsPage** — event-of-origin label prefers `project.program?.name`; the existing `hackathon.eventStartedAt` special-cases (`funkhaus-2024` → Symmetry 2024, `synergy-hack-2024` → Synergy 2025) stay as fallback for projects without `program_id` set.
- **M2ProgramPage** — header reframed: M2 is the post-event continuation track ("keep building what you shipped, with a mentor and a defined Milestone 2"), no longer the headline product.
- **ProgramsPage** — copy broader than "past WebZero winners"; reads as "open opportunities — continuation tracks and upcoming events".
- **ProgramCard** — M2 cards link to `/m2-program` (custom destination); other types still route to `/programs/:slug`. Future custom destinations (e.g. `/dogfooding`) plug into the same `customRouteForProgramType` map.

Client build clean, lint clean, server tests still 171/171.

## Out of scope (later)
- New `/dogfooding` custom page.
- Per-event admin permissions — Phase 3 (#95).
- Removing legacy `hackathon_*` columns — Phase 4 (not opened yet).

## Test plan
- [ ] On `/`, hero subtitle no longer says "hackathon projects" — reads as multi-event.
- [ ] On `/`, the event filter dropdown lists the hackathon-type programs from the `programs` table (in mock mode, that's Symbiosis 2025, Symmetry 2024, Synergy 2025, Bitrefill 2026).
- [ ] On `/winners/symbiosis-2025`, the page title reads "Symbiosis 2025 Winners".
- [ ] On `/project/:id` for a project with `program` populated, the event label uses the program name.
- [ ] On `/m2-program`, the header positions M2 as something done *after* an event.
- [ ] On `/programs`, clicking the M2 card navigates to `/m2-program`; clicking a hackathon card navigates to `/programs/:slug`.

`stadium-tester` report will be pasted after running against the Vercel preview.