### PR TITLE
feat(auth): per-event admin permissions (Phase 3)

### DIFF
--- a/client/src/components/admin/ProgramAdminsSection.tsx
+++ b/client/src/components/admin/ProgramAdminsSection.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useState, useCallback } from "react";
+import { Trash2, Loader2 } from "lucide-react";
+import { api, type ApiProgramAdmin, ApiError } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+
+type ChainOption = ApiProgramAdmin["walletChain"];
+
+/**
+ * Per-event admin management (Phase 3 #95). Lists `program_admins` and lets
+ * a global admin assign / remove per-program admins. Non-global admins see
+ * the list only — add/remove controls are hidden.
+ *
+ * Each call is gated on a fresh SIWS signature; the parent passes
+ * `signAuthHeader` (typically wired to `useWalletAuth().signAction`).
+ */
+export function ProgramAdminsSection({
+  programSlug,
+  signAuthHeader,
+  isGlobalAdmin,
+}: {
+  programSlug: string;
+  signAuthHeader: () => Promise<string>;
+  isGlobalAdmin: boolean;
+}) {
+  const { toast } = useToast();
+  const [admins, setAdmins] = useState<ApiProgramAdmin[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [adding, setAdding] = useState(false);
+  const [wallet, setWallet] = useState("");
+  const [chain, setChain] = useState<ChainOption>("substrate");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const authHeader = await signAuthHeader();
+      const res = await api.listProgramAdmins(programSlug, authHeader);
+      setAdmins(res.data);
+    } catch (e) {
+      const err = e as Error;
+      toast({
+        title: "Couldn't load admins",
+        description: err?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [programSlug, signAuthHeader, toast]);
+
+  useEffect(() => {
+    if (programSlug) load();
+  }, [programSlug, load]);
+
+  const handleAdd = async () => {
+    if (!wallet.trim()) return;
+    setAdding(true);
+    try {
+      const authHeader = await signAuthHeader();
+      const res = await api.addProgramAdmin(
+        programSlug,
+        { wallet: wallet.trim(), walletChain: chain },
+        authHeader,
+      );
+      setAdmins((prev) => {
+        if (prev.some((a) => a.wallet === res.data.wallet && a.walletChain === res.data.walletChain)) {
+          return prev;
+        }
+        return [...prev, res.data];
+      });
+      setWallet("");
+      toast({ title: "Admin added" });
+    } catch (e) {
+      const msg = e instanceof ApiError ? e.message : (e as Error)?.message;
+      toast({
+        title: "Couldn't add admin",
+        description: msg || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const handleRemove = async (admin: ApiProgramAdmin) => {
+    try {
+      const authHeader = await signAuthHeader();
+      await api.removeProgramAdmin(programSlug, admin.wallet, admin.walletChain, authHeader);
+      setAdmins((prev) =>
+        prev.filter((a) => !(a.wallet === admin.wallet && a.walletChain === admin.walletChain)),
+      );
+      toast({ title: "Admin removed" });
+    } catch (e) {
+      const err = e as Error;
+      toast({
+        title: "Couldn't remove admin",
+        description: err?.message || "Unknown error",
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <section className="panel p-4 mb-3">
+      <header className="mb-3 flex items-baseline justify-between gap-3">
+        <div className="label-hw text-display">·PROGRAM ADMINS</div>
+        <p className="label-hw-dim hidden md:block">
+          Global admins are always authorized; only wallets listed here can administer this program scope.
+        </p>
+      </header>
+
+      {loading ? (
+        <div className="flex items-center gap-2 label-hw-dim py-3">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+          Loading…
+        </div>
+      ) : admins.length === 0 ? (
+        <p className="label-hw-dim py-3">No per-program admins assigned yet.</p>
+      ) : (
+        <ul className="divide-y divide-hairline">
+          {admins.map((a) => (
+            <li
+              key={`${a.walletChain}:${a.wallet}`}
+              className="flex items-center justify-between gap-3 py-2"
+            >
+              <div className="min-w-0">
+                <p className="truncate font-mono text-[12px] text-display">{a.wallet}</p>
+                <p className="label-hw-dim">{a.walletChain.toUpperCase()}</p>
+              </div>
+              {isGlobalAdmin && (
+                <button
+                  type="button"
+                  onClick={() => handleRemove(a)}
+                  aria-label={`Remove ${a.wallet}`}
+                  className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-destructive hover:bg-destructive/10 px-2 py-1 inline-flex items-center gap-1"
+                >
+                  <Trash2 className="h-3 w-3" />
+                  REMOVE
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {isGlobalAdmin && (
+        <div className="mt-4 flex flex-col gap-2 border-t border-hairline pt-4 md:flex-row">
+          <input
+            placeholder="Wallet address"
+            value={wallet}
+            onChange={(e) => setWallet(e.target.value)}
+            className="md:flex-1 font-mono text-[12px] bg-panel-deep border border-hairline text-display px-2 py-1.5 focus:outline-none focus:border-display"
+          />
+          <select
+            value={chain}
+            onChange={(e) => setChain(e.target.value as ChainOption)}
+            className="md:w-[140px] font-mono text-[11px] tracking-[0.14em] bg-panel-deep border border-hairline text-display px-2 py-1.5 focus:outline-none focus:border-display"
+          >
+            <option value="substrate">SUBSTRATE</option>
+            <option value="ethereum">ETHEREUM</option>
+            <option value="solana">SOLANA</option>
+          </select>
+          <button
+            type="button"
+            onClick={handleAdd}
+            disabled={adding || !wallet.trim()}
+            className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-4 py-1.5"
+          >
+            {adding ? "ADDING…" : "ADD ADMIN"}
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -174,6 +174,14 @@ export type ApiProgramApplication = {
   reviewNotes?: string | null;
 };
 
+/** Shape of a row in the `program_admins` table (Phase 3 #95). */
+export type ApiProgramAdmin = {
+  programId: string;
+  walletChain: "substrate" | "ethereum" | "solana";
+  wallet: string;
+  createdAt: string;
+};
+
 /** Shape of a row in the `programs` table (Phase 1 revamp). */
 export type ApiProgram = {
   id: string;
@@ -1252,6 +1260,60 @@ export const api = {
         : { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     });
+  },
+
+  /**
+   * Per-event admins (Phase 3 #95). Read is gated on requireProgramAdmin
+   * (global admins and per-program admins can list). Add/remove are gated
+   * on requireAdmin (global admins only).
+   */
+  listProgramAdmins: async (
+    slug: string,
+    authHeader: string,
+  ): Promise<{ status: string; data: ApiProgramAdmin[] }> => {
+    if (USE_MOCK_DATA) {
+      return { status: "success", data: [] };
+    }
+    return request(`/programs/${encodeURIComponent(slug)}/admins`, {
+      headers: { "x-siws-auth": authHeader },
+    });
+  },
+
+  addProgramAdmin: async (
+    slug: string,
+    payload: { wallet: string; walletChain: ApiProgramAdmin["walletChain"] },
+    authHeader: string,
+  ): Promise<{ status: string; data: ApiProgramAdmin }> => {
+    if (USE_MOCK_DATA) {
+      const created: ApiProgramAdmin = {
+        programId: slug,
+        walletChain: payload.walletChain,
+        wallet: payload.wallet,
+        createdAt: new Date().toISOString(),
+      };
+      return { status: "success", data: created };
+    }
+    return request(`/programs/${encodeURIComponent(slug)}/admins`, {
+      method: "POST",
+      headers: { "x-siws-auth": authHeader, "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  },
+
+  removeProgramAdmin: async (
+    slug: string,
+    wallet: string,
+    walletChain: ApiProgramAdmin["walletChain"],
+    authHeader: string,
+  ): Promise<void> => {
+    if (USE_MOCK_DATA) return;
+    await request(
+      `/programs/${encodeURIComponent(slug)}/admins/${encodeURIComponent(wallet)}?chain=${encodeURIComponent(walletChain)}`,
+      {
+        method: "DELETE",
+        headers: { "x-siws-auth": authHeader },
+      },
+    );
   },
 };
 

--- a/client/src/pages/AdminProgramPage.tsx
+++ b/client/src/pages/AdminProgramPage.tsx
@@ -11,6 +11,7 @@ import {
   ApiError,
 } from "@/lib/api";
 import { ApplicationCard } from "@/components/admin/ApplicationCard";
+import { ProgramAdminsSection } from "@/components/admin/ProgramAdminsSection";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 
@@ -36,7 +37,12 @@ const AdminProgramPage = () => {
   const { toast } = useToast();
   const auth = useWalletAuth();
   const connectedAddress = auth.account?.address ?? null;
-  const isAdminWallet = checkIsAdmin(connectedAddress ?? undefined, auth.account?.chain);
+  // Phase 3 #95: a global admin matches `ADMIN_ADDRESSES`; a per-program
+  // admin matches `program_admins` for THIS program. Both can reach the
+  // page; only global admins see the add/remove controls.
+  const isGlobalAdmin = checkIsAdmin(connectedAddress ?? undefined, auth.account?.chain);
+  const [isProgramAdmin, setIsProgramAdmin] = useState(false);
+  const isAdminWallet = isGlobalAdmin || isProgramAdmin;
 
   const [program, setProgram] = useState<ApiProgram | null>(null);
   const [applications, setApplications] = useState<ApiProgramApplication[]>([]);
@@ -81,18 +87,46 @@ const AdminProgramPage = () => {
   };
 
   const connectWallet = async () => {
+    if (!slug) return;
     setErrorData(null);
     try {
       const found = await auth.connect();
-      const admin = found.find((a) => checkIsAdmin(a.address, a.chain));
-      if (!admin) {
+      const globalAdmin = found.find((a) => checkIsAdmin(a.address, a.chain));
+
+      // Global admin shortcut — no server probe needed.
+      if (globalAdmin) {
+        auth.selectAccount(globalAdmin);
+        setIsProgramAdmin(false);
+        return;
+      }
+
+      // Phase 3 #95: probe the program-scoped admins endpoint with the first
+      // available account. A 200 means the wallet is listed in program_admins
+      // for THIS program; a 403 means it's not authorized here.
+      const candidate = found[0];
+      if (!candidate) {
         setErrorData({
-          walletAddresses: found.map((a) => a.address),
+          walletAddresses: [],
           expectedAddresses: ADMIN_ADDRESSES.filter((e) => e.chain === auth.chain).map((e) => e.address),
         });
         return;
       }
-      auth.selectAccount(admin);
+      auth.selectAccount(candidate);
+      try {
+        const authHeader = await auth.signAction("admin-action");
+        await api.listProgramAdmins(slug, authHeader);
+        setIsProgramAdmin(true);
+      } catch (probeErr) {
+        if (probeErr instanceof ApiError && probeErr.status === 403) {
+          setErrorData({
+            walletAddresses: found.map((a) => a.address),
+            expectedAddresses: ADMIN_ADDRESSES.filter((e) => e.chain === auth.chain).map((e) => e.address),
+          });
+          auth.disconnect();
+          return;
+        }
+        throw probeErr;
+      }
     } catch (e) {
       toast({
         title: "Couldn't connect wallet",
@@ -154,8 +188,7 @@ const AdminProgramPage = () => {
               <div className="panel p-6">
                 <div className="label-hw text-display mb-3">·ADMIN WALLET REQUIRED</div>
                 <p className="text-body text-sm mb-4">
-                  Connect a wallet whose address is in <code className="text-display">VITE_ADMIN_ADDRESSES</code> to
-                  review applications.
+                  Connect a global admin wallet, or a wallet that has been assigned to this program via the admins panel.
                 </p>
                 <button
                   type="button"
@@ -183,6 +216,12 @@ const AdminProgramPage = () => {
               </div>
             ) : (
               <>
+                <ProgramAdminsSection
+                  programSlug={program.slug}
+                  signAuthHeader={() => auth.signAction("admin-action")}
+                  isGlobalAdmin={isGlobalAdmin}
+                />
+
                 <div className="panel px-3 py-2.5 mb-3 flex flex-wrap items-center gap-2">
                   <HardwareToggle
                     options={FILTER_OPTIONS}

--- a/server/api/controllers/program.controller.js
+++ b/server/api/controllers/program.controller.js
@@ -2,10 +2,13 @@ import programService from '../services/program.service.js';
 import programApplicationService from '../services/program-application.service.js';
 import projectService from '../services/project.service.js';
 import notificationService from '../services/notification.service.js';
+import programAdminRepository from '../repositories/program-admin.repository.js';
 import { validateApplicationFields } from '../utils/application-fields.validator.js';
 import { validateProgram } from '../utils/validation.js';
 import { randomUUID } from 'node:crypto';
 import logger from '../utils/logger.js';
+
+const VALID_CHAINS = ['substrate', 'ethereum', 'solana'];
 
 class ProgramController {
   async list(req, res) {
@@ -297,6 +300,76 @@ class ProgramController {
       }
       console.error('❌ Error creating program application:', error);
       res.status(500).json({ status: 'error', message: 'Failed to create application' });
+    }
+  }
+
+  // --- Phase 3 (#95): per-event admins ---
+
+  async listAdmins(req, res) {
+    try {
+      const { slug } = req.params;
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const admins = await programAdminRepository.list(program.id);
+      res.status(200).json({ status: 'success', data: admins });
+    } catch (error) {
+      console.error('❌ Error listing program admins:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to list program admins' });
+    }
+  }
+
+  async addAdmin(req, res) {
+    try {
+      const { slug } = req.params;
+      const { wallet, walletChain } = req.body || {};
+      if (!wallet || typeof wallet !== 'string') {
+        return res.status(422).json({ status: 'error', message: 'wallet is required' });
+      }
+      if (!VALID_CHAINS.includes(walletChain)) {
+        return res.status(422).json({
+          status: 'error',
+          message: `walletChain must be one of: ${VALID_CHAINS.join(', ')}`,
+        });
+      }
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const added = await programAdminRepository.add(program.id, walletChain, wallet);
+      if (!added) {
+        return res.status(422).json({
+          status: 'error',
+          message: `Invalid ${walletChain} wallet address`,
+        });
+      }
+      res.status(201).json({ status: 'success', data: added });
+    } catch (error) {
+      console.error('❌ Error adding program admin:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to add program admin' });
+    }
+  }
+
+  async removeAdmin(req, res) {
+    try {
+      const { slug, wallet } = req.params;
+      const walletChain = req.query.chain;
+      if (!VALID_CHAINS.includes(walletChain)) {
+        return res.status(422).json({
+          status: 'error',
+          message: `chain query param must be one of: ${VALID_CHAINS.join(', ')}`,
+        });
+      }
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      await programAdminRepository.remove(program.id, walletChain, wallet);
+      res.status(204).end();
+    } catch (error) {
+      console.error('❌ Error removing program admin:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to remove program admin' });
     }
   }
 }

--- a/server/api/middleware/__tests__/auth.middleware.test.js
+++ b/server/api/middleware/__tests__/auth.middleware.test.js
@@ -50,6 +50,18 @@ vi.mock('../../auth/nonceStore.js', () => ({
   consumeNonce: vi.fn(),
 }));
 
+vi.mock('../../repositories/program.repository.js', () => ({
+  default: {
+    findBySlug: vi.fn(),
+  },
+}));
+
+vi.mock('../../repositories/program-admin.repository.js', () => ({
+  default: {
+    isAdmin: vi.fn(),
+  },
+}));
+
 // Now import what we need
 import { verifySIWS, parseMessage } from '@talismn/siws';
 import { signatureVerify, decodeAddress } from '@polkadot/util-crypto';
@@ -59,7 +71,9 @@ import projectService from '../../services/project.service.js';
 import { consumeNonce } from '../../auth/nonceStore.js';
 
 // Import middleware under test
-const { requireAdmin, requireTeamMemberOrAdmin } = await import('../auth.middleware.js');
+const { requireAdmin, requireTeamMemberOrAdmin, requireProgramAdmin } = await import('../auth.middleware.js');
+const programRepository = (await import('../../repositories/program.repository.js')).default;
+const programAdminRepository = (await import('../../repositories/program-admin.repository.js')).default;
 
 // Helpers
 function makeReq(overrides = {}) {
@@ -424,6 +438,155 @@ describe('requireTeamMemberOrAdmin', () => {
 
     expect(res.statusCode).toBe(403);
     expect(res.body.message).toMatch(/Invalid domain/i);
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+// ─── requireProgramAdmin (#95) ──────────────────────────────────
+
+describe('requireProgramAdmin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NODE_ENV = 'test';
+    process.env.DISABLE_SIWS_DOMAIN_CHECK = 'true';
+    consumeNonce.mockResolvedValue({ ok: true });
+  });
+
+  it('returns 400 when slug param is missing', async () => {
+    const req = makeReq({
+      params: {},
+      headers: { 'x-siws-auth': encodePayload(VALID_PAYLOAD) },
+    });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireProgramAdmin('slug')(req, res, next);
+
+    expect(res.statusCode).toBe(400);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('bypasses auth in non-production with dev-bypass header', async () => {
+    const req = makeReq({
+      params: { slug: 'bitrefill-2026' },
+      headers: { 'x-siws-auth': 'dev-bypass' },
+    });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireProgramAdmin('slug')(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user.isGlobalAdmin).toBe(true);
+    expect(req.user.programSlug).toBe('bitrefill-2026');
+  });
+
+  it('allows global authorized signers without checking program_admins', async () => {
+    signatureVerify.mockReturnValue({ isValid: true, crypto: 'sr25519' });
+    parseMessage.mockReturnValue({
+      address: '5FakeAdmin1',
+      statement: 'Perform administrative action on Stadium',
+      domain: 'localhost',
+      expirationTime: new Date(Date.now() + 60_000).toISOString(),
+      nonce: 'abc',
+    });
+    isAuthorizedSigner.mockReturnValue(true);
+
+    const req = makeReq({
+      params: { slug: 'bitrefill-2026' },
+      headers: { 'x-siws-auth': encodePayload(VALID_PAYLOAD) },
+    });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireProgramAdmin('slug')(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user.isGlobalAdmin).toBe(true);
+    expect(programAdminRepository.isAdmin).not.toHaveBeenCalled();
+  });
+
+  it('allows program-scoped admins for the matching program', async () => {
+    signatureVerify.mockReturnValue({ isValid: true, crypto: 'sr25519' });
+    parseMessage.mockReturnValue({
+      address: '5RandomNonAdmin',
+      statement: 'Perform administrative action on Stadium',
+      domain: 'localhost',
+      expirationTime: new Date(Date.now() + 60_000).toISOString(),
+      nonce: 'abc',
+    });
+    isAuthorizedSigner.mockReturnValue(false);
+    programRepository.findBySlug.mockResolvedValue({ id: 'bitrefill-2026', slug: 'bitrefill-2026' });
+    programAdminRepository.isAdmin.mockResolvedValue(true);
+
+    const req = makeReq({
+      params: { slug: 'bitrefill-2026' },
+      headers: {
+        'x-siws-auth': encodePayload({ ...VALID_PAYLOAD, address: '5RandomNonAdmin' }),
+      },
+    });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireProgramAdmin('slug')(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    expect(req.user.isGlobalAdmin).toBe(false);
+    expect(req.user.programId).toBe('bitrefill-2026');
+  });
+
+  it('rejects with 403 a signer that is neither global nor program admin', async () => {
+    signatureVerify.mockReturnValue({ isValid: true, crypto: 'sr25519' });
+    parseMessage.mockReturnValue({
+      address: '5SomeoneElse',
+      statement: 'Perform administrative action on Stadium',
+      domain: 'localhost',
+      expirationTime: new Date(Date.now() + 60_000).toISOString(),
+      nonce: 'abc',
+    });
+    isAuthorizedSigner.mockReturnValue(false);
+    programRepository.findBySlug.mockResolvedValue({ id: 'symbiosis-2025', slug: 'symbiosis-2025' });
+    programAdminRepository.isAdmin.mockResolvedValue(false);
+
+    const req = makeReq({
+      params: { slug: 'symbiosis-2025' },
+      headers: {
+        'x-siws-auth': encodePayload({ ...VALID_PAYLOAD, address: '5SomeoneElse' }),
+      },
+    });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireProgramAdmin('slug')(req, res, next);
+
+    expect(res.statusCode).toBe(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when the program slug does not exist', async () => {
+    signatureVerify.mockReturnValue({ isValid: true, crypto: 'sr25519' });
+    parseMessage.mockReturnValue({
+      address: '5SomeoneElse',
+      statement: 'Perform administrative action on Stadium',
+      domain: 'localhost',
+      expirationTime: new Date(Date.now() + 60_000).toISOString(),
+      nonce: 'abc',
+    });
+    isAuthorizedSigner.mockReturnValue(false);
+    programRepository.findBySlug.mockResolvedValue(null);
+
+    const req = makeReq({
+      params: { slug: 'no-such-program' },
+      headers: {
+        'x-siws-auth': encodePayload({ ...VALID_PAYLOAD, address: '5SomeoneElse' }),
+      },
+    });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireProgramAdmin('slug')(req, res, next);
+
+    expect(res.statusCode).toBe(404);
     expect(next).not.toHaveBeenCalled();
   });
 });

--- a/server/api/middleware/__tests__/wallet-contact.middleware.test.js
+++ b/server/api/middleware/__tests__/wallet-contact.middleware.test.js
@@ -41,6 +41,14 @@ vi.mock('../../auth/nonceStore.js', () => ({
   consumeNonce: vi.fn(),
 }));
 
+vi.mock('../../repositories/program.repository.js', () => ({
+  default: { findBySlug: vi.fn() },
+}));
+
+vi.mock('../../repositories/program-admin.repository.js', () => ({
+  default: { isAdmin: vi.fn() },
+}));
+
 import { parseMessage, verifySIWS } from '@talismn/siws';
 import { signatureVerify, decodeAddress } from '@polkadot/util-crypto';
 import { u8aToHex } from '@polkadot/util';

--- a/server/api/middleware/auth.middleware.js
+++ b/server/api/middleware/auth.middleware.js
@@ -22,6 +22,8 @@ import { getVerifier } from '../auth/verifiers/index.js';
 import { validateStatement } from '../auth/statements.js';
 import { normalizeAddress } from '../auth/normalize.js';
 import { consumeNonce } from '../auth/nonceStore.js';
+import programRepository from '../repositories/program.repository.js';
+import programAdminRepository from '../repositories/program-admin.repository.js';
 
 dotenv.config();
 
@@ -357,6 +359,82 @@ export const requireOwnWallet = async (req, res, next) => {
   logSuccess(`Signer ${auth.parsed.address} matches target wallet ${req.params.address}`);
   req.user = { address: auth.parsed.address, chain: auth.chain };
   return next();
+};
+
+/**
+ * Per-event admin (Phase 3, #95). The signer must be either a global
+ * authorized signer (ADMIN_WALLETS) OR an entry in `program_admins` for the
+ * program identified by `req.params[slugParam]`.
+ *
+ * @param {string} [slugParam='slug'] - name of the URL param holding the
+ *   program slug. Routes mounted under `/programs/:slug/...` get the default.
+ */
+export const requireProgramAdmin = (slugParam = 'slug') => async (req, res, next) => {
+  const slug = req.params?.[slugParam];
+  log(`Initiating program-admin verification for ${req.method} ${req.originalUrl} (slug=${slug})`);
+
+  if (!slug || typeof slug !== 'string') {
+    logError(`Missing ${slugParam} param.`);
+    return res.status(400).json({ status: 'error', message: `Program ${slugParam} is required` });
+  }
+
+  const authHeader = req.headers['x-siws-auth'];
+
+  if (process.env.NODE_ENV !== 'production' && authHeader === 'dev-bypass') {
+    log(chalk.yellow('⚠️  DEV MODE: Bypassing SIWS authentication for program admin'));
+    req.user = { address: ADMIN_WALLETS[0] || 'dev-admin', programSlug: slug, isGlobalAdmin: true };
+    return next();
+  }
+
+  if (!authHeader) {
+    logError('Verification failed: Missing x-siws-auth header.');
+    return res.status(401).json({ status: 'error', message: 'Missing SIWS auth header' });
+  }
+
+  const auth = await authenticateRequest(authHeader, { checkDomain: true });
+  if (!auth.ok) {
+    return res.status(auth.status).json(auth.body);
+  }
+
+  const signerAddress = auth.parsed.address;
+
+  // Global authorized signers always pass.
+  if (isAuthorizedSigner(auth.chain, signerAddress)) {
+    logSuccess(`Global admin ${signerAddress} accessing program "${slug}".`);
+    req.user = { address: signerAddress, chain: auth.chain, programSlug: slug, isGlobalAdmin: true };
+    return next();
+  }
+
+  // Otherwise the signer must be an entry in program_admins for this program.
+  try {
+    const program = await programRepository.findBySlug(slug);
+    if (!program) {
+      logError(`Program "${slug}" not found.`);
+      return res.status(404).json({ status: 'error', message: 'Program not found' });
+    }
+
+    const isProgramAdmin = await programAdminRepository.isAdmin(program.id, auth.chain, signerAddress);
+    if (!isProgramAdmin) {
+      logError(`${signerAddress} is not an admin for program "${slug}".`);
+      return res.status(403).json({
+        status: 'error',
+        message: 'Address is not authorized to administer this program',
+      });
+    }
+
+    logSuccess(`Program admin ${signerAddress} accessing "${slug}".`);
+    req.user = {
+      address: signerAddress,
+      chain: auth.chain,
+      programSlug: slug,
+      programId: program.id,
+      isGlobalAdmin: false,
+    };
+    return next();
+  } catch (err) {
+    logError(`Database error during program-admin check: ${err.message}`);
+    return res.status(500).json({ status: 'error', message: 'Internal server error during authorization' });
+  }
 };
 
 /**

--- a/server/api/repositories/program-admin.repository.js
+++ b/server/api/repositories/program-admin.repository.js
@@ -1,0 +1,68 @@
+import { supabase } from '../../db.js';
+import { normalizeAddress } from '../auth/normalize.js';
+
+const transform = (row) => {
+  if (!row) return null;
+  return {
+    programId: row.program_id,
+    walletChain: row.wallet_chain,
+    wallet: row.wallet,
+    createdAt: row.created_at,
+  };
+};
+
+class ProgramAdminRepository {
+  async list(programId) {
+    const { data, error } = await supabase
+      .from('program_admins')
+      .select('*')
+      .eq('program_id', programId)
+      .order('created_at', { ascending: true });
+    if (error) throw error;
+    return (data || []).map(transform);
+  }
+
+  async add(programId, walletChain, walletAddress) {
+    const normalized = normalizeAddress(walletChain, walletAddress);
+    if (!normalized) return null;
+    const { data, error } = await supabase
+      .from('program_admins')
+      .upsert(
+        { program_id: programId, wallet_chain: walletChain, wallet: normalized },
+        { onConflict: 'program_id,wallet_chain,wallet' },
+      )
+      .select('*')
+      .single();
+    if (error) throw error;
+    return transform(data);
+  }
+
+  async remove(programId, walletChain, walletAddress) {
+    const normalized = normalizeAddress(walletChain, walletAddress);
+    if (!normalized) return false;
+    const { error } = await supabase
+      .from('program_admins')
+      .delete()
+      .eq('program_id', programId)
+      .eq('wallet_chain', walletChain)
+      .eq('wallet', normalized);
+    if (error) throw error;
+    return true;
+  }
+
+  async isAdmin(programId, walletChain, walletAddress) {
+    const normalized = normalizeAddress(walletChain, walletAddress);
+    if (!normalized) return false;
+    const { data, error } = await supabase
+      .from('program_admins')
+      .select('wallet')
+      .eq('program_id', programId)
+      .eq('wallet_chain', walletChain)
+      .eq('wallet', normalized)
+      .maybeSingle();
+    if (error) throw error;
+    return !!data;
+  }
+}
+
+export default new ProgramAdminRepository();

--- a/server/api/routes/program.routes.js
+++ b/server/api/routes/program.routes.js
@@ -1,6 +1,9 @@
 import { Router } from 'express';
 import programController from '../controllers/program.controller.js';
-import requireAdmin, { requireTeamMemberOrAdminByBodyProject } from '../middleware/auth.middleware.js';
+import requireAdmin, {
+  requireTeamMemberOrAdminByBodyProject,
+  requireProgramAdmin,
+} from '../middleware/auth.middleware.js';
 
 const router = Router();
 
@@ -13,7 +16,11 @@ router.post('/', requireAdmin, programController.createProgram);
 router.patch('/:slug', requireAdmin, programController.updateProgram);
 
 // --- Phase 1 revamp: applications (#43, #47) ---
-router.get('/:slug/applications', requireAdmin, programController.listApplicationsForProgram);
+router.get(
+  '/:slug/applications',
+  requireProgramAdmin('slug'),
+  programController.listApplicationsForProgram,
+);
 router.post(
   '/:slug/applications',
   requireTeamMemberOrAdminByBodyProject,
@@ -21,8 +28,14 @@ router.post(
 );
 router.patch(
   '/:slug/applications/:applicationId',
-  requireAdmin,
+  requireProgramAdmin('slug'),
   programController.updateApplicationStatus,
 );
+
+// --- Phase 3 (#95): per-event admins ---
+// Read = program admin or global; mutate = global only.
+router.get('/:slug/admins', requireProgramAdmin('slug'), programController.listAdmins);
+router.post('/:slug/admins', requireAdmin, programController.addAdmin);
+router.delete('/:slug/admins/:wallet', requireAdmin, programController.removeAdmin);
 
 export default router;

--- a/supabase/migrations/20260520400000_program_admins.sql
+++ b/supabase/migrations/20260520400000_program_admins.sql
@@ -1,0 +1,20 @@
+-- Per-event admin permissions (Phase 3, closes #95).
+-- `program_admins` lets each program (event or continuation track) carry its
+-- own admin allow-list — distinct from the global `ADMIN_WALLETS` env, which
+-- stays as the superadmin escape hatch.
+--
+-- The stored `wallet` is the normalized form (substrate SS58, EVM lowercase,
+-- Solana base58) so lookups are direct equality checks. `wallet_chain` keeps
+-- the per-chain comparison honest — an address valid on chain X can't be
+-- spoofed via chain Y.
+
+CREATE TABLE IF NOT EXISTS program_admins (
+  program_id   TEXT NOT NULL REFERENCES programs(id) ON DELETE CASCADE,
+  wallet_chain TEXT NOT NULL CHECK (wallet_chain IN ('substrate', 'ethereum', 'solana')),
+  wallet       TEXT NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (program_id, wallet_chain, wallet)
+);
+
+CREATE INDEX IF NOT EXISTS idx_program_admins_wallet
+  ON program_admins(wallet_chain, wallet);


### PR DESCRIPTION
Closes #95. Sequentially after #96 (schema) and #97 (copy/IA).

## Summary

Each event/track can now have its own admins, distinct from the global \`ADMIN_WALLETS\` env. The global list stays as the superadmin escape hatch.

### Server

- **Migration** \`supabase/migrations/20260520400000_program_admins.sql\` — composite PK \`(program_id, wallet_chain, wallet)\`; wallet stored normalized so lookups are direct equality.
- **\`program-admin.repository.js\`** — \`list / add / remove / isAdmin\`. All writes normalize via \`normalizeAddress(chain, address)\`.
- **\`requireProgramAdmin(slugParam)\`** middleware — passes if the SIWS signer is a global authorized signer OR is listed in \`program_admins\` for the program identified by the URL slug.
- **Routes**:
  - \`GET /programs/:slug/admins\` → \`requireProgramAdmin\` (global or per-program)
  - \`POST /programs/:slug/admins\` → \`requireAdmin\` (global only)
  - \`DELETE /programs/:slug/admins/:wallet?chain=...\` → \`requireAdmin\` (global only)
- The existing application-management routes (\`GET /:slug/applications\`, \`PATCH /:slug/applications/:applicationId\`) now use \`requireProgramAdmin('slug')\` so per-event admins can review their event's applications. Other admin-protected routes that aren't event-scoped (POST /programs, PATCH /:slug) remain global-only.
- 6 new middleware tests cover global pass-through, per-program pass, unauthorized 403, missing-slug 400, and unknown-program 404.

### Client

- New \`ProgramAdminsSection\` component, mounted on \`AdminProgramPage\`. Lists current admins; global admins see add/remove controls, per-program admins see the list only.
- \`AdminProgramPage\`'s connect-wallet flow now also accepts per-program admins via a SIWS probe against \`GET /:slug/admins\` — a 200 unlocks the page, a 403 shows the "not authorized" message.
- \`api.ts\` gains \`listProgramAdmins / addProgramAdmin / removeProgramAdmin\` + an \`ApiProgramAdmin\` type.

Full server test suite passes (177/177, +6 from Phase 1). Client build clean, lint clean.

## Out of scope

- Removing the \`ADMIN_WALLETS\` env list — it stays as the global superadmin escape hatch.
- Migrating other admin-protected routes that aren't event-scoped.

## Test plan

- [ ] On \`/admin/programs/symbiosis-2025\`, a global admin can see the new "Program admins" section and add a wallet (the wallet appears in the list immediately).
- [ ] After adding a non-global wallet as admin for \`symbiosis-2025\`, that wallet can connect to the page and see the admins list — but the add/remove controls are hidden.
- [ ] A program admin for one program cannot access another program's admin page (gets the "Not authorized for this program" toast).
- [ ] A global admin can still do everything across every program (regression).
- [ ] On \`/admin/programs/symbiosis-2025\`, a global admin removing a wallet causes the row to disappear from the list immediately.

\`stadium-tester\` report will be pasted after running against the Vercel preview.