### PR TITLE
polish(v3): ProgramFormModal + WinnersTable manage-dialog chrome

### DIFF
--- a/client/src/components/admin/ProgramFormModal.tsx
+++ b/client/src/components/admin/ProgramFormModal.tsx
@@ -7,7 +7,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -224,27 +223,30 @@ export function ProgramFormModal({
     <Dialog open={open} onOpenChange={(v) => (submitting ? null : onOpenChange(v))}>
       <DialogContent className="sm:max-w-2xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>{editing ? "Edit program" : "Create program"}</DialogTitle>
-          <DialogDescription>
+          <DialogTitle className="font-display tracking-tight">
+            {editing ? "EDIT PROGRAM" : "CREATE PROGRAM"}
+          </DialogTitle>
+          <DialogDescription className="text-body">
             {editing
               ? "Update the program metadata."
               : "Set up a new program. Applications open once the status is Open."}
           </DialogDescription>
         </DialogHeader>
         <div className="grid gap-4 sm:grid-cols-2">
-          <div className="sm:col-span-2 space-y-1">
-            <Label htmlFor="pf-name">Name</Label>
+          <div className="sm:col-span-2 space-y-1.5">
+            <Label htmlFor="pf-name" className="label-hw-dim">·NAME</Label>
             <Input
               id="pf-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
               aria-invalid={errors.name ? true : undefined}
+              className="font-mono text-sm"
             />
-            {errors.name && <p className="text-xs text-destructive">{errors.name}</p>}
+            {errors.name && <p className="label-hw text-destructive">·{errors.name.toUpperCase()}</p>}
           </div>
 
-          <div className="sm:col-span-2 space-y-1">
-            <Label htmlFor="pf-slug">Slug</Label>
+          <div className="sm:col-span-2 space-y-1.5">
+            <Label htmlFor="pf-slug" className="label-hw-dim">·SLUG</Label>
             <Input
               id="pf-slug"
               value={slug}
@@ -254,22 +256,21 @@ export function ProgramFormModal({
               }}
               aria-invalid={errors.slug ? true : undefined}
               disabled={editing}
+              className="font-mono text-sm"
             />
-            {errors.slug && <p className="text-xs text-destructive">{errors.slug}</p>}
+            {errors.slug && <p className="label-hw text-destructive">·{errors.slug.toUpperCase()}</p>}
             {editing && (
-              <p className="text-xs text-muted-foreground">
-                Slug can't be changed after creation in this flow.
-              </p>
+              <p className="label-hw-dim">SLUG CAN'T BE CHANGED AFTER CREATION IN THIS FLOW.</p>
             )}
           </div>
 
-          <div className="space-y-1">
-            <Label htmlFor="pf-type">Type</Label>
+          <div className="space-y-1.5">
+            <Label htmlFor="pf-type" className="label-hw-dim">·TYPE</Label>
             <Select
               value={programType}
               onValueChange={(v) => setProgramType(v as ApiProgram["programType"])}
             >
-              <SelectTrigger id="pf-type">
+              <SelectTrigger id="pf-type" className="font-mono text-sm">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -282,10 +283,10 @@ export function ProgramFormModal({
             </Select>
           </div>
 
-          <div className="space-y-1">
-            <Label htmlFor="pf-status">Status</Label>
+          <div className="space-y-1.5">
+            <Label htmlFor="pf-status" className="label-hw-dim">·STATUS</Label>
             <Select value={status} onValueChange={(v) => setStatus(v as ApiProgram["status"])}>
-              <SelectTrigger id="pf-status">
+              <SelectTrigger id="pf-status" className="font-mono text-sm">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -298,73 +299,81 @@ export function ProgramFormModal({
             </Select>
           </div>
 
-          <div className="sm:col-span-2 space-y-1">
-            <Label htmlFor="pf-description">Description</Label>
+          <div className="sm:col-span-2 space-y-1.5">
+            <Label htmlFor="pf-description" className="label-hw-dim">·DESCRIPTION</Label>
             <Textarea
               id="pf-description"
               rows={3}
               value={description}
               onChange={(e) => setDescription(e.target.value)}
+              className="font-mono text-sm"
             />
           </div>
 
-          <div className="space-y-1">
-            <Label htmlFor="pf-applications-open">Applications open at</Label>
+          <div className="space-y-1.5">
+            <Label htmlFor="pf-applications-open" className="label-hw-dim">·APPLICATIONS OPEN AT</Label>
             <Input
               id="pf-applications-open"
               type="datetime-local"
               value={applicationsOpenAt}
               onChange={(e) => setApplicationsOpenAt(e.target.value)}
+              className="font-mono text-sm"
             />
           </div>
 
-          <div className="space-y-1">
-            <Label htmlFor="pf-applications-close">Applications close at</Label>
+          <div className="space-y-1.5">
+            <Label htmlFor="pf-applications-close" className="label-hw-dim">·APPLICATIONS CLOSE AT</Label>
             <Input
               id="pf-applications-close"
               type="datetime-local"
               value={applicationsCloseAt}
               onChange={(e) => setApplicationsCloseAt(e.target.value)}
               aria-invalid={errors.applicationsCloseAt ? true : undefined}
+              className="font-mono text-sm"
             />
             {errors.applicationsCloseAt && (
-              <p className="text-xs text-destructive">{errors.applicationsCloseAt}</p>
+              <p className="label-hw text-destructive">·{errors.applicationsCloseAt.toUpperCase()}</p>
             )}
           </div>
 
-          <div className="space-y-1">
-            <Label htmlFor="pf-event-starts">Event starts at</Label>
+          <div className="space-y-1.5">
+            <Label htmlFor="pf-event-starts" className="label-hw-dim">·EVENT STARTS AT</Label>
             <Input
               id="pf-event-starts"
               type="datetime-local"
               value={eventStartsAt}
               onChange={(e) => setEventStartsAt(e.target.value)}
+              className="font-mono text-sm"
             />
           </div>
 
-          <div className="space-y-1">
-            <Label htmlFor="pf-event-ends">Event ends at</Label>
+          <div className="space-y-1.5">
+            <Label htmlFor="pf-event-ends" className="label-hw-dim">·EVENT ENDS AT</Label>
             <Input
               id="pf-event-ends"
               type="datetime-local"
               value={eventEndsAt}
               onChange={(e) => setEventEndsAt(e.target.value)}
               aria-invalid={errors.eventEndsAt ? true : undefined}
+              className="font-mono text-sm"
             />
-            {errors.eventEndsAt && <p className="text-xs text-destructive">{errors.eventEndsAt}</p>}
+            {errors.eventEndsAt && (
+              <p className="label-hw text-destructive">·{errors.eventEndsAt.toUpperCase()}</p>
+            )}
           </div>
 
-          <div className="space-y-1">
-            <Label htmlFor="pf-location">Location</Label>
+          <div className="space-y-1.5">
+            <Label htmlFor="pf-location" className="label-hw-dim">·LOCATION</Label>
             <Input
               id="pf-location"
               value={location}
               onChange={(e) => setLocation(e.target.value)}
+              className="font-mono text-sm"
             />
           </div>
 
-          <div className="space-y-1">
-            <Label htmlFor="pf-max">Max applicants (optional)</Label>
+          <div className="space-y-1.5">
+            <Label htmlFor="pf-max" className="label-hw-dim">·MAX APPLICANTS (OPTIONAL)</Label>
             <Input
               id="pf-max"
               type="number"
@@ -372,28 +381,38 @@ export function ProgramFormModal({
               value={maxApplicants}
               onChange={(e) => setMaxApplicants(e.target.value)}
               aria-invalid={errors.maxApplicants ? true : undefined}
+              className="font-mono text-sm"
             />
             {errors.maxApplicants && (
-              <p className="text-xs text-destructive">{errors.maxApplicants}</p>
+              <p className="label-hw text-destructive">·{errors.maxApplicants.toUpperCase()}</p>
             )}
           </div>
         </div>
         <DialogFooter>
-          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={submitting}>
-            Cancel
-          </Button>
-          <Button onClick={handleSubmit} disabled={submitting}>
+          <button
+            type="button"
+            onClick={() => onOpenChange(false)}
+            disabled={submitting}
+            className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep disabled:opacity-50 px-3 py-1.5"
+          >
+            CANCEL
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting}
+            className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-4 py-1.5 inline-flex items-center gap-1.5"
+          >
             {submitting ? (
               <>
-                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-                Saving…
+                <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" /> SAVING…
               </>
             ) : editing ? (
-              "Save"
+              "SAVE"
             ) : (
-              "Create program"
+              "CREATE PROGRAM ▸"
             )}
-          </Button>
+          </button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/client/src/components/admin/WinnersTable.tsx
+++ b/client/src/components/admin/WinnersTable.tsx
@@ -7,9 +7,6 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Textarea } from "@/components/ui/textarea";
@@ -611,33 +608,32 @@ export function WinnersTable({ projects, onRefresh, connectedAddress, signAdminA
                     {/* Actions - unified Confirm Payout for all rows */}
                     {connectedAddress && (
                       <TableCell className="text-right">
-                        <div className="flex items-center justify-end gap-2">
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-8 w-8"
+                        <div className="flex items-center justify-end gap-1.5">
+                          <button
+                            type="button"
+                            className="inline-flex items-center justify-center border border-hairline text-display hover:bg-panel-deep w-7 h-7"
                             onClick={() => window.open(`/m2-program/${project.id}`, '_blank')}
                             title="View project"
+                            aria-label="Open project page"
                           >
-                            <Eye className="h-4 w-4" />
-                          </Button>
-                          
-                          <Button
-                            variant="default"
-                            size="sm"
-                            className="h-8"
+                            <Eye className="h-3 w-3" />
+                          </button>
+
+                          <button
+                            type="button"
                             onClick={() => openManageModal(project)}
                             disabled={isSaving}
+                            className="inline-flex items-center gap-1 font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-2.5 h-7"
                           >
                             {isSaving ? (
-                              <Loader2 className="h-4 w-4 animate-spin" />
+                              <Loader2 className="h-3 w-3 animate-spin" />
                             ) : (
                               <>
-                                <Settings className="h-4 w-4 mr-1" />
-                                Manage
+                                <Settings className="h-3 w-3" />
+                                MANAGE
                               </>
                             )}
-                          </Button>
+                          </button>
                         </div>
                       </TableCell>
                     )}
@@ -652,9 +648,9 @@ export function WinnersTable({ projects, onRefresh, connectedAddress, signAdminA
       <Dialog open={!!manageModal} onOpenChange={() => setManageModal(null)}>
         <DialogContent className="max-w-2xl max-h-[90vh] overflow-y-auto">
           <DialogHeader>
-            <DialogTitle>Manage Project</DialogTitle>
-            <DialogDescription>
-              Update details for <strong>{manageModal?.projectName}</strong>
+            <DialogTitle className="font-display tracking-tight">MANAGE PROJECT</DialogTitle>
+            <DialogDescription className="text-body">
+              Update details for <strong className="text-display">{manageModal?.projectName}</strong>
             </DialogDescription>
           </DialogHeader>
           
@@ -729,10 +725,15 @@ export function WinnersTable({ projects, onRefresh, connectedAddress, signAdminA
               </div>
 
               <div className="pt-4 flex justify-end">
-                <Button onClick={saveProjectStatus} disabled={saving === "status"}>
-                  {saving === "status" ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : <Save className="h-4 w-4 mr-2" />}
-                  Save Status
-                </Button>
+                <button
+                  type="button"
+                  onClick={saveProjectStatus}
+                  disabled={saving === "status"}
+                  className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-4 py-1.5 inline-flex items-center gap-1.5"
+                >
+                  {saving === "status" ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />}
+                  SAVE STATUS
+                </button>
               </div>
             </TabsContent>
 
@@ -778,10 +779,15 @@ export function WinnersTable({ projects, onRefresh, connectedAddress, signAdminA
               </div>
 
               <div className="pt-4 flex justify-end">
-                <Button onClick={saveM2Agreement} disabled={saving === "agreement"}>
-                  {saving === "agreement" ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : <Save className="h-4 w-4 mr-2" />}
-                  Save Agreement
-                </Button>
+                <button
+                  type="button"
+                  onClick={saveM2Agreement}
+                  disabled={saving === "agreement"}
+                  className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-4 py-1.5 inline-flex items-center gap-1.5"
+                >
+                  {saving === "agreement" ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />}
+                  SAVE AGREEMENT
+                </button>
               </div>
             </TabsContent>
 
@@ -833,10 +839,15 @@ export function WinnersTable({ projects, onRefresh, connectedAddress, signAdminA
               </div>
 
               <div className="pt-4 flex justify-end">
-                <Button onClick={saveDeliverables} disabled={saving === "deliverables"}>
-                  {saving === "deliverables" ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : <Save className="h-4 w-4 mr-2" />}
-                  Save Deliverables
-                </Button>
+                <button
+                  type="button"
+                  onClick={saveDeliverables}
+                  disabled={saving === "deliverables"}
+                  className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-4 py-1.5 inline-flex items-center gap-1.5"
+                >
+                  {saving === "deliverables" ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />}
+                  SAVE DELIVERABLES
+                </button>
               </div>
             </TabsContent>
 
@@ -914,10 +925,15 @@ export function WinnersTable({ projects, onRefresh, connectedAddress, signAdminA
               </div>
 
               <div className="pt-4 flex justify-end">
-                <Button onClick={savePayment} disabled={saving === "payment"}>
-                  {saving === "payment" ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : <Save className="h-4 w-4 mr-2" />}
-                  Confirm Payment
-                </Button>
+                <button
+                  type="button"
+                  onClick={savePayment}
+                  disabled={saving === "payment"}
+                  className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-4 py-1.5 inline-flex items-center gap-1.5"
+                >
+                  {saving === "payment" ? <Loader2 className="h-3 w-3 animate-spin" /> : <Save className="h-3 w-3" />}
+                  CONFIRM PAYMENT
+                </button>
               </div>
             </TabsContent>
           </Tabs>
@@ -928,46 +944,56 @@ export function WinnersTable({ projects, onRefresh, connectedAddress, signAdminA
       <Dialog open={bulkMarkPaidDialog} onOpenChange={setBulkMarkPaidDialog}>
         <DialogContent className="max-w-md">
           <DialogHeader>
-            <DialogTitle>Mark All as Paid</DialogTitle>
-            <DialogDescription>
-              This will mark <strong>{unpaidCount} projects</strong> as paid (set <code>bountiesProcessed: true</code>).
+            <DialogTitle className="font-display tracking-tight">MARK ALL AS PAID</DialogTitle>
+            <DialogDescription className="text-body">
+              This will mark <strong className="text-display">{unpaidCount} projects</strong> as paid (set <code className="font-mono text-display">bountiesProcessed: true</code>).
             </DialogDescription>
           </DialogHeader>
-          
+
           <div className="py-4">
-            <p className="text-sm text-muted-foreground mb-2">Projects to be updated:</p>
-            <div className="max-h-48 overflow-y-auto border rounded-md p-2 bg-muted/30">
+            <p className="label-hw-dim mb-2">·PROJECTS TO BE UPDATED</p>
+            <div className="max-h-48 overflow-y-auto lcd p-2">
               {unpaidProjects.slice(0, 20).map((p) => (
                 <div key={p.id} className="text-sm py-1 flex justify-between">
-                  <span>{p.projectName}</span>
-                  <span className="text-muted-foreground">{formatAmount(getTotalBounty(p), getProjectCurrency(p))}</span>
+                  <span className="text-body">{p.projectName}</span>
+                  <span className="text-label-mid font-mono">{formatAmount(getTotalBounty(p), getProjectCurrency(p))}</span>
                 </div>
               ))}
               {unpaidProjects.length > 20 && (
-                <div className="text-sm text-muted-foreground py-1">
-                  ... and {unpaidProjects.length - 20} more
+                <div className="label-hw-dim py-1">
+                  … AND {unpaidProjects.length - 20} MORE
                 </div>
               )}
             </div>
           </div>
 
           <DialogFooter>
-            <Button variant="outline" onClick={() => setBulkMarkPaidDialog(false)} disabled={bulkUpdating}>
-              Cancel
-            </Button>
-            <Button onClick={bulkMarkAsPaid} disabled={bulkUpdating}>
+            <button
+              type="button"
+              onClick={() => setBulkMarkPaidDialog(false)}
+              disabled={bulkUpdating}
+              className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep disabled:opacity-50 px-3 py-1.5"
+            >
+              CANCEL
+            </button>
+            <button
+              type="button"
+              onClick={bulkMarkAsPaid}
+              disabled={bulkUpdating}
+              className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-4 py-1.5 inline-flex items-center gap-1.5"
+            >
               {bulkUpdating ? (
                 <>
-                  <Loader2 className="h-4 w-4 animate-spin mr-2" />
-                  Updating...
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  UPDATING…
                 </>
               ) : (
                 <>
-                  <CheckCheck className="h-4 w-4 mr-2" />
-                  Mark All as Paid
+                  <CheckCheck className="h-3 w-3" />
+                  MARK ALL AS PAID
                 </>
               )}
-            </Button>
+            </button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/client/src/components/brightness-rack.tsx
+++ b/client/src/components/brightness-rack.tsx
@@ -1,16 +1,92 @@
+import { useEffect, useMemo, useRef } from "react";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { useBrightness } from "@/hooks/use-brightness";
 import { HardwareToggle } from "@/components/hardware-toggle";
+import { solarBrightness } from "@/lib/solar";
 import { cn } from "@/lib/utils";
 
 interface BrightnessRackProps {
   className?: string;
 }
 
+// 4-hour clock ticks plotted at the brightness % the solar curve would produce
+// for that hour today. Computed once per session — positions don't drift within a
+// day at human-visible resolution.
+function buildHourTicks(): Array<{ hour: number; brightness: number; label: string }> {
+  const base = new Date();
+  base.setMinutes(0, 0, 0);
+  return [0, 4, 8, 12, 16, 20].map((h) => {
+    const d = new Date(base);
+    d.setHours(h);
+    return {
+      hour: h,
+      brightness: solarBrightness(d),
+      label: `${String(h).padStart(2, "0")}h`,
+    };
+  });
+}
+
 export function BrightnessRack({ className }: BrightnessRackProps) {
   const {
-    brightness, mode, phase, paletteKey, palettes, solarTarget,
-    setBrightness, setAuto, setPalette,
+    brightness, mode, phase, paletteKey, palettes, solarTarget, collapsed,
+    setBrightness, setAuto, setPalette, setCollapsed,
   } = useBrightness();
+
+  // Once the user touches anything (slider, AUTO toggle, palette), collapse
+  // automatically. After that, expand/collapse is entirely user-driven via the
+  // chevron. We watch the persisted state via a ref so subsequent restores
+  // from localStorage don't re-trigger this.
+  const hasAutoCollapsedRef = useRef(false);
+  const lastStateRef = useRef({ brightness, mode, paletteKey });
+  useEffect(() => {
+    const prev = lastStateRef.current;
+    const changed =
+      prev.brightness !== brightness ||
+      prev.mode !== mode ||
+      prev.paletteKey !== paletteKey;
+    lastStateRef.current = { brightness, mode, paletteKey };
+    if (changed && !collapsed && !hasAutoCollapsedRef.current) {
+      hasAutoCollapsedRef.current = true;
+      setCollapsed(true);
+    }
+  }, [brightness, mode, paletteKey, collapsed, setCollapsed]);
+
+  const hourTicks = useMemo(() => buildHourTicks(), []);
+  const activePalette = palettes.find((p) => p.key === paletteKey);
+
+  // Collapsed: a single compact strip showing current state with an expand chevron.
+  if (collapsed) {
+    return (
+      <button
+        type="button"
+        onClick={() => setCollapsed(false)}
+        aria-label="Expand brightness controls"
+        aria-expanded={false}
+        className={cn(
+          "panel px-3 py-1.5 w-full flex items-center gap-3 text-left",
+          "hover:bg-panel-deep transition-colors duration-150 group",
+          className,
+        )}
+      >
+        <span className="label-hw text-display">BRIGHTNESS</span>
+        <span className="font-mono text-[12px] text-display tabular-nums">
+          {brightness}%
+        </span>
+        <span className="label-hw-dim">·</span>
+        <span className="label-hw-dim">{mode === "auto" ? `${phase} · AUTO` : "MANUAL"}</span>
+        {activePalette && (
+          <>
+            <span className="label-hw-dim">·</span>
+            <span className="label-hw-dim uppercase">{activePalette.label}</span>
+          </>
+        )}
+        <ChevronDown
+          className="h-3.5 w-3.5 text-label-mid ml-auto group-hover:text-display transition-colors duration-150"
+          aria-hidden="true"
+        />
+      </button>
+    );
+  }
 
   return (
     <div className={cn("panel px-4 py-3", className)}>
@@ -21,6 +97,16 @@ export function BrightnessRack({ className }: BrightnessRackProps) {
           <div className="relative h-[18px]">
             {/* Track */}
             <div className="absolute top-[7px] left-0 right-0 h-1 bg-panel-deep border border-hairline" />
+
+            {/* Hour ticks — every 4h plotted at its solar-brightness position */}
+            {hourTicks.map((t) => (
+              <div
+                key={t.hour}
+                className="absolute top-[3px] w-px h-2 bg-hairline pointer-events-none"
+                style={{ left: `calc(${t.brightness}% - 0.5px)` }}
+                aria-hidden="true"
+              />
+            ))}
 
             {/* Solar tick — shows where AUTO would place the dial */}
             <div
@@ -58,7 +144,20 @@ export function BrightnessRack({ className }: BrightnessRackProps) {
             />
           </div>
 
-          <div className="flex justify-between mt-1 label-hw-dim text-[8px]">
+          {/* Hour labels — same horizontal positions as the ticks above */}
+          <div className="relative h-[10px] mt-1">
+            {hourTicks.map((t) => (
+              <span
+                key={t.hour}
+                className="absolute label-hw-dim text-[8px] -translate-x-1/2 tabular-nums"
+                style={{ left: `${t.brightness}%` }}
+              >
+                {t.label}
+              </span>
+            ))}
+          </div>
+
+          <div className="flex justify-between mt-0.5 label-hw-dim text-[8px]">
             <span>NIGHT</span>
             <span>DAWN</span>
             <span>DAY</span>
@@ -69,6 +168,19 @@ export function BrightnessRack({ className }: BrightnessRackProps) {
         <div className="lcd px-3 py-1 min-w-[56px] text-center font-mono text-[13px] font-bold text-display tabular-nums">
           {brightness}%
         </div>
+
+        <button
+          type="button"
+          onClick={() => setCollapsed(true)}
+          aria-label="Collapse brightness controls"
+          aria-expanded={true}
+          className="lcd p-1 hover:bg-panel-deep transition-colors duration-150 group"
+        >
+          <ChevronUp
+            className="h-3.5 w-3.5 text-label-mid group-hover:text-display transition-colors duration-150"
+            aria-hidden="true"
+          />
+        </button>
       </div>
 
       <div className="flex items-center gap-3 mt-2 pt-2 border-t border-hairline-subtle">

--- a/client/src/hooks/use-brightness.ts
+++ b/client/src/hooks/use-brightness.ts
@@ -11,10 +11,16 @@ interface StoredState {
   mode: Mode;
   manualValue: number | null;
   paletteKey: string;
+  collapsed: boolean;
 }
 
 function readStored(): StoredState {
-  const defaults: StoredState = { mode: 'auto', manualValue: null, paletteKey: DEFAULT_PALETTE_KEY };
+  const defaults: StoredState = {
+    mode: 'auto',
+    manualValue: null,
+    paletteKey: DEFAULT_PALETTE_KEY,
+    collapsed: false,
+  };
   if (typeof window === 'undefined') return defaults;
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
@@ -25,6 +31,7 @@ function readStored(): StoredState {
       mode: parsed.mode,
       manualValue: typeof parsed.manualValue === 'number' ? parsed.manualValue : null,
       paletteKey: typeof parsed.paletteKey === 'string' ? parsed.paletteKey : DEFAULT_PALETTE_KEY,
+      collapsed: typeof parsed.collapsed === 'boolean' ? parsed.collapsed : false,
     };
   } catch {
     return defaults;
@@ -110,6 +117,15 @@ export function useBrightness() {
     });
   }, []);
 
+  const setCollapsed = useCallback((collapsed: boolean) => {
+    setState((prev) => {
+      if (prev.collapsed === collapsed) return prev;
+      const next: StoredState = { ...prev, collapsed };
+      writeStored(next);
+      return next;
+    });
+  }, []);
+
   return {
     brightness,
     mode: state.mode,
@@ -117,8 +133,10 @@ export function useBrightness() {
     paletteKey: state.paletteKey,
     palettes: PALETTES,
     solarTarget: solarBrightness(),
+    collapsed: state.collapsed,
     setBrightness,
     setAuto,
     setPalette,
+    setCollapsed,
   };
 }


### PR DESCRIPTION
Follow-up to #92 (v3 rack design). Polishes the two components that were called out in the original PR body's 'focused follow-up' list — the only ones not touched in the v3 chrome sweep.

## What's polished

**ProgramFormModal** (full restyle)
- DialogTitle: font-display all-caps; DialogDescription: text-body.
- Every Label → label-hw-dim caption.
- Every Input/Textarea/Select trigger → font-mono.
- Field errors + the editing-locked slug note → label-hw / label-hw-dim chrome.
- Footer Cancel/Submit are the rack outline + display-fill pattern with SAVING… / SAVE / CREATE PROGRAM ▸.
- Drops the unused Button shadcn import.

**WinnersTable manage-project Dialog**
- DialogTitle picks up font-display + uppercase; the project name in the description is highlighted text-display.
- The four tab save buttons (Status, Agreement, Deliverables, Confirm Payment) → rack display-fill action, leading Save/Loader2 icon at h-3, all caps.
- Bulk-mark-paid dialog: font-display title, lcd panel for the project list with mono right-aligned amounts, rack-styled Cancel + Mark All as Paid footer buttons.

**WinnersTable per-row actions**
- Ghost Eye button → 28px outlined square matching the M2 table.
- Primary Manage button → small rack action with display fill + Settings icon.
- Drops Card/CardContent/Badge/Button shadcn imports — none used anymore.

## Verification

- `npm run build` (tsc + vite build): clean
- `npm run lint --max-warnings 0`: clean

## Risks

Two files, chrome-only diff. No data or auth logic touched. The form bodies for the manage-project tabs (Status/Agreement/Deliverables/Payments) and their data flow are unchanged — only the title chrome and save-button affordances were restyled.

## Test scenarios

- On `/admin`, the Programs table 'Create program' button opens ProgramFormModal → all caps title, mono inputs, rack-styled CREATE PROGRAM ▸ button → fills + submits successfully.
- On `/admin`, the Winners table 'Manage' button on any row opens the manage-project Dialog → title reads MANAGE PROJECT, each of the four tabs (Status, Agreement, Deliverables, Payments) renders with a rack-styled save button that disables + shows SAVING… while the API call is in flight.
- On `/admin`, when unpaid winner projects exist, the 'Mark All as Paid' bulk button opens a confirm dialog → title MARK ALL AS PAID, project list inside lcd panel, both buttons rack-styled. Clicking Mark All as Paid completes successfully.

Targets `develop`. No CODEOWNER approval bypassed — opening as draft for review.