### PR TITLE
fix(cors): allow any localhost:* origin in dev (Vite port-bump)

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -11,16 +11,23 @@ const app = express();
 const PORT = process.env.PORT || 2000;
 
 // CORS Configuration: allow explicit list + any Vercel deployment (*.vercel.app)
+// In non-production, also allow any http://localhost:* or http://127.0.0.1:*
+// origin so Vite's auto-port-bump (5173 → 5174, 8080 → 8081, …) doesn't break
+// preflight when the developer has another process holding the default port.
+const isProd = process.env.NODE_ENV === 'production';
 const explicitOrigins = process.env.CORS_ORIGIN
     ? process.env.CORS_ORIGIN.split(',').map(origin => origin.trim())
-    : process.env.NODE_ENV === 'production'
+    : isProd
       ? ['https://stadium.joinwebzero.com', 'https://stadium-indol.vercel.app', 'https://stadium-nu.vercel.app']
-      : ['http://localhost:3000', 'http://localhost:5173', 'http://localhost:8080', 'https://stadium-indol.vercel.app', 'https://stadium-nu.vercel.app'];
+      : ['https://stadium-indol.vercel.app', 'https://stadium-nu.vercel.app'];
+
+const LOCALHOST_DEV_ORIGIN = /^http:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/;
 
 const allowOrigin = (origin, cb) => {
     if (!origin) return cb(null, true); // same-origin or non-browser
     if (explicitOrigins.includes(origin)) return cb(null, origin);
     if (/^https:\/\/[^/]+\.vercel\.app$/.test(origin)) return cb(null, origin); // echo origin for credentials
+    if (!isProd && LOCALHOST_DEV_ORIGIN.test(origin)) return cb(null, origin);
     return cb(null, false);
 };
 


### PR DESCRIPTION
## Symptom

`POST /api/programs` from a local Vite dev client fails preflight with:

```
Access to fetch at 'http://localhost:2000/api/programs' from origin
'http://localhost:8081' has been blocked by CORS policy:
Response to preflight request doesn't pass access control check:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

## Cause

`server/server.js` had a hardcoded dev origin allowlist: `:3000`, `:5173`, `:8080`. Vite's configured port is `8080` (`client/vite.config.ts:11`) but it auto-bumps to `8081` / `8082` / … when its preferred port is taken. The bumped origin isn't in the list, so the response carries no `Access-Control-Allow-Origin` header.

## Fix

Replace the dev port list with a regex match on `http://localhost:*` / `http://127.0.0.1:*` that **only fires when `NODE_ENV !== 'production'`**. Production keeps its explicit allowlist (`stadium.joinwebzero.com` + the two named Vercel domains + the `*.vercel.app` regex) untouched.

## Verification

- `npm test` in `server/`: **177 / 177 passed**.
- `isProd` is computed once and the localhost branch is gated on `!isProd` — production paths cannot accidentally allow localhost.

## Test scenarios

- With a local `server` running on `:2000` and a local `client` Vite dev server bumped to `:8081` (because `:8080` is already in use), opening `http://localhost:8081` and hitting an admin-create endpoint completes preflight (`OPTIONS`) with status 200 and `Access-Control-Allow-Origin: http://localhost:8081` in the response headers; the subsequent `POST /api/programs` proceeds normally.
- With `NODE_ENV=production` and `Origin: http://localhost:8081` on a request, preflight is **rejected** (no `Access-Control-Allow-Origin` header sent) — localhost remains dev-only.

Targets `develop`. Draft for review.