### PR TITLE
feat(programs): event_url + per-program sponsors with goals & follow-ups

### DIFF
--- a/client/src/components/admin/ProgramFormModal.tsx
+++ b/client/src/components/admin/ProgramFormModal.tsx
@@ -85,6 +85,7 @@ export function ProgramFormModal({
   const [description, setDescription] = useState("");
   const [location, setLocation] = useState("");
   const [maxApplicants, setMaxApplicants] = useState("");
+  const [eventUrl, setEventUrl] = useState("");
   const [applicationsOpenAt, setApplicationsOpenAt] = useState("");
   const [applicationsCloseAt, setApplicationsCloseAt] = useState("");
   const [eventStartsAt, setEventStartsAt] = useState("");
@@ -104,6 +105,7 @@ export function ProgramFormModal({
       setDescription(program.description || "");
       setLocation(program.location || "");
       setMaxApplicants(program.maxApplicants ? String(program.maxApplicants) : "");
+      setEventUrl(program.eventUrl || "");
       setApplicationsOpenAt(isoToLocal(program.applicationsOpenAt));
       setApplicationsCloseAt(isoToLocal(program.applicationsCloseAt));
       setEventStartsAt(isoToLocal(program.eventStartsAt));
@@ -117,6 +119,7 @@ export function ProgramFormModal({
       setDescription("");
       setLocation("");
       setMaxApplicants("");
+      setEventUrl("");
       setApplicationsOpenAt("");
       setApplicationsCloseAt("");
       setEventStartsAt("");
@@ -139,6 +142,9 @@ export function ProgramFormModal({
     if (maxApplicants) {
       const n = Number(maxApplicants);
       if (!Number.isInteger(n) || n < 1) e.maxApplicants = "Must be a positive integer.";
+    }
+    if (eventUrl.trim() && !/^https?:\/\//i.test(eventUrl.trim())) {
+      e.eventUrl = "Must start with http:// or https://";
     }
     if (applicationsOpenAt && applicationsCloseAt) {
       if (new Date(applicationsOpenAt).getTime() >= new Date(applicationsCloseAt).getTime()) {
@@ -195,6 +201,7 @@ export function ProgramFormModal({
         description: description.trim() || null,
         location: location.trim() || null,
         maxApplicants: maxApplicants ? Number(maxApplicants) : null,
+        eventUrl: eventUrl.trim() || null,
         applicationsOpenAt: localToIso(applicationsOpenAt),
         applicationsCloseAt: localToIso(applicationsCloseAt),
         eventStartsAt: localToIso(eventStartsAt),
@@ -385,6 +392,22 @@ export function ProgramFormModal({
             />
             {errors.maxApplicants && (
               <p className="label-hw text-destructive">·{errors.maxApplicants.toUpperCase()}</p>
+            )}
+          </div>
+
+          <div className="sm:col-span-2 space-y-1.5">
+            <Label htmlFor="pf-event-url" className="label-hw-dim">·EVENT URL (LUMA / SIGN-UP PAGE)</Label>
+            <Input
+              id="pf-event-url"
+              type="url"
+              placeholder="https://lu.ma/your-event"
+              value={eventUrl}
+              onChange={(e) => setEventUrl(e.target.value)}
+              aria-invalid={errors.eventUrl ? true : undefined}
+              className="font-mono text-sm"
+            />
+            {errors.eventUrl && (
+              <p className="label-hw text-destructive">·{errors.eventUrl.toUpperCase()}</p>
             )}
           </div>
         </div>

--- a/client/src/components/admin/ProgramSponsorsSection.tsx
+++ b/client/src/components/admin/ProgramSponsorsSection.tsx
@@ -1,0 +1,383 @@
+import { useCallback, useEffect, useState } from "react";
+import { Plus, Trash2, X, Loader2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { useToast } from "@/hooks/use-toast";
+import { api, type ApiProgramSponsor, ApiError } from "@/lib/api";
+
+const SUGGESTED_PROFILES = ["developer", "designer", "marketer", "artist", "researcher", "founder"];
+
+interface SponsorDraft {
+  name: string;
+  submissionTarget: string; // string for the <input type="number">
+  targetProfiles: string[];
+  applicationInstructions: string;
+  followUpNotes: string;
+  applyUrl: string;
+}
+
+const emptyDraft: SponsorDraft = {
+  name: "",
+  submissionTarget: "",
+  targetProfiles: [],
+  applicationInstructions: "",
+  followUpNotes: "",
+  applyUrl: "",
+};
+
+const draftFromSponsor = (s: ApiProgramSponsor): SponsorDraft => ({
+  name: s.name,
+  submissionTarget: typeof s.submissionTarget === "number" ? String(s.submissionTarget) : "",
+  targetProfiles: s.targetProfiles,
+  applicationInstructions: s.applicationInstructions || "",
+  followUpNotes: s.followUpNotes || "",
+  applyUrl: s.applyUrl || "",
+});
+
+const payloadFromDraft = (d: SponsorDraft) => ({
+  name: d.name.trim(),
+  submissionTarget: d.submissionTarget.trim() ? Number(d.submissionTarget) : null,
+  targetProfiles: d.targetProfiles,
+  applicationInstructions: d.applicationInstructions.trim() || null,
+  followUpNotes: d.followUpNotes.trim() || null,
+  applyUrl: d.applyUrl.trim() || null,
+});
+
+function ProfileChips({
+  value, onChange, disabled,
+}: { value: string[]; onChange: (next: string[]) => void; disabled?: boolean }) {
+  const toggle = (p: string) => {
+    onChange(value.includes(p) ? value.filter((x) => x !== p) : [...value, p]);
+  };
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {SUGGESTED_PROFILES.map((p) => {
+        const on = value.includes(p);
+        return (
+          <button
+            key={p}
+            type="button"
+            onClick={() => toggle(p)}
+            disabled={disabled}
+            className={
+              on
+                ? "font-mono text-[10px] tracking-[0.12em] uppercase border border-display bg-display text-shell px-2 py-[2px]"
+                : "font-mono text-[10px] tracking-[0.12em] uppercase border border-hairline text-label-mid hover:text-display hover:bg-panel-deep px-2 py-[2px]"
+            }
+          >
+            {p}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function SponsorForm({
+  draft, setDraft, busy,
+}: { draft: SponsorDraft; setDraft: (d: SponsorDraft) => void; busy: boolean }) {
+  return (
+    <div className="space-y-3">
+      <div className="grid sm:grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label className="label-hw-dim">·SPONSOR NAME *</Label>
+          <Input
+            value={draft.name}
+            onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+            placeholder="Bitrefill"
+            disabled={busy}
+            className="font-mono text-sm"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label className="label-hw-dim">·SUBMISSION TARGET (#)</Label>
+          <Input
+            type="number"
+            min={0}
+            value={draft.submissionTarget}
+            onChange={(e) => setDraft({ ...draft, submissionTarget: e.target.value })}
+            placeholder="10"
+            disabled={busy}
+            className="font-mono text-sm"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="label-hw-dim">·TARGET BUILDER PROFILES</Label>
+        <ProfileChips
+          value={draft.targetProfiles}
+          onChange={(next) => setDraft({ ...draft, targetProfiles: next })}
+          disabled={busy}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="label-hw-dim">·HOW TO APPLY (INSTRUCTIONS)</Label>
+        <Textarea
+          rows={3}
+          value={draft.applicationInstructions}
+          onChange={(e) => setDraft({ ...draft, applicationInstructions: e.target.value })}
+          placeholder="Send a 1-paragraph pitch to apply@example.com with your wallet address and a repo link."
+          disabled={busy}
+          className="font-mono text-sm"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="label-hw-dim">·APPLY URL (OPTIONAL)</Label>
+        <Input
+          type="url"
+          value={draft.applyUrl}
+          onChange={(e) => setDraft({ ...draft, applyUrl: e.target.value })}
+          placeholder="https://sponsor.com/apply"
+          disabled={busy}
+          className="font-mono text-sm"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label className="label-hw-dim">·POST-EVENT FOLLOW-UPS</Label>
+        <Textarea
+          rows={2}
+          value={draft.followUpNotes}
+          onChange={(e) => setDraft({ ...draft, followUpNotes: e.target.value })}
+          placeholder="Send 1-week recap email; confirm winning team has KYC docs ready."
+          disabled={busy}
+          className="font-mono text-sm"
+        />
+      </div>
+    </div>
+  );
+}
+
+export function ProgramSponsorsSection({
+  programSlug,
+  signAuthHeader,
+}: {
+  programSlug: string;
+  signAuthHeader: () => Promise<string>;
+}) {
+  const { toast } = useToast();
+  const [sponsors, setSponsors] = useState<ApiProgramSponsor[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [drafts, setDrafts] = useState<Record<string, SponsorDraft>>({});
+  const [creating, setCreating] = useState(false);
+  const [createDraft, setCreateDraft] = useState<SponsorDraft>(emptyDraft);
+  const [createBusy, setCreateBusy] = useState(false);
+
+  const load = useCallback(() => {
+    let active = true;
+    setLoading(true);
+    api
+      .listProgramSponsors(programSlug)
+      .then((r) => {
+        if (!active) return;
+        setSponsors(r.data);
+        const next: Record<string, SponsorDraft> = {};
+        for (const s of r.data) next[s.id] = draftFromSponsor(s);
+        setDrafts(next);
+      })
+      .catch((e: unknown) => {
+        if (!active) return;
+        toast({
+          title: "Couldn't load sponsors",
+          description: e instanceof Error ? e.message : "Unknown error",
+          variant: "destructive",
+        });
+      })
+      .finally(() => { if (active) setLoading(false); });
+    return () => { active = false; };
+  }, [programSlug, toast]);
+
+  useEffect(() => {
+    const cleanup = load();
+    return cleanup;
+  }, [load]);
+
+  const handleSave = async (id: string) => {
+    const draft = drafts[id];
+    if (!draft || !draft.name.trim()) {
+      toast({ title: "Sponsor name is required", variant: "destructive" });
+      return;
+    }
+    setBusyId(id);
+    try {
+      const authHeader = await signAuthHeader();
+      const res = await api.updateProgramSponsor(programSlug, id, payloadFromDraft(draft), authHeader);
+      setSponsors((prev) => prev.map((s) => (s.id === id ? res.data : s)));
+      toast({ title: "Sponsor updated" });
+    } catch (e) {
+      toast({
+        title: "Couldn't update sponsor",
+        description: e instanceof ApiError ? e.message : (e as Error)?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("Remove this sponsor? This cannot be undone.")) return;
+    setBusyId(id);
+    try {
+      const authHeader = await signAuthHeader();
+      await api.deleteProgramSponsor(programSlug, id, authHeader);
+      setSponsors((prev) => prev.filter((s) => s.id !== id));
+      toast({ title: "Sponsor removed" });
+    } catch (e) {
+      toast({
+        title: "Couldn't remove sponsor",
+        description: e instanceof ApiError ? e.message : (e as Error)?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const handleCreate = async () => {
+    if (!createDraft.name.trim()) {
+      toast({ title: "Sponsor name is required", variant: "destructive" });
+      return;
+    }
+    setCreateBusy(true);
+    try {
+      const authHeader = await signAuthHeader();
+      const res = await api.createProgramSponsor(programSlug, payloadFromDraft(createDraft), authHeader);
+      setSponsors((prev) => [...prev, res.data]);
+      setDrafts((prev) => ({ ...prev, [res.data.id]: draftFromSponsor(res.data) }));
+      setCreateDraft(emptyDraft);
+      setCreating(false);
+      toast({ title: "Sponsor added" });
+    } catch (e) {
+      toast({
+        title: "Couldn't add sponsor",
+        description: e instanceof ApiError ? e.message : (e as Error)?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setCreateBusy(false);
+    }
+  };
+
+  return (
+    <div className="panel p-4 mb-3">
+      <div className="flex items-center justify-between mb-3 pb-3 border-b border-hairline-subtle">
+        <span className="label-hw text-display">·SPONSORS &amp; GOALS</span>
+        {!creating && (
+          <button
+            type="button"
+            onClick={() => { setCreating(true); setCreateDraft(emptyDraft); }}
+            className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim px-3 py-1.5"
+          >
+            <Plus className="h-3 w-3" />
+            ADD SPONSOR
+          </button>
+        )}
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 label-hw-dim py-4">
+          <Loader2 className="h-3 w-3 animate-spin" /> LOADING SPONSORS…
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {creating && (
+            <div className="lcd p-4 space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="label-hw text-display">·NEW SPONSOR</span>
+                <button
+                  type="button"
+                  onClick={() => { setCreating(false); setCreateDraft(emptyDraft); }}
+                  className="text-label-mid hover:text-display"
+                  aria-label="Cancel new sponsor"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </div>
+              <SponsorForm draft={createDraft} setDraft={setCreateDraft} busy={createBusy} />
+              <div className="flex justify-end gap-2 pt-1">
+                <button
+                  type="button"
+                  onClick={() => { setCreating(false); setCreateDraft(emptyDraft); }}
+                  disabled={createBusy}
+                  className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep disabled:opacity-50 px-3 py-1.5"
+                >
+                  CANCEL
+                </button>
+                <button
+                  type="button"
+                  onClick={handleCreate}
+                  disabled={createBusy}
+                  className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-4 py-1.5"
+                >
+                  {createBusy ? (
+                    <>
+                      <Loader2 className="h-3 w-3 animate-spin" /> SAVING…
+                    </>
+                  ) : (
+                    "SAVE SPONSOR ▸"
+                  )}
+                </button>
+              </div>
+            </div>
+          )}
+
+          {sponsors.length === 0 && !creating ? (
+            <p className="text-body text-sm">
+              No sponsors yet. Add one to track goals and the post-event follow-ups for this program.
+            </p>
+          ) : (
+            sponsors.map((s) => {
+              const draft = drafts[s.id];
+              const busy = busyId === s.id;
+              if (!draft) return null;
+              return (
+                <div key={s.id} className="lcd p-4 space-y-3">
+                  <div className="flex items-center justify-between">
+                    <span className="label-hw text-display">·{s.name.toUpperCase()}</span>
+                    <button
+                      type="button"
+                      onClick={() => handleDelete(s.id)}
+                      disabled={busy}
+                      className="inline-flex items-center gap-1 font-mono text-[10px] tracking-[0.14em] border border-hairline text-label-mid hover:text-destructive hover:border-destructive hover:bg-panel-deep disabled:opacity-50 px-2.5 py-1"
+                      aria-label="Remove sponsor"
+                    >
+                      <Trash2 className="h-3 w-3" />
+                      REMOVE
+                    </button>
+                  </div>
+                  <SponsorForm
+                    draft={draft}
+                    setDraft={(d) => setDrafts((prev) => ({ ...prev, [s.id]: d }))}
+                    busy={busy}
+                  />
+                  <div className="flex justify-end pt-1">
+                    <button
+                      type="button"
+                      onClick={() => handleSave(s.id)}
+                      disabled={busy}
+                      className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-4 py-1.5"
+                    >
+                      {busy ? (
+                        <>
+                          <Loader2 className="h-3 w-3 animate-spin" /> SAVING…
+                        </>
+                      ) : (
+                        "SAVE CHANGES"
+                      )}
+                    </button>
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -197,6 +197,21 @@ export type ApiProgram = {
   eventEndsAt?: string | null;
   location?: string | null;
   maxApplicants?: number | null;
+  eventUrl?: string | null;
+  createdAt?: string;
+  updatedAt?: string;
+};
+
+/** Per-program sponsor / partner with goals + follow-up tracking. */
+export type ApiProgramSponsor = {
+  id: string;
+  programId: string;
+  name: string;
+  submissionTarget?: number | null;
+  targetProfiles: string[];
+  applicationInstructions?: string | null;
+  followUpNotes?: string | null;
+  applyUrl?: string | null;
   createdAt?: string;
   updatedAt?: string;
 };
@@ -1047,6 +1062,84 @@ export const api = {
         : { "Content-Type": "application/json" },
       body: JSON.stringify(patch),
     });
+  },
+
+  // --- Program sponsors ---
+
+  listProgramSponsors: async (
+    slug: string,
+  ): Promise<{ status: string; data: ApiProgramSponsor[] }> => {
+    if (USE_MOCK_DATA) {
+      const { mockProgramSponsors } = await import("./mockPrograms");
+      return { status: "success", data: mockProgramSponsors[slug] || [] };
+    }
+    return request(`/programs/${encodeURIComponent(slug)}/sponsors`);
+  },
+
+  createProgramSponsor: async (
+    slug: string,
+    payload: Omit<ApiProgramSponsor, "id" | "programId" | "createdAt" | "updatedAt">,
+    authHeader?: string,
+  ): Promise<{ status: string; data: ApiProgramSponsor }> => {
+    if (USE_MOCK_DATA) {
+      const { mockProgramSponsors } = await import("./mockPrograms");
+      const created: ApiProgramSponsor = {
+        id: `sponsor-${Date.now()}`,
+        programId: slug,
+        ...payload,
+      };
+      mockProgramSponsors[slug] = [...(mockProgramSponsors[slug] || []), created];
+      return { status: "success", data: created };
+    }
+    return request(`/programs/${encodeURIComponent(slug)}/sponsors`, {
+      method: "POST",
+      headers: authHeader
+        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
+        : { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  },
+
+  updateProgramSponsor: async (
+    slug: string,
+    sponsorId: string,
+    patch: Partial<Omit<ApiProgramSponsor, "id" | "programId" | "createdAt" | "updatedAt">>,
+    authHeader?: string,
+  ): Promise<{ status: string; data: ApiProgramSponsor }> => {
+    if (USE_MOCK_DATA) {
+      const { mockProgramSponsors } = await import("./mockPrograms");
+      const list = mockProgramSponsors[slug] || [];
+      const idx = list.findIndex((s) => s.id === sponsorId);
+      if (idx === -1) throw new ApiError("Sponsor not found", 404);
+      const merged = { ...list[idx], ...patch };
+      list[idx] = merged;
+      return { status: "success", data: merged };
+    }
+    return request(`/programs/${encodeURIComponent(slug)}/sponsors/${encodeURIComponent(sponsorId)}`, {
+      method: "PATCH",
+      headers: authHeader
+        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
+        : { "Content-Type": "application/json" },
+      body: JSON.stringify(patch),
+    });
+  },
+
+  deleteProgramSponsor: async (
+    slug: string,
+    sponsorId: string,
+    authHeader?: string,
+  ): Promise<{ status: string }> => {
+    if (USE_MOCK_DATA) {
+      const { mockProgramSponsors } = await import("./mockPrograms");
+      const list = mockProgramSponsors[slug] || [];
+      mockProgramSponsors[slug] = list.filter((s) => s.id !== sponsorId);
+      return { status: "success" };
+    }
+    await request(`/programs/${encodeURIComponent(slug)}/sponsors/${encodeURIComponent(sponsorId)}`, {
+      method: "DELETE",
+      headers: authHeader ? { "x-siws-auth": authHeader } : undefined,
+    });
+    return { status: "success" };
   },
 
   /**

--- a/client/src/lib/mockPrograms.ts
+++ b/client/src/lib/mockPrograms.ts
@@ -9,7 +9,7 @@
  *     so previews mirror the canonical-events backfill migration.
  */
 
-import type { ApiProgram } from "./api";
+import type { ApiProgram, ApiProgramSponsor } from "./api";
 
 export const mockPrograms: ApiProgram[] = [
   {
@@ -135,3 +135,26 @@ export const mockPrograms: ApiProgram[] = [
     updatedAt: "2026-04-22T00:00:00Z",
   },
 ];
+
+/**
+ * Per-program sponsor fixtures, keyed by program slug. Mock writes mutate
+ * this in place so the preview mirrors the real /api/programs/:slug/sponsors
+ * shape closely enough for UI work.
+ */
+export const mockProgramSponsors: Record<string, ApiProgramSponsor[]> = {
+  "bitrefill-2026": [
+    {
+      id: "sponsor-bitrefill-2026-bitrefill",
+      programId: "bitrefill-2026",
+      name: "Bitrefill",
+      submissionTarget: 10,
+      targetProfiles: ["developer", "designer"],
+      applicationInstructions:
+        "Send a 1-paragraph pitch to apply@bitrefill.com with your wallet address and a link to your repo.",
+      followUpNotes: "Send 1-week recap email; confirm winning team has KYC docs ready.",
+      applyUrl: "https://bitrefill.com/apply",
+      createdAt: "2026-05-20T00:00:00Z",
+      updatedAt: "2026-05-20T00:00:00Z",
+    },
+  ],
+};

--- a/client/src/lib/siwsUtils.ts
+++ b/client/src/lib/siwsUtils.ts
@@ -3,7 +3,7 @@
  */
 
 export interface SiwsContext {
-  action: 'update-team' | 'submit-deliverable' | 'update-project' | 'register-address' | 'admin-action' | 'create-project' | 'delete-project' | 'review-project' | 'approve-project' | 'reject-project' | 'post-update' | 'update-funding-signal' | 'apply-to-program' | 'create-program' | 'update-program' | 'review-application' | 'update-notifications';
+  action: 'update-team' | 'submit-deliverable' | 'update-project' | 'register-address' | 'admin-action' | 'create-project' | 'delete-project' | 'review-project' | 'approve-project' | 'reject-project' | 'post-update' | 'update-funding-signal' | 'apply-to-program' | 'create-program' | 'update-program' | 'review-application' | 'update-program-sponsors' | 'update-notifications';
   projectId?: string;
   projectTitle?: string;
   programTitle?: string;
@@ -66,6 +66,8 @@ export function generateSiwsStatement(context: SiwsContext): string {
       return `Update program on ${baseDomain}`;
     case 'review-application':
       return `Review application on ${baseDomain}`;
+    case 'update-program-sponsors':
+      return `Update program sponsors on ${baseDomain}`;
 
     // Phase 2 revamp (#71): notification preferences
     case 'update-notifications':

--- a/client/src/pages/AdminProgramPage.tsx
+++ b/client/src/pages/AdminProgramPage.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/lib/api";
 import { ApplicationCard } from "@/components/admin/ApplicationCard";
 import { ProgramAdminsSection } from "@/components/admin/ProgramAdminsSection";
+import { ProgramSponsorsSection } from "@/components/admin/ProgramSponsorsSection";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 
@@ -220,6 +221,11 @@ const AdminProgramPage = () => {
                   programSlug={program.slug}
                   signAuthHeader={() => auth.signAction("admin-action")}
                   isGlobalAdmin={isGlobalAdmin}
+                />
+
+                <ProgramSponsorsSection
+                  programSlug={program.slug}
+                  signAuthHeader={() => auth.signAction("update-program-sponsors")}
                 />
 
                 <div className="panel px-3 py-2.5 mb-3 flex flex-wrap items-center gap-2">

--- a/client/src/pages/ProgramDetailPage.tsx
+++ b/client/src/pages/ProgramDetailPage.tsx
@@ -5,6 +5,7 @@ import { RotateCw } from "lucide-react";
 import {
   api,
   type ApiProgram,
+  type ApiProgramSponsor,
   type ApiProject,
   type ApiProgramApplication,
   ApiError,
@@ -40,6 +41,7 @@ const ProgramDetailPage = () => {
 
   const [myProjects, setMyProjects] = useState<ApiProject[]>([]);
   const [myApplications, setMyApplications] = useState<ApiProgramApplication[]>([]);
+  const [sponsors, setSponsors] = useState<ApiProgramSponsor[]>([]);
   const [modalOpen, setModalOpen] = useState(false);
 
   useEffect(() => {
@@ -69,6 +71,17 @@ const ProgramDetailPage = () => {
       .catch(() => { if (active) setMyProjects([]); });
     return () => { active = false; };
   }, [connectedAddress]);
+
+  // Load sponsors once we know the program exists.
+  useEffect(() => {
+    if (!slug || !program) { setSponsors([]); return; }
+    let active = true;
+    api
+      .listProgramSponsors(slug)
+      .then((r) => { if (active) setSponsors(r.data); })
+      .catch(() => { if (active) setSponsors([]); });
+    return () => { active = false; };
+  }, [slug, program]);
 
   const refetchApplications = useCallback(() => {
     if (!program || myProjects.length === 0) {
@@ -235,7 +248,7 @@ const ProgramDetailPage = () => {
               </div>
             )}
 
-            {(applicationsRange || eventRange) && (
+            {(applicationsRange || eventRange || program.eventUrl) && (
               <div className="panel p-4 mb-4">
                 <div className="label-hw mb-3">·KEY DATES</div>
                 <div className="space-y-2">
@@ -251,6 +264,62 @@ const ProgramDetailPage = () => {
                       <span className="font-mono text-[12px] text-display">{eventRange}</span>
                     </div>
                   )}
+                  {program.eventUrl && (
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="label-hw-dim">SIGN UP</span>
+                      <a
+                        href={program.eventUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-mono text-[12px] text-display hover:underline break-all max-w-[60%] text-right"
+                      >
+                        {program.eventUrl}
+                      </a>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {sponsors.length > 0 && (
+              <div className="panel p-4 mb-4">
+                <div className="label-hw mb-3">·SPONSORS &amp; HOW TO APPLY</div>
+                <div className="space-y-3">
+                  {sponsors.map((s) => (
+                    <div key={s.id} className="lcd p-3 space-y-2">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-display text-base tracking-tight text-display uppercase">{s.name}</span>
+                        {typeof s.submissionTarget === "number" && s.submissionTarget > 0 && (
+                          <span className="border border-hairline text-display bg-panel-deep px-2 py-[1px] font-mono text-[10px] tracking-[0.12em] uppercase">
+                            TARGET {s.submissionTarget}
+                          </span>
+                        )}
+                        {s.targetProfiles.map((p) => (
+                          <span
+                            key={p}
+                            className="border border-hairline text-label-mid px-2 py-[1px] font-mono text-[10px] tracking-[0.12em] uppercase"
+                          >
+                            {p}
+                          </span>
+                        ))}
+                      </div>
+                      {s.applicationInstructions && (
+                        <p className="text-body text-sm leading-relaxed whitespace-pre-line">
+                          {s.applicationInstructions}
+                        </p>
+                      )}
+                      {s.applyUrl && (
+                        <a
+                          href={s.applyUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 font-mono text-xs text-display hover:underline break-all"
+                        >
+                          {s.applyUrl} ▸
+                        </a>
+                      )}
+                    </div>
+                  ))}
                 </div>
               </div>
             )}

--- a/server/api/auth/statements.js
+++ b/server/api/auth/statements.js
@@ -34,6 +34,7 @@ export const VALID_STATEMENTS = [
   'Create program on Stadium',
   'Update program on Stadium',
   'Review application on Stadium',
+  'Update program sponsors on Stadium',
   // Phase 2 revamp: wallet contacts (#67)
   'Update notification preferences for wallet on Stadium',
 ];

--- a/server/api/controllers/__tests__/program-sponsor.test.js
+++ b/server/api/controllers/__tests__/program-sponsor.test.js
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../services/program.service.js', () => ({
+  default: {
+    findBySlug: vi.fn(),
+  },
+}));
+vi.mock('../../services/program-sponsor.service.js', () => ({
+  default: {
+    listByProgramId: vi.fn(),
+    findById: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+vi.mock('../../services/program-application.service.js', () => ({
+  default: {
+    listByProgram: vi.fn(),
+    listByProject: vi.fn(),
+    findOne: vi.fn(),
+    create: vi.fn(),
+  },
+}));
+vi.mock('../../services/project.service.js', () => ({
+  default: { getProjectById: vi.fn() },
+}));
+vi.mock('../../services/notification.service.js', () => ({
+  default: { notifyOnApplicationStatusChange: vi.fn() },
+}));
+vi.mock('../../repositories/program-admin.repository.js', () => ({
+  default: {
+    listByProgram: vi.fn(),
+    add: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+const programService = (await import('../../services/program.service.js')).default;
+const sponsorService = (await import('../../services/program-sponsor.service.js')).default;
+const programController = (await import('../program.controller.js')).default;
+
+const mockRes = () => {
+  const res = {};
+  res.status = vi.fn(() => res);
+  res.json = vi.fn(() => res);
+  res.end = vi.fn(() => res);
+  return res;
+};
+
+const PROGRAM = { id: 'dogfooding-2026-berlin', slug: 'dogfooding-2026-berlin', name: 'Dogfooding 2026' };
+
+describe('ProgramController.listSponsors', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 404 when the program is unknown', async () => {
+    programService.findBySlug.mockResolvedValue(null);
+    const req = { params: { slug: 'nope' } };
+    const res = mockRes();
+    await programController.listSponsors(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns the program sponsors', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    sponsorService.listByProgramId.mockResolvedValue([
+      { id: 'a', name: 'Bitrefill', targetProfiles: ['developer'] },
+    ]);
+    const req = { params: { slug: PROGRAM.slug } };
+    const res = mockRes();
+    await programController.listSponsors(req, res);
+    expect(sponsorService.listByProgramId).toHaveBeenCalledWith(PROGRAM.id);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'success', data: expect.any(Array) }),
+    );
+  });
+});
+
+describe('ProgramController.createSponsor', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 422 when name is missing', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    const req = { params: { slug: PROGRAM.slug }, body: { name: '' } };
+    const res = mockRes();
+    await programController.createSponsor(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('returns 422 when submissionTarget is negative', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    const req = {
+      params: { slug: PROGRAM.slug },
+      body: { name: 'Bitrefill', submissionTarget: -1 },
+    };
+    const res = mockRes();
+    await programController.createSponsor(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('returns 422 when applyUrl is malformed', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    const req = {
+      params: { slug: PROGRAM.slug },
+      body: { name: 'Bitrefill', applyUrl: 'ftp://nope' },
+    };
+    const res = mockRes();
+    await programController.createSponsor(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('creates the sponsor with programId stamped from the URL', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    sponsorService.create.mockImplementation((p) => Promise.resolve({ id: 'new', ...p }));
+    const body = {
+      name: 'Bitrefill',
+      submissionTarget: 10,
+      targetProfiles: ['developer', 'designer'],
+      applicationInstructions: 'Email apply@bitrefill.com',
+      applyUrl: 'https://bitrefill.com/apply',
+    };
+    const req = { params: { slug: PROGRAM.slug }, body };
+    const res = mockRes();
+    await programController.createSponsor(req, res);
+    expect(sponsorService.create).toHaveBeenCalledWith(
+      expect.objectContaining({ ...body, programId: PROGRAM.id }),
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+});
+
+describe('ProgramController.updateSponsor', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 404 when the sponsor does not belong to the program', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    sponsorService.findById.mockResolvedValue({ id: 'x', programId: 'other-program' });
+    const req = {
+      params: { slug: PROGRAM.slug, sponsorId: 'x' },
+      body: { name: 'patched' },
+    };
+    const res = mockRes();
+    await programController.updateSponsor(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(sponsorService.update).not.toHaveBeenCalled();
+  });
+
+  it('returns 422 when a partial patch fails validation', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    sponsorService.findById.mockResolvedValue({ id: 'x', programId: PROGRAM.id });
+    const req = {
+      params: { slug: PROGRAM.slug, sponsorId: 'x' },
+      body: { applyUrl: 'not-a-url' },
+    };
+    const res = mockRes();
+    await programController.updateSponsor(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('applies a valid partial patch', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    sponsorService.findById.mockResolvedValue({ id: 'x', programId: PROGRAM.id });
+    sponsorService.update.mockResolvedValue({ id: 'x', name: 'Bitrefill', followUpNotes: 'Send recap' });
+    const req = {
+      params: { slug: PROGRAM.slug, sponsorId: 'x' },
+      body: { followUpNotes: 'Send recap' },
+    };
+    const res = mockRes();
+    await programController.updateSponsor(req, res);
+    expect(sponsorService.update).toHaveBeenCalledWith('x', { followUpNotes: 'Send recap' });
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});
+
+describe('ProgramController.deleteSponsor', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 404 when sponsor belongs to a different program', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    sponsorService.findById.mockResolvedValue({ id: 'x', programId: 'other-program' });
+    const req = { params: { slug: PROGRAM.slug, sponsorId: 'x' } };
+    const res = mockRes();
+    await programController.deleteSponsor(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(sponsorService.delete).not.toHaveBeenCalled();
+  });
+
+  it('deletes and returns 204', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    sponsorService.findById.mockResolvedValue({ id: 'x', programId: PROGRAM.id });
+    sponsorService.delete.mockResolvedValue();
+    const req = { params: { slug: PROGRAM.slug, sponsorId: 'x' } };
+    const res = mockRes();
+    await programController.deleteSponsor(req, res);
+    expect(sponsorService.delete).toHaveBeenCalledWith('x');
+    expect(res.status).toHaveBeenCalledWith(204);
+  });
+});

--- a/server/api/controllers/program.controller.js
+++ b/server/api/controllers/program.controller.js
@@ -1,10 +1,11 @@
 import programService from '../services/program.service.js';
 import programApplicationService from '../services/program-application.service.js';
+import programSponsorService from '../services/program-sponsor.service.js';
 import projectService from '../services/project.service.js';
 import notificationService from '../services/notification.service.js';
 import programAdminRepository from '../repositories/program-admin.repository.js';
 import { validateApplicationFields } from '../utils/application-fields.validator.js';
-import { validateProgram } from '../utils/validation.js';
+import { validateProgram, validateSponsor } from '../utils/validation.js';
 import { randomUUID } from 'node:crypto';
 import logger from '../utils/logger.js';
 
@@ -370,6 +371,84 @@ class ProgramController {
     } catch (error) {
       console.error('❌ Error removing program admin:', error);
       res.status(500).json({ status: 'error', message: 'Failed to remove program admin' });
+    }
+  }
+
+  // --- Sponsors (per-program) ---
+
+  async listSponsors(req, res) {
+    try {
+      const { slug } = req.params;
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const sponsors = await programSponsorService.listByProgramId(program.id);
+      res.status(200).json({ status: 'success', data: sponsors });
+    } catch (error) {
+      console.error('❌ Error listing program sponsors:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to list program sponsors' });
+    }
+  }
+
+  async createSponsor(req, res) {
+    try {
+      const { slug } = req.params;
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const { valid, error } = validateSponsor(req.body);
+      if (!valid) {
+        return res.status(422).json({ status: 'error', message: error });
+      }
+      const created = await programSponsorService.create({ ...req.body, programId: program.id });
+      res.status(201).json({ status: 'success', data: created });
+    } catch (error) {
+      console.error('❌ Error creating program sponsor:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to create program sponsor' });
+    }
+  }
+
+  async updateSponsor(req, res) {
+    try {
+      const { slug, sponsorId } = req.params;
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const existing = await programSponsorService.findById(sponsorId);
+      if (!existing || existing.programId !== program.id) {
+        return res.status(404).json({ status: 'error', message: 'Sponsor not found' });
+      }
+      const { valid, error } = validateSponsor(req.body, { partial: true });
+      if (!valid) {
+        return res.status(422).json({ status: 'error', message: error });
+      }
+      const updated = await programSponsorService.update(sponsorId, req.body);
+      res.status(200).json({ status: 'success', data: updated });
+    } catch (error) {
+      console.error('❌ Error updating program sponsor:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to update program sponsor' });
+    }
+  }
+
+  async deleteSponsor(req, res) {
+    try {
+      const { slug, sponsorId } = req.params;
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const existing = await programSponsorService.findById(sponsorId);
+      if (!existing || existing.programId !== program.id) {
+        return res.status(404).json({ status: 'error', message: 'Sponsor not found' });
+      }
+      await programSponsorService.delete(sponsorId);
+      res.status(204).end();
+    } catch (error) {
+      console.error('❌ Error deleting program sponsor:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to delete program sponsor' });
     }
   }
 }

--- a/server/api/repositories/program-sponsor.repository.js
+++ b/server/api/repositories/program-sponsor.repository.js
@@ -1,0 +1,86 @@
+import { supabase } from '../../db.js';
+
+// Transform Supabase row (snake_case) to API format (camelCase).
+const transformSponsor = (row) => {
+  if (!row) return null;
+  return {
+    id: row.id,
+    programId: row.program_id,
+    name: row.name,
+    submissionTarget: row.submission_target,
+    targetProfiles: Array.isArray(row.target_profiles) ? row.target_profiles : [],
+    applicationInstructions: row.application_instructions,
+    followUpNotes: row.follow_up_notes,
+    applyUrl: row.apply_url,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+};
+
+const toSnakeCase = (data) => {
+  const row = {};
+  if ('programId' in data) row.program_id = data.programId;
+  if ('name' in data) row.name = data.name;
+  if ('submissionTarget' in data) row.submission_target = data.submissionTarget ?? null;
+  if ('targetProfiles' in data) row.target_profiles = Array.isArray(data.targetProfiles) ? data.targetProfiles : [];
+  if ('applicationInstructions' in data) row.application_instructions = data.applicationInstructions ?? null;
+  if ('followUpNotes' in data) row.follow_up_notes = data.followUpNotes ?? null;
+  if ('applyUrl' in data) row.apply_url = data.applyUrl ?? null;
+  return row;
+};
+
+class ProgramSponsorRepository {
+  async listByProgramId(programId) {
+    const { data, error } = await supabase
+      .from('program_sponsors')
+      .select('*')
+      .eq('program_id', programId)
+      .order('created_at', { ascending: true });
+    if (error) throw error;
+    return (data || []).map(transformSponsor);
+  }
+
+  async findById(id) {
+    const { data, error } = await supabase
+      .from('program_sponsors')
+      .select('*')
+      .eq('id', id)
+      .maybeSingle();
+    if (error) throw error;
+    return transformSponsor(data);
+  }
+
+  async create(payload) {
+    const row = toSnakeCase(payload);
+    const { data, error } = await supabase
+      .from('program_sponsors')
+      .insert(row)
+      .select('*')
+      .single();
+    if (error) throw error;
+    return transformSponsor(data);
+  }
+
+  async update(id, patch) {
+    const row = toSnakeCase(patch);
+    row.updated_at = new Date().toISOString();
+    const { data, error } = await supabase
+      .from('program_sponsors')
+      .update(row)
+      .eq('id', id)
+      .select('*')
+      .single();
+    if (error) throw error;
+    return transformSponsor(data);
+  }
+
+  async delete(id) {
+    const { error } = await supabase
+      .from('program_sponsors')
+      .delete()
+      .eq('id', id);
+    if (error) throw error;
+  }
+}
+
+export default new ProgramSponsorRepository();

--- a/server/api/repositories/program.repository.js
+++ b/server/api/repositories/program.repository.js
@@ -17,6 +17,7 @@ const transformProgram = (row) => {
     eventEndsAt: row.event_ends_at,
     location: row.location,
     maxApplicants: row.max_applicants,
+    eventUrl: row.event_url ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -37,6 +38,7 @@ const toSnakeCase = (data) => {
   if ('eventEndsAt' in data) row.event_ends_at = data.eventEndsAt ?? null;
   if ('location' in data) row.location = data.location ?? null;
   if ('maxApplicants' in data) row.max_applicants = data.maxApplicants ?? null;
+  if ('eventUrl' in data) row.event_url = data.eventUrl ?? null;
   return row;
 };
 

--- a/server/api/routes/program.routes.js
+++ b/server/api/routes/program.routes.js
@@ -38,4 +38,19 @@ router.get('/:slug/admins', requireProgramAdmin('slug'), programController.listA
 router.post('/:slug/admins', requireAdmin, programController.addAdmin);
 router.delete('/:slug/admins/:wallet', requireAdmin, programController.removeAdmin);
 
+// --- Sponsors (per-program) ---
+// Read = public; mutate = program admin or global.
+router.get('/:slug/sponsors', programController.listSponsors);
+router.post('/:slug/sponsors', requireProgramAdmin('slug'), programController.createSponsor);
+router.patch(
+  '/:slug/sponsors/:sponsorId',
+  requireProgramAdmin('slug'),
+  programController.updateSponsor,
+);
+router.delete(
+  '/:slug/sponsors/:sponsorId',
+  requireProgramAdmin('slug'),
+  programController.deleteSponsor,
+);
+
 export default router;

--- a/server/api/services/program-sponsor.service.js
+++ b/server/api/services/program-sponsor.service.js
@@ -1,0 +1,25 @@
+import sponsorRepository from '../repositories/program-sponsor.repository.js';
+
+class ProgramSponsorService {
+  async listByProgramId(programId) {
+    return await sponsorRepository.listByProgramId(programId);
+  }
+
+  async findById(id) {
+    return await sponsorRepository.findById(id);
+  }
+
+  async create(payload) {
+    return await sponsorRepository.create(payload);
+  }
+
+  async update(id, patch) {
+    return await sponsorRepository.update(id, patch);
+  }
+
+  async delete(id) {
+    return await sponsorRepository.delete(id);
+  }
+}
+
+export default new ProgramSponsorService();

--- a/server/api/utils/validation.js
+++ b/server/api/utils/validation.js
@@ -450,6 +450,14 @@ export const validateProgram = (data, { partial = false } = {}) => {
       return { valid: false, error: 'maxApplicants must be a positive integer' };
     }
   }
+  if (has('eventUrl') && data.eventUrl !== null && data.eventUrl !== '') {
+    if (typeof data.eventUrl !== 'string' || data.eventUrl.length > 500) {
+      return { valid: false, error: 'eventUrl must be a string (max 500 characters)' };
+    }
+    if (!/^https?:\/\//i.test(data.eventUrl)) {
+      return { valid: false, error: 'eventUrl must start with http:// or https://' };
+    }
+  }
 
   const isoOrNull = (val) => {
     if (val === null || val === undefined || val === '') return true;
@@ -477,3 +485,64 @@ export const validateProgram = (data, { partial = false } = {}) => {
   return { valid: true };
 };
 
+// --- Sponsors (per-program) ---
+
+// Open-ended profile vocabulary — the team can write anything but these are the
+// expected canonical values. Validator only enforces shape, not the dictionary.
+export const SUGGESTED_SPONSOR_PROFILES = [
+  'developer',
+  'designer',
+  'marketer',
+  'artist',
+  'researcher',
+  'founder',
+  'other',
+];
+
+export const validateSponsor = (data, { partial = false } = {}) => {
+  if (!data || typeof data !== 'object') {
+    return { valid: false, error: 'Sponsor payload must be an object' };
+  }
+  const has = (k) => Object.prototype.hasOwnProperty.call(data, k);
+
+  if (!partial || has('name')) {
+    if (typeof data.name !== 'string' || !validateLength(data.name, 1, 200)) {
+      return { valid: false, error: 'name is required (1–200 characters)' };
+    }
+  }
+  if (has('submissionTarget') && data.submissionTarget !== null && data.submissionTarget !== '') {
+    const n = Number(data.submissionTarget);
+    if (!Number.isInteger(n) || n < 0 || n > 100000) {
+      return { valid: false, error: 'submissionTarget must be a non-negative integer (max 100000)' };
+    }
+  }
+  if (has('targetProfiles') && data.targetProfiles !== null) {
+    if (!Array.isArray(data.targetProfiles)) {
+      return { valid: false, error: 'targetProfiles must be an array of strings' };
+    }
+    if (data.targetProfiles.length > 20) {
+      return { valid: false, error: 'targetProfiles allows at most 20 entries' };
+    }
+    for (const p of data.targetProfiles) {
+      if (typeof p !== 'string' || !validateLength(p, 1, 60)) {
+        return { valid: false, error: 'targetProfiles entries must be strings 1–60 chars' };
+      }
+    }
+  }
+  for (const key of ['applicationInstructions', 'followUpNotes']) {
+    if (has(key) && data[key] !== null && data[key] !== '') {
+      if (typeof data[key] !== 'string' || data[key].length > 4000) {
+        return { valid: false, error: `${key} must be a string (max 4000 characters)` };
+      }
+    }
+  }
+  if (has('applyUrl') && data.applyUrl !== null && data.applyUrl !== '') {
+    if (typeof data.applyUrl !== 'string' || data.applyUrl.length > 500) {
+      return { valid: false, error: 'applyUrl must be a string (max 500 characters)' };
+    }
+    if (!/^https?:\/\//i.test(data.applyUrl)) {
+      return { valid: false, error: 'applyUrl must start with http:// or https://' };
+    }
+  }
+  return { valid: true };
+};

--- a/supabase/migrations/20260520500000_program_event_meta_and_sponsors.sql
+++ b/supabase/migrations/20260520500000_program_event_meta_and_sponsors.sql
@@ -1,0 +1,26 @@
+-- Program event metadata + sponsors.
+-- Adds an `event_url` field to `programs` (Luma / registration link) and a new
+-- `program_sponsors` table to track each program's sponsor goals: submission
+-- target, target builder profiles, application instructions, and post-event
+-- follow-up notes. A program has zero or many sponsors.
+--
+-- Additive and idempotent — safe to re-run.
+
+ALTER TABLE programs
+  ADD COLUMN IF NOT EXISTS event_url TEXT;
+
+CREATE TABLE IF NOT EXISTS program_sponsors (
+  id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  program_id               TEXT NOT NULL REFERENCES programs(id) ON DELETE CASCADE,
+  name                     TEXT NOT NULL,
+  submission_target        INTEGER,
+  target_profiles          TEXT[] NOT NULL DEFAULT '{}',
+  application_instructions TEXT,
+  follow_up_notes          TEXT,
+  apply_url                TEXT,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_program_sponsors_program_id
+  ON program_sponsors(program_id);


### PR DESCRIPTION
C of the three-part admin UX request. Adds an event_url field to programs (Luma / sign-up page) and a per-program sponsor sub-resource so each event can carry its own apply-here block and internal post-event follow-up notes without overloading the description.

Lays the groundwork for the Dogfooding 2026 + Bitrefill 2026 setups: `Bitrefill 2026` is already seeded in develop (see `programs-as-canonical-events` migration) — this PR lets you write a real "How to apply for Bitrefill" block on its detail page and track the post-event follow-ups internally.

## Schema (`20260520500000_program_event_meta_and_sponsors.sql`)

- `programs.event_url TEXT` — Luma / sign-up page link
- `program_sponsors` (id, program_id FK, name, submission_target, target_profiles TEXT[], application_instructions, follow_up_notes, apply_url, created_at, updated_at) + idx on program_id

## Server

- `program.repository`: round-trip `event_url` through transform/toSnakeCase
- `program-sponsor.{repository,service}`: list/find/create/update/delete
- `program.controller`: listSponsors / createSponsor / updateSponsor / deleteSponsor. The update / delete handlers cross-check `programId` so a sponsor from program A can't be mutated via program B's slug.
- `program.routes`: GET `/programs/:slug/sponsors` public; POST/PATCH/DELETE behind `requireProgramAdmin('slug')` — same gate used by admins/applications, so per-event admins can manage their own sponsors without needing global admin.
- `validation`: `eventUrl` (program) + full `validateSponsor` (name 1–200, submissionTarget non-negative int ≤ 100000, targetProfiles array of strings ≤ 60 chars, instructions/notes ≤ 4000, applyUrl http/https).
- `statements`: `Update program sponsors on Stadium` added so SIWS messages for sponsor mutations pass `validateStatement`.

## Tests

`server/api/controllers/__tests__/program-sponsor.test.js` — 11 new cases:
- listSponsors 404 when program unknown / happy path
- createSponsor 422 on missing name / negative target / malformed applyUrl
- createSponsor stamps programId from the URL on the service call
- updateSponsor 404 when sponsor belongs to a different program / 422 on bad partial / 200 on valid patch
- deleteSponsor 404 when cross-program / 204 happy path

Full server suite: **188 / 188 passing** (was 177; +11 new).

## Client

- `ApiProgram` gains `eventUrl`; new `ApiProgramSponsor` type
- `api.ts`: `listProgramSponsors` / `createProgramSponsor` / `updateProgramSponsor` / `deleteProgramSponsor` with full mock-mode parity via `mockProgramSponsors` keyed by slug (Bitrefill 2026 sponsor seeded for previews)
- `siwsUtils`: `update-program-sponsors` action → matching server statement
- `ProgramFormModal`: new `EVENT URL` field (validates http/https), wired into the create/update payload
- `ProgramDetailPage`: `SIGN UP` row in Key Dates when `eventUrl` is set; new `SPONSORS & HOW TO APPLY` panel rendering each sponsor's name + submission-target chip + profile chips + instructions + apply link
- `ProgramSponsorsSection`: admin editor with inline add/edit/remove, profile chip multi-select, separate field for post-event follow-ups (admin-only — not rendered on the public page); each mutation signs with the new statement. Confirms before delete.
- `AdminProgramPage`: mounts the new section right after `ProgramAdminsSection`

## Verification

- `cd server && npm test` → 188 / 188
- `cd client && npm run build` → clean (tsc + vite)
- `cd client && npm run lint` → 0 warnings / 0 errors (`--max-warnings 0`)

## Test scenarios

- On `/admin/programs/bitrefill-2026` as a global admin, the SPONSORS & GOALS panel is visible. Click ADD SPONSOR, fill name + submission target + profile chips + apply URL + instructions + follow-up notes, click SAVE SPONSOR ▸. After one wallet signature, the sponsor appears in the list and survives a page reload.
- On the same page, edit an existing sponsor's `apply_url` and `follow_up_notes`, click SAVE CHANGES → one signature, list updates in place.
- On the same page, click REMOVE on a sponsor → browser confirm → one signature → row disappears.
- On `/programs/bitrefill-2026` (public), the SPONSORS & HOW TO APPLY panel renders sponsor name, target chip, profile chips, the application instructions, and the apply link as a real `<a target="_blank">`. The `follow_up_notes` field is NOT rendered (admin-only).
- In ProgramFormModal, fill the EVENT URL field with a malformed value (e.g. `ftp://x`) → validation error 'MUST START WITH HTTP:// OR HTTPS://' surfaces inline; valid `https://lu.ma/...` saves.
- Mock-mode preview (`VITE_USE_MOCK_DATA=true`): `/programs/bitrefill-2026` shows the seeded Bitrefill sponsor without any server calls.

## Migration & deploy

Apply `20260520500000_program_event_meta_and_sponsors.sql` on a Supabase branch first to confirm the additive DDL is clean, then on prod. Both columns are nullable / default-empty so the migration is safe on existing rows.

Targets `develop`. Draft for review.

## Out of scope (separate PRs)

- B: Luma CSV upload for program applications
- A: admin session token (eliminate per-action signing)