### PR TITLE
scripts: add seed:dogfooding npm shortcut (#48)

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -11,6 +11,7 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "seed:dev": "node scripts/seed-dev.js",
+    "seed:dogfooding": "node scripts/seed-dogfooding-program.js",
     "generate:multisig": "node scripts/generate-multisig.js",
     "generate:test-account": "node scripts/generate-test-account.js",
     "db:purge": "mongosh blockspace-stadium --eval \"db.dropDatabase()\" --quiet",


### PR DESCRIPTION
Tiny wrap-up for #48. The Dogfooding 2026 seed script (`server/scripts/seed-dogfooding-program.js`) already exists with final copy and correct dates, but was missing an `npm run` entry — wires it up next to `seed:dev` so it's discoverable.

## Verification

```
$ cd server && npm run seed:dogfooding -- --dry-run
--- seed-dogfooding-program ---
Supabase URL: https://***.supabase.co
Mode:         DRY RUN (no writes)

Planned row:
  id=dogfooding-2026-berlin
  name="Dogfooding 2026"
  slug=dogfooding-2026-berlin
  program_type=dogfooding
  status=open
  applications: 2026-05-20T16:36:00.372Z → 2026-05-30T23:59:59Z
  event:        2026-06-13T00:00:00Z → 2026-06-19T23:59:59Z
  location:     Berlin

DRY RUN: no insert performed.
```

## Test scenarios

- On a fresh clone with `server/.env` containing `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`, running `cd server && npm run seed:dogfooding -- --dry-run` prints the planned row and exits 0 with no DB writes.

Targets `develop`. Draft for review.