### PR TITLE
feat(programs): Luma CSV signup import with dry-run preview

### DIFF
--- a/client/src/components/admin/ProgramSignupsSection.tsx
+++ b/client/src/components/admin/ProgramSignupsSection.tsx
@@ -1,0 +1,309 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Upload, Loader2, Trash2, FileText, X } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import {
+  api,
+  type ApiProgramSignup,
+  type ProgramSignupImportSummary,
+  ApiError,
+} from "@/lib/api";
+
+const formatDate = (iso?: string | null) => {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+};
+
+const truncateAddress = (addr?: string | null) => {
+  if (!addr) return "—";
+  if (addr.length <= 14) return addr;
+  return `${addr.slice(0, 6)}…${addr.slice(-4)}`;
+};
+
+interface Props {
+  programSlug: string;
+  signAuthHeader: () => Promise<string>;
+}
+
+export function ProgramSignupsSection({ programSlug, signAuthHeader }: Props) {
+  const { toast } = useToast();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [signups, setSignups] = useState<ApiProgramSignup[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const [csvText, setCsvText] = useState<string | null>(null);
+  const [csvFileName, setCsvFileName] = useState<string | null>(null);
+  const [planning, setPlanning] = useState(false);
+  const [committing, setCommitting] = useState(false);
+  const [preview, setPreview] = useState<ProgramSignupImportSummary | null>(null);
+
+  const load = useCallback(() => {
+    let active = true;
+    setLoading(true);
+    (async () => {
+      try {
+        const authHeader = await signAuthHeader();
+        const r = await api.listProgramSignups(programSlug, authHeader);
+        if (active) setSignups(r.data);
+      } catch (e) {
+        if (active) {
+          toast({
+            title: "Couldn't load signups",
+            description: e instanceof Error ? e.message : "Unknown error",
+            variant: "destructive",
+          });
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => { active = false; };
+  }, [programSlug, signAuthHeader, toast]);
+
+  useEffect(() => {
+    const cleanup = load();
+    return cleanup;
+  }, [load]);
+
+  const onFile = (file: File | null) => {
+    setPreview(null);
+    if (!file) {
+      setCsvText(null);
+      setCsvFileName(null);
+      return;
+    }
+    setCsvFileName(file.name);
+    const reader = new FileReader();
+    reader.onload = () => setCsvText(typeof reader.result === "string" ? reader.result : "");
+    reader.onerror = () => {
+      toast({ title: "Couldn't read file", variant: "destructive" });
+      setCsvText(null);
+    };
+    reader.readAsText(file);
+  };
+
+  const clearFile = () => {
+    setCsvText(null);
+    setCsvFileName(null);
+    setPreview(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const handlePreview = async () => {
+    if (!csvText) return;
+    setPlanning(true);
+    try {
+      const authHeader = await signAuthHeader();
+      const r = await api.importProgramSignups(programSlug, csvText, { dryRun: true }, authHeader);
+      setPreview(r.data);
+    } catch (e) {
+      toast({
+        title: "Couldn't preview import",
+        description: e instanceof ApiError ? e.message : (e as Error)?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setPlanning(false);
+    }
+  };
+
+  const handleCommit = async () => {
+    if (!csvText) return;
+    setCommitting(true);
+    try {
+      const authHeader = await signAuthHeader();
+      const r = await api.importProgramSignups(programSlug, csvText, { dryRun: false }, authHeader);
+      toast({ title: `Imported ${r.data.inserted.length} new signups` });
+      setSignups((prev) => [...r.data.inserted, ...prev]);
+      clearFile();
+    } catch (e) {
+      toast({
+        title: "Couldn't import signups",
+        description: e instanceof ApiError ? e.message : (e as Error)?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setCommitting(false);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("Remove this signup? This cannot be undone.")) return;
+    setBusyId(id);
+    try {
+      const authHeader = await signAuthHeader();
+      await api.deleteProgramSignup(programSlug, id, authHeader);
+      setSignups((prev) => prev.filter((s) => s.id !== id));
+      toast({ title: "Signup removed" });
+    } catch (e) {
+      toast({
+        title: "Couldn't remove signup",
+        description: e instanceof ApiError ? e.message : (e as Error)?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const signupCount = useMemo(() => signups.length, [signups]);
+
+  return (
+    <div className="panel p-4 mb-3">
+      <div className="flex items-center justify-between mb-3 pb-3 border-b border-hairline-subtle">
+        <div className="flex items-center gap-3">
+          <span className="label-hw text-display">·SIGNUPS</span>
+          <span className="lcd px-2 py-[1px] font-mono text-[10px] text-display tabular-nums">
+            {signupCount}
+          </span>
+        </div>
+        <span className="label-hw-dim">LUMA CSV IMPORT</span>
+      </div>
+
+      {/* CSV picker + preview / commit */}
+      <div className="lcd p-3 space-y-3 mb-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".csv,text/csv"
+            onChange={(e) => onFile(e.target.files?.[0] || null)}
+            disabled={planning || committing}
+            className="hidden"
+            id="signups-csv-input"
+          />
+          <label
+            htmlFor="signups-csv-input"
+            className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep px-3 py-1.5 cursor-pointer"
+          >
+            <FileText className="h-3 w-3" />
+            CHOOSE CSV
+          </label>
+          {csvFileName && (
+            <span className="label-hw-dim inline-flex items-center gap-1 max-w-[40ch] truncate">
+              ·{csvFileName.toUpperCase()}
+              <button
+                type="button"
+                onClick={clearFile}
+                aria-label="Clear file"
+                className="text-label-mid hover:text-display ml-1"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          )}
+          <div className="flex-1" />
+          <button
+            type="button"
+            onClick={handlePreview}
+            disabled={!csvText || planning || committing}
+            className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep disabled:opacity-50 px-3 py-1.5"
+          >
+            {planning ? (<><Loader2 className="h-3 w-3 animate-spin" /> PREVIEWING…</>) : "PREVIEW"}
+          </button>
+          <button
+            type="button"
+            onClick={handleCommit}
+            disabled={!csvText || !preview || preview.newCount === 0 || committing}
+            className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:bg-panel-deep disabled:text-label-dim disabled:border-hairline disabled:cursor-not-allowed px-4 py-1.5"
+          >
+            {committing ? (
+              <>
+                <Loader2 className="h-3 w-3 animate-spin" /> IMPORTING…
+              </>
+            ) : (
+              <>
+                <Upload className="h-3 w-3" />
+                IMPORT {preview && preview.newCount > 0 ? `(${preview.newCount})` : ""} ▸
+              </>
+            )}
+          </button>
+        </div>
+        {!csvText && (
+          <p className="label-hw-dim">
+            EXPORT YOUR LUMA EVENT REGISTRATIONS AS CSV (NAME, EMAIL, WALLET, REGISTERED-AT COLUMNS RECOGNIZED).
+          </p>
+        )}
+        {preview && (
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2 pt-1">
+            <div>
+              <div className="label-hw-dim">PARSED</div>
+              <div className="font-mono text-[14px] text-display tabular-nums">{preview.totalParsed}</div>
+            </div>
+            <div>
+              <div className="label-hw-dim">NEW</div>
+              <div className="font-mono text-[14px] text-led tabular-nums">{preview.newCount}</div>
+            </div>
+            <div>
+              <div className="label-hw-dim">DUPLICATES</div>
+              <div className="font-mono text-[14px] text-label-mid tabular-nums">{preview.duplicates}</div>
+            </div>
+            <div>
+              <div className="label-hw-dim">SKIPPED (NO EMAIL)</div>
+              <div className="font-mono text-[14px] text-label-mid tabular-nums">{preview.skippedNoEmail}</div>
+            </div>
+          </div>
+        )}
+        {preview && preview.newPreview.length > 0 && (
+          <div className="pt-2">
+            <div className="label-hw-dim mb-1">·SAMPLE (FIRST 5 NEW)</div>
+            <ul className="font-mono text-[11px] space-y-0.5">
+              {preview.newPreview.map((r, i) => (
+                <li key={i} className="text-body">
+                  {r.email}{r.name ? ` — ${r.name}` : ""}{r.wallet ? ` · ${truncateAddress(r.wallet)}` : ""}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+
+      {/* Existing list */}
+      {loading ? (
+        <div className="flex items-center gap-2 label-hw-dim py-4">
+          <Loader2 className="h-3 w-3 animate-spin" /> LOADING SIGNUPS…
+        </div>
+      ) : signups.length === 0 ? (
+        <p className="text-body text-sm">No signups yet. Import a Luma CSV above to populate.</p>
+      ) : (
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between label-hw-dim">
+            <span>·EMAIL · NAME · WALLET</span>
+            <span>REGISTERED</span>
+          </div>
+          {signups.map((s) => (
+            <div
+              key={s.id}
+              className="lcd px-3 py-2 flex items-center justify-between gap-3"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="font-mono text-[12px] text-display truncate">{s.email}</div>
+                <div className="label-hw-dim truncate">
+                  {(s.name || "—").toUpperCase()}
+                  {s.wallet ? ` · ${truncateAddress(s.wallet)}` : ""}
+                </div>
+              </div>
+              <div className="flex items-center gap-2 flex-shrink-0">
+                <span className="font-mono text-[10px] text-label-mid tabular-nums">
+                  {formatDate(s.registeredAt).toUpperCase()}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => handleDelete(s.id)}
+                  disabled={busyId === s.id}
+                  aria-label="Remove signup"
+                  className="inline-flex items-center justify-center border border-hairline text-label-mid hover:text-destructive hover:border-destructive hover:bg-panel-deep disabled:opacity-50 w-7 h-7"
+                >
+                  {busyId === s.id ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -216,6 +216,31 @@ export type ApiProgramSponsor = {
   updatedAt?: string;
 };
 
+/** Shape of a row in `program_signups` (Luma CSV imports). */
+export type ApiProgramSignup = {
+  id: string;
+  programId: string;
+  email: string;
+  name?: string | null;
+  wallet?: string | null;
+  registeredAt?: string | null;
+  source: string;
+  rawRow?: Record<string, unknown> | null;
+  createdAt?: string;
+};
+
+/** Summary returned by POST /programs/:slug/signups/import. */
+export type ProgramSignupImportSummary = {
+  dryRun: boolean;
+  totalParsed: number;
+  skippedNoEmail: number;
+  duplicates: number;
+  newCount: number;
+  newPreview: Array<{ email: string; name?: string | null; wallet?: string | null }>;
+  duplicatePreview: Array<{ email: string; name?: string | null }>;
+  inserted: ApiProgramSignup[];
+};
+
 /** Shape of a row in `project_updates` (Phase 1 revamp, #39). */
 export type ApiProjectUpdate = {
   id: string;
@@ -1136,6 +1161,68 @@ export const api = {
       return { status: "success" };
     }
     await request(`/programs/${encodeURIComponent(slug)}/sponsors/${encodeURIComponent(sponsorId)}`, {
+      method: "DELETE",
+      headers: authHeader ? { "x-siws-auth": authHeader } : undefined,
+    });
+    return { status: "success" };
+  },
+
+  // --- Program signups (Luma CSV) ---
+
+  listProgramSignups: async (
+    slug: string,
+    authHeader?: string,
+  ): Promise<{ status: string; data: ApiProgramSignup[]; meta: { count: number } }> => {
+    if (USE_MOCK_DATA) {
+      const { mockProgramSignups } = await import("./mockPrograms");
+      const list = mockProgramSignups[slug] || [];
+      return { status: "success", data: list, meta: { count: list.length } };
+    }
+    return request(`/programs/${encodeURIComponent(slug)}/signups`, {
+      headers: authHeader ? { "x-siws-auth": authHeader } : undefined,
+    });
+  },
+
+  importProgramSignups: async (
+    slug: string,
+    csv: string,
+    options: { dryRun: boolean },
+    authHeader?: string,
+  ): Promise<{ status: string; data: ProgramSignupImportSummary }> => {
+    if (USE_MOCK_DATA) {
+      const { mockProgramSignups, importMockSignups } = await import("./mockPrograms");
+      const summary = importMockSignups(slug, csv, options.dryRun);
+      return {
+        status: "success",
+        data: {
+          dryRun: options.dryRun,
+          ...summary,
+          inserted: options.dryRun ? [] : mockProgramSignups[slug] || [],
+        },
+      };
+    }
+    const qs = options.dryRun ? "?dry_run=true" : "";
+    return request(`/programs/${encodeURIComponent(slug)}/signups/import${qs}`, {
+      method: "POST",
+      headers: authHeader
+        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
+        : { "Content-Type": "application/json" },
+      body: JSON.stringify({ csv }),
+    });
+  },
+
+  deleteProgramSignup: async (
+    slug: string,
+    signupId: string,
+    authHeader?: string,
+  ): Promise<{ status: string }> => {
+    if (USE_MOCK_DATA) {
+      const { mockProgramSignups } = await import("./mockPrograms");
+      const list = mockProgramSignups[slug] || [];
+      mockProgramSignups[slug] = list.filter((s) => s.id !== signupId);
+      return { status: "success" };
+    }
+    await request(`/programs/${encodeURIComponent(slug)}/signups/${encodeURIComponent(signupId)}`, {
       method: "DELETE",
       headers: authHeader ? { "x-siws-auth": authHeader } : undefined,
     });

--- a/client/src/lib/mockPrograms.ts
+++ b/client/src/lib/mockPrograms.ts
@@ -9,7 +9,7 @@
  *     so previews mirror the canonical-events backfill migration.
  */
 
-import type { ApiProgram, ApiProgramSponsor } from "./api";
+import type { ApiProgram, ApiProgramSignup, ApiProgramSponsor } from "./api";
 
 export const mockPrograms: ApiProgram[] = [
   {
@@ -158,3 +158,115 @@ export const mockProgramSponsors: Record<string, ApiProgramSponsor[]> = {
     },
   ],
 };
+
+/** Per-program signup fixtures (mock mode). */
+export const mockProgramSignups: Record<string, ApiProgramSignup[]> = {};
+
+/**
+ * Tiny CSV parser used only in mock mode so previews can demo the import
+ * flow without a backend. Mirrors the canonical-field synonyms the server
+ * parser supports.
+ */
+const HEADER_SYNONYMS = {
+  email: ["email", "emailaddress", "mail"],
+  name: ["name", "fullname", "attendeename"],
+  wallet: ["wallet", "walletaddress", "address", "cryptowallet", "web3wallet"],
+};
+
+const norm = (s: string) => s.trim().toLowerCase().replace(/[\s_-]+/g, "");
+
+function parseCsvLine(line: string): string[] {
+  const out: string[] = [];
+  let cur = "";
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i += 1) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"' && line[i + 1] === '"') { cur += '"'; i += 1; }
+      else if (ch === '"') inQuotes = false;
+      else cur += ch;
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ",") {
+      out.push(cur);
+      cur = "";
+    } else {
+      cur += ch;
+    }
+  }
+  out.push(cur);
+  return out;
+}
+
+export function importMockSignups(
+  slug: string,
+  csv: string,
+  dryRun: boolean,
+): {
+  totalParsed: number;
+  skippedNoEmail: number;
+  duplicates: number;
+  newCount: number;
+  newPreview: Array<{ email: string; name?: string | null; wallet?: string | null }>;
+  duplicatePreview: Array<{ email: string; name?: string | null }>;
+} {
+  const lines = csv.split(/\r?\n/).filter((l) => l.trim().length > 0);
+  if (lines.length === 0) {
+    return {
+      totalParsed: 0, skippedNoEmail: 0, duplicates: 0, newCount: 0,
+      newPreview: [], duplicatePreview: [],
+    };
+  }
+  const header = parseCsvLine(lines[0]).map((h) => h.trim());
+  const idx = (synonyms: string[]) =>
+    header.findIndex((h) => synonyms.includes(norm(h)));
+  const emailIdx = idx(HEADER_SYNONYMS.email);
+  const nameIdx = idx(HEADER_SYNONYMS.name);
+  const walletIdx = idx(HEADER_SYNONYMS.wallet);
+
+  const existing = mockProgramSignups[slug] || [];
+  const existingEmails = new Set(existing.map((s) => s.email));
+
+  let totalParsed = 0;
+  let skipped = 0;
+  const newRows: Array<{ email: string; name?: string | null; wallet?: string | null }> = [];
+  const duplicates: Array<{ email: string; name?: string | null }> = [];
+
+  for (let i = 1; i < lines.length; i += 1) {
+    totalParsed += 1;
+    const cols = parseCsvLine(lines[i]);
+    const emailRaw = emailIdx >= 0 ? (cols[emailIdx] || "").trim().toLowerCase() : "";
+    if (!emailRaw || !emailRaw.includes("@")) { skipped += 1; continue; }
+    const name = nameIdx >= 0 ? (cols[nameIdx] || "").trim() || null : null;
+    const wallet = walletIdx >= 0 ? (cols[walletIdx] || "").trim() || null : null;
+    if (existingEmails.has(emailRaw)) {
+      duplicates.push({ email: emailRaw, name });
+    } else {
+      newRows.push({ email: emailRaw, name, wallet });
+      existingEmails.add(emailRaw);
+    }
+  }
+
+  if (!dryRun && newRows.length > 0) {
+    const inserted: ApiProgramSignup[] = newRows.map((r, i) => ({
+      id: `mock-signup-${Date.now()}-${i}`,
+      programId: slug,
+      email: r.email,
+      name: r.name,
+      wallet: r.wallet,
+      registeredAt: new Date().toISOString(),
+      source: "luma",
+      createdAt: new Date().toISOString(),
+    }));
+    mockProgramSignups[slug] = [...existing, ...inserted];
+  }
+
+  return {
+    totalParsed,
+    skippedNoEmail: skipped,
+    duplicates: duplicates.length,
+    newCount: newRows.length,
+    newPreview: newRows.slice(0, 5),
+    duplicatePreview: duplicates.slice(0, 5),
+  };
+}

--- a/client/src/lib/siwsUtils.ts
+++ b/client/src/lib/siwsUtils.ts
@@ -3,7 +3,7 @@
  */
 
 export interface SiwsContext {
-  action: 'update-team' | 'submit-deliverable' | 'update-project' | 'register-address' | 'admin-action' | 'create-project' | 'delete-project' | 'review-project' | 'approve-project' | 'reject-project' | 'post-update' | 'update-funding-signal' | 'apply-to-program' | 'create-program' | 'update-program' | 'review-application' | 'update-program-sponsors' | 'update-notifications';
+  action: 'update-team' | 'submit-deliverable' | 'update-project' | 'register-address' | 'admin-action' | 'create-project' | 'delete-project' | 'review-project' | 'approve-project' | 'reject-project' | 'post-update' | 'update-funding-signal' | 'apply-to-program' | 'create-program' | 'update-program' | 'review-application' | 'update-program-sponsors' | 'import-program-signups' | 'update-notifications';
   projectId?: string;
   projectTitle?: string;
   programTitle?: string;
@@ -68,6 +68,8 @@ export function generateSiwsStatement(context: SiwsContext): string {
       return `Review application on ${baseDomain}`;
     case 'update-program-sponsors':
       return `Update program sponsors on ${baseDomain}`;
+    case 'import-program-signups':
+      return `Import program signups on ${baseDomain}`;
 
     // Phase 2 revamp (#71): notification preferences
     case 'update-notifications':

--- a/client/src/pages/AdminProgramPage.tsx
+++ b/client/src/pages/AdminProgramPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { Navigation } from "@/components/Navigation";
 import { HardwareToggle } from "@/components/hardware-toggle";
@@ -46,6 +46,23 @@ const AdminProgramPage = () => {
   const [isProgramAdmin, setIsProgramAdmin] = useState(false);
   const isAdminWallet = isGlobalAdmin || isProgramAdmin;
 
+  // Stabilize per-action signers so child sections that include
+  // `signAuthHeader` in their effect deps don't loop forever — every render
+  // of this page would otherwise produce a fresh `() => auth.signAction(...)`
+  // arrow and re-trigger the wallet popup. `signAction` itself is memoized
+  // in useWalletAuth against `account`, so these stay stable until the user
+  // disconnects or switches account.
+  const { signAction } = auth;
+  const signAdminAction = useCallback(() => signAction("admin-action"), [signAction]);
+  const signUpdateSponsors = useCallback(
+    () => signAction("update-program-sponsors"),
+    [signAction],
+  );
+  const signImportSignups = useCallback(
+    () => signAction("import-program-signups"),
+    [signAction],
+  );
+
   const [program, setProgram] = useState<ApiProgram | null>(null);
   const [applications, setApplications] = useState<ApiProgramApplication[]>([]);
   const [loading, setLoading] = useState(true);
@@ -75,7 +92,7 @@ const AdminProgramPage = () => {
   const loadApplications = async () => {
     if (!slug || !connectedAddress || !isAdminWallet) return;
     try {
-      const authHeader = await auth.signAction("admin-action");
+      const authHeader = await signAdminAction();
       const res = await api.listProgramApplications(slug, authHeader);
       setApplications(res.data);
     } catch (e) {
@@ -220,18 +237,18 @@ const AdminProgramPage = () => {
               <>
                 <ProgramAdminsSection
                   programSlug={program.slug}
-                  signAuthHeader={() => auth.signAction("admin-action")}
+                  signAuthHeader={signAdminAction}
                   isGlobalAdmin={isGlobalAdmin}
                 />
 
                 <ProgramSponsorsSection
                   programSlug={program.slug}
-                  signAuthHeader={() => auth.signAction("update-program-sponsors")}
+                  signAuthHeader={signUpdateSponsors}
                 />
 
                 <ProgramSignupsSection
                   programSlug={program.slug}
-                  signAuthHeader={() => auth.signAction("import-program-signups")}
+                  signAuthHeader={signImportSignups}
                 />
 
                 <div className="panel px-3 py-2.5 mb-3 flex flex-wrap items-center gap-2">

--- a/client/src/pages/AdminProgramPage.tsx
+++ b/client/src/pages/AdminProgramPage.tsx
@@ -13,6 +13,7 @@ import {
 import { ApplicationCard } from "@/components/admin/ApplicationCard";
 import { ProgramAdminsSection } from "@/components/admin/ProgramAdminsSection";
 import { ProgramSponsorsSection } from "@/components/admin/ProgramSponsorsSection";
+import { ProgramSignupsSection } from "@/components/admin/ProgramSignupsSection";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 
@@ -226,6 +227,11 @@ const AdminProgramPage = () => {
                 <ProgramSponsorsSection
                   programSlug={program.slug}
                   signAuthHeader={() => auth.signAction("update-program-sponsors")}
+                />
+
+                <ProgramSignupsSection
+                  programSlug={program.slug}
+                  signAuthHeader={() => auth.signAction("import-program-signups")}
                 />
 
                 <div className="panel px-3 py-2.5 mb-3 flex flex-wrap items-center gap-2">

--- a/server/api/auth/statements.js
+++ b/server/api/auth/statements.js
@@ -35,6 +35,7 @@ export const VALID_STATEMENTS = [
   'Update program on Stadium',
   'Review application on Stadium',
   'Update program sponsors on Stadium',
+  'Import program signups on Stadium',
   // Phase 2 revamp: wallet contacts (#67)
   'Update notification preferences for wallet on Stadium',
 ];

--- a/server/api/controllers/__tests__/program-signup.test.js
+++ b/server/api/controllers/__tests__/program-signup.test.js
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../services/program.service.js', () => ({
+  default: { findBySlug: vi.fn() },
+}));
+vi.mock('../../services/program-signup.service.js', () => ({
+  default: {
+    listByProgramId: vi.fn(),
+    countByProgramId: vi.fn(),
+    planImport: vi.fn(),
+    commitImport: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+vi.mock('../../repositories/program-signup.repository.js', () => ({
+  default: { findById: vi.fn() },
+}));
+vi.mock('../../services/program-application.service.js', () => ({
+  default: { listByProgram: vi.fn(), listByProject: vi.fn(), findOne: vi.fn(), create: vi.fn() },
+}));
+vi.mock('../../services/project.service.js', () => ({
+  default: { getProjectById: vi.fn() },
+}));
+vi.mock('../../services/notification.service.js', () => ({
+  default: { notifyOnApplicationStatusChange: vi.fn() },
+}));
+vi.mock('../../repositories/program-admin.repository.js', () => ({
+  default: { listByProgram: vi.fn(), add: vi.fn(), remove: vi.fn() },
+}));
+
+const programService = (await import('../../services/program.service.js')).default;
+const signupService = (await import('../../services/program-signup.service.js')).default;
+const signupRepository = (await import('../../repositories/program-signup.repository.js')).default;
+const programController = (await import('../program.controller.js')).default;
+
+const mockRes = () => {
+  const res = {};
+  res.status = vi.fn(() => res);
+  res.json = vi.fn(() => res);
+  res.end = vi.fn(() => res);
+  return res;
+};
+
+const PROGRAM = { id: 'bitrefill-2026', slug: 'bitrefill-2026', name: 'Bitrefill 2026' };
+
+describe('ProgramController.listSignups', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 404 when the program is unknown', async () => {
+    programService.findBySlug.mockResolvedValue(null);
+    const req = { params: { slug: 'nope' } };
+    const res = mockRes();
+    await programController.listSignups(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns signups with a count meta', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    signupService.listByProgramId.mockResolvedValue([
+      { id: 'a', email: 'alice@example.com' },
+      { id: 'b', email: 'bob@example.com' },
+    ]);
+    const req = { params: { slug: PROGRAM.slug } };
+    const res = mockRes();
+    await programController.listSignups(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'success',
+        data: expect.any(Array),
+        meta: expect.objectContaining({ count: 2 }),
+      }),
+    );
+  });
+});
+
+describe('ProgramController.importSignups', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 422 when the body has neither csv text nor a csv field', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    const req = { params: { slug: PROGRAM.slug }, body: {}, query: {} };
+    const res = mockRes();
+    await programController.importSignups(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('returns 422 when the csv body is whitespace only', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    const req = { params: { slug: PROGRAM.slug }, body: '   ', query: {} };
+    const res = mockRes();
+    await programController.importSignups(req, res);
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('routes to planImport when dry_run=true and never inserts', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    signupService.planImport.mockResolvedValue({
+      totalParsed: 3,
+      skippedNoEmail: 0,
+      duplicates: 1,
+      newCount: 2,
+      newRows: [
+        { email: 'a@x.com', programId: PROGRAM.id },
+        { email: 'b@x.com', programId: PROGRAM.id },
+      ],
+      newPreview: [{ email: 'a@x.com' }, { email: 'b@x.com' }],
+      duplicatePreview: [{ email: 'dup@x.com' }],
+    });
+    const req = {
+      params: { slug: PROGRAM.slug },
+      body: { csv: 'Name,Email\nA,a@x.com\nB,b@x.com\nDup,dup@x.com' },
+      query: { dry_run: 'true' },
+    };
+    const res = mockRes();
+    await programController.importSignups(req, res);
+    expect(signupService.planImport).toHaveBeenCalled();
+    expect(signupService.commitImport).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.data.dryRun).toBe(true);
+    expect(payload.data.newCount).toBe(2);
+    expect(payload.data.duplicates).toBe(1);
+    // The wire payload should not include the full newRows array.
+    expect(payload.data.newRows).toBeUndefined();
+    expect(payload.data.inserted).toEqual([]);
+  });
+
+  it('routes to commitImport when dry_run is absent and returns inserted', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    signupService.commitImport.mockResolvedValue({
+      totalParsed: 2,
+      skippedNoEmail: 0,
+      duplicates: 0,
+      newCount: 2,
+      newRows: [],
+      newPreview: [],
+      duplicatePreview: [],
+      inserted: [
+        { id: '1', email: 'a@x.com' },
+        { id: '2', email: 'b@x.com' },
+      ],
+    });
+    const req = {
+      params: { slug: PROGRAM.slug },
+      body: 'Name,Email\nA,a@x.com\nB,b@x.com',
+      query: {},
+    };
+    const res = mockRes();
+    await programController.importSignups(req, res);
+    expect(signupService.commitImport).toHaveBeenCalled();
+    expect(signupService.planImport).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.data.dryRun).toBe(false);
+    expect(payload.data.inserted).toHaveLength(2);
+  });
+});
+
+describe('ProgramController.deleteSignup', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 404 when the signup belongs to another program', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    signupRepository.findById.mockResolvedValue({ id: 'x', programId: 'other' });
+    const req = { params: { slug: PROGRAM.slug, signupId: 'x' } };
+    const res = mockRes();
+    await programController.deleteSignup(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(signupService.delete).not.toHaveBeenCalled();
+  });
+
+  it('deletes and returns 204', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    signupRepository.findById.mockResolvedValue({ id: 'x', programId: PROGRAM.id });
+    signupService.delete.mockResolvedValue();
+    const req = { params: { slug: PROGRAM.slug, signupId: 'x' } };
+    const res = mockRes();
+    await programController.deleteSignup(req, res);
+    expect(signupService.delete).toHaveBeenCalledWith('x');
+    expect(res.status).toHaveBeenCalledWith(204);
+  });
+});

--- a/server/api/controllers/program.controller.js
+++ b/server/api/controllers/program.controller.js
@@ -1,9 +1,11 @@
 import programService from '../services/program.service.js';
 import programApplicationService from '../services/program-application.service.js';
 import programSponsorService from '../services/program-sponsor.service.js';
+import programSignupService from '../services/program-signup.service.js';
 import projectService from '../services/project.service.js';
 import notificationService from '../services/notification.service.js';
 import programAdminRepository from '../repositories/program-admin.repository.js';
+import programSignupRepository from '../repositories/program-signup.repository.js';
 import { validateApplicationFields } from '../utils/application-fields.validator.js';
 import { validateProgram, validateSponsor } from '../utils/validation.js';
 import { randomUUID } from 'node:crypto';
@@ -449,6 +451,98 @@ class ProgramController {
     } catch (error) {
       console.error('❌ Error deleting program sponsor:', error);
       res.status(500).json({ status: 'error', message: 'Failed to delete program sponsor' });
+    }
+  }
+
+  // --- Signups (Luma CSV imports) ---
+
+  async listSignups(req, res) {
+    try {
+      const { slug } = req.params;
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const signups = await programSignupService.listByProgramId(program.id);
+      res.status(200).json({
+        status: 'success',
+        data: signups,
+        meta: { count: signups.length },
+      });
+    } catch (error) {
+      console.error('❌ Error listing program signups:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to list program signups' });
+    }
+  }
+
+  async importSignups(req, res) {
+    try {
+      const { slug } = req.params;
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+
+      // Accepts the CSV as either a raw text/csv body or as { csv: "..." }
+      // inside a JSON body. The former scales further; the latter is the
+      // path the admin UI uses today because shadcn forms speak JSON.
+      let csvText = '';
+      if (typeof req.body === 'string') {
+        csvText = req.body;
+      } else if (req.body && typeof req.body.csv === 'string') {
+        csvText = req.body.csv;
+      } else {
+        return res.status(422).json({
+          status: 'error',
+          message: 'Missing CSV body. Send Content-Type text/csv or JSON {"csv":"..."}',
+        });
+      }
+      if (!csvText.trim()) {
+        return res.status(422).json({ status: 'error', message: 'CSV body is empty' });
+      }
+
+      const dryRun = req.query.dry_run === 'true' || req.query.dry_run === '1';
+
+      const summary = dryRun
+        ? await programSignupService.planImport(program.id, csvText)
+        : await programSignupService.commitImport(program.id, csvText);
+
+      // Drop the verbose `newRows` array on the wire — the preview slices and
+      // counts are enough for the admin UI to render the summary.
+      const { newRows: _omit, inserted, ...wire } = summary;
+      void _omit;
+      res.status(200).json({
+        status: 'success',
+        data: {
+          dryRun,
+          ...wire,
+          inserted: dryRun ? [] : inserted || [],
+        },
+      });
+    } catch (error) {
+      console.error('❌ Error importing program signups:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to import program signups' });
+    }
+  }
+
+  async deleteSignup(req, res) {
+    try {
+      const { slug, signupId } = req.params;
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      // Cross-check program scoping: a signup from program A must not be
+      // deletable via program B's slug. Symmetric with sponsors.
+      const existing = await programSignupRepository.findById(signupId);
+      if (!existing || existing.programId !== program.id) {
+        return res.status(404).json({ status: 'error', message: 'Signup not found' });
+      }
+      await programSignupService.delete(signupId);
+      res.status(204).end();
+    } catch (error) {
+      console.error('❌ Error deleting program signup:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to delete program signup' });
     }
   }
 }

--- a/server/api/repositories/program-signup.repository.js
+++ b/server/api/repositories/program-signup.repository.js
@@ -1,0 +1,88 @@
+import { supabase } from '../../db.js';
+
+const transformSignup = (row) => {
+  if (!row) return null;
+  return {
+    id: row.id,
+    programId: row.program_id,
+    email: row.email,
+    name: row.name,
+    wallet: row.wallet,
+    registeredAt: row.registered_at,
+    source: row.source,
+    rawRow: row.raw_row,
+    createdAt: row.created_at,
+  };
+};
+
+class ProgramSignupRepository {
+  async listByProgramId(programId) {
+    const { data, error } = await supabase
+      .from('program_signups')
+      .select('*')
+      .eq('program_id', programId)
+      .order('registered_at', { ascending: false, nullsFirst: false })
+      .order('created_at', { ascending: false });
+    if (error) throw error;
+    return (data || []).map(transformSignup);
+  }
+
+  async listEmailsByProgramId(programId) {
+    const { data, error } = await supabase
+      .from('program_signups')
+      .select('email')
+      .eq('program_id', programId);
+    if (error) throw error;
+    return new Set((data || []).map((r) => r.email));
+  }
+
+  async findById(id) {
+    const { data, error } = await supabase
+      .from('program_signups')
+      .select('*')
+      .eq('id', id)
+      .maybeSingle();
+    if (error) throw error;
+    return transformSignup(data);
+  }
+
+  /**
+   * Insert many signup rows. Each row must already have programId + email set.
+   * Returns the inserted rows. Caller is responsible for filtering out dups
+   * before calling (so the parser's `skipped` count stays meaningful).
+   */
+  async insertMany(rows) {
+    if (!rows.length) return [];
+    const payload = rows.map((r) => ({
+      program_id: r.programId,
+      email: r.email,
+      name: r.name ?? null,
+      wallet: r.wallet ?? null,
+      registered_at: r.registeredAt ?? null,
+      source: r.source || 'luma',
+      raw_row: r.rawRow ?? null,
+    }));
+    const { data, error } = await supabase
+      .from('program_signups')
+      .insert(payload)
+      .select('*');
+    if (error) throw error;
+    return (data || []).map(transformSignup);
+  }
+
+  async delete(id) {
+    const { error } = await supabase.from('program_signups').delete().eq('id', id);
+    if (error) throw error;
+  }
+
+  async countByProgramId(programId) {
+    const { count, error } = await supabase
+      .from('program_signups')
+      .select('*', { count: 'exact', head: true })
+      .eq('program_id', programId);
+    if (error) throw error;
+    return count ?? 0;
+  }
+}
+
+export default new ProgramSignupRepository();

--- a/server/api/routes/program.routes.js
+++ b/server/api/routes/program.routes.js
@@ -1,4 +1,4 @@
-import { Router } from 'express';
+import { Router, text, json } from 'express';
 import programController from '../controllers/program.controller.js';
 import requireAdmin, {
   requireTeamMemberOrAdminByBodyProject,
@@ -6,6 +6,14 @@ import requireAdmin, {
 } from '../middleware/auth.middleware.js';
 
 const router = Router();
+
+// CSV imports can run hundreds of rows; bump the body limit on the signup
+// import route only, leaving the default express.json() limit elsewhere.
+// Accept both text/csv (raw) and application/json {"csv":"..."} bodies.
+const csvBody = [
+  text({ type: 'text/csv', limit: '5mb' }),
+  json({ limit: '5mb' }),
+];
 
 // --- Public, Read-Only Routes ---
 router.get('/', programController.list);
@@ -51,6 +59,23 @@ router.delete(
   '/:slug/sponsors/:sponsorId',
   requireProgramAdmin('slug'),
   programController.deleteSponsor,
+);
+
+// --- Signups (Luma CSV imports) ---
+// All admin — same gate as applications. CSV body parsers stack with the
+// shared SIWS middleware: parser runs first to produce req.body, then
+// requireProgramAdmin reads x-siws-auth from headers.
+router.get('/:slug/signups', requireProgramAdmin('slug'), programController.listSignups);
+router.post(
+  '/:slug/signups/import',
+  ...csvBody,
+  requireProgramAdmin('slug'),
+  programController.importSignups,
+);
+router.delete(
+  '/:slug/signups/:signupId',
+  requireProgramAdmin('slug'),
+  programController.deleteSignup,
 );
 
 export default router;

--- a/server/api/services/program-signup.service.js
+++ b/server/api/services/program-signup.service.js
@@ -1,0 +1,59 @@
+import signupRepository from '../repositories/program-signup.repository.js';
+import { parseLumaCsv } from '../utils/luma-csv.parser.js';
+
+class ProgramSignupService {
+  async listByProgramId(programId) {
+    return await signupRepository.listByProgramId(programId);
+  }
+
+  async countByProgramId(programId) {
+    return await signupRepository.countByProgramId(programId);
+  }
+
+  /**
+   * Plan an import — parse the CSV, classify each row as new vs duplicate of
+   * an existing signup (by email), return a summary without writing anything.
+   */
+  async planImport(programId, csvText) {
+    const { rows, skipped, totalParsed } = await parseLumaCsv(csvText);
+    const existingEmails = await signupRepository.listEmailsByProgramId(programId);
+
+    const newRows = [];
+    const duplicateRows = [];
+    for (const r of rows) {
+      if (existingEmails.has(r.email)) {
+        duplicateRows.push(r);
+      } else {
+        newRows.push({ ...r, programId, source: 'luma' });
+      }
+    }
+    return {
+      totalParsed,
+      skippedNoEmail: skipped,
+      duplicates: duplicateRows.length,
+      newCount: newRows.length,
+      newRows,
+      duplicatePreview: duplicateRows.slice(0, 5).map(({ email, name }) => ({ email, name })),
+      newPreview: newRows.slice(0, 5).map(({ email, name, wallet }) => ({ email, name, wallet })),
+    };
+  }
+
+  /**
+   * Commit an import — parse, plan, and insert non-duplicates. Returns the
+   * same shape as planImport plus the inserted rows.
+   */
+  async commitImport(programId, csvText) {
+    const plan = await this.planImport(programId, csvText);
+    if (plan.newCount === 0) {
+      return { ...plan, inserted: [] };
+    }
+    const inserted = await signupRepository.insertMany(plan.newRows);
+    return { ...plan, inserted };
+  }
+
+  async delete(id) {
+    return await signupRepository.delete(id);
+  }
+}
+
+export default new ProgramSignupService();

--- a/server/api/utils/__tests__/luma-csv.parser.test.js
+++ b/server/api/utils/__tests__/luma-csv.parser.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { parseLumaCsv } from '../luma-csv.parser.js';
+
+describe('parseLumaCsv', () => {
+  it('returns no rows for empty input', async () => {
+    const r = await parseLumaCsv('');
+    expect(r.rows).toEqual([]);
+    expect(r.skipped).toBe(0);
+    expect(r.totalParsed).toBe(0);
+  });
+
+  it('parses the canonical Luma export header set', async () => {
+    const csv = [
+      'Name,Email,Wallet,Registered At',
+      'Alice,alice@example.com,5GrwvaEF...,2026-05-10T12:00:00Z',
+      'Bob,BOB@example.com,,2026-05-11T08:30:00Z',
+    ].join('\n');
+    const r = await parseLumaCsv(csv);
+    expect(r.totalParsed).toBe(2);
+    expect(r.skipped).toBe(0);
+    expect(r.rows).toHaveLength(2);
+    expect(r.rows[0]).toMatchObject({
+      email: 'alice@example.com',
+      name: 'Alice',
+      wallet: '5GrwvaEF...',
+      registeredAt: '2026-05-10T12:00:00.000Z',
+    });
+    // Email is normalized to lowercase for dedup.
+    expect(r.rows[1].email).toBe('bob@example.com');
+    expect(r.rows[1].wallet).toBeNull();
+  });
+
+  it('accepts header synonyms (email_address, full name, registration date, etc.)', async () => {
+    const csv = [
+      'Full Name,Email Address,Crypto Wallet,Registration Date',
+      'Cathy,cathy@example.com,0xdeadbeef,2026-05-12',
+    ].join('\n');
+    const r = await parseLumaCsv(csv);
+    expect(r.rows).toHaveLength(1);
+    expect(r.rows[0]).toMatchObject({
+      email: 'cathy@example.com',
+      name: 'Cathy',
+      wallet: '0xdeadbeef',
+    });
+    expect(r.rows[0].registeredAt).not.toBeNull();
+  });
+
+  it('skips rows missing an email and preserves all other rows', async () => {
+    const csv = [
+      'Name,Email',
+      'NoEmail,',
+      'BadEmail,not-an-address',
+      'Good,good@example.com',
+    ].join('\n');
+    const r = await parseLumaCsv(csv);
+    expect(r.totalParsed).toBe(3);
+    expect(r.skipped).toBe(2);
+    expect(r.rows).toHaveLength(1);
+    expect(r.rows[0].email).toBe('good@example.com');
+  });
+
+  it('preserves unmodelled columns in rawRow', async () => {
+    const csv = [
+      'Name,Email,Ticket Type,Custom Q',
+      'Alice,alice@example.com,VIP,Ethereum + Solana',
+    ].join('\n');
+    const r = await parseLumaCsv(csv);
+    expect(r.rows[0].rawRow).toMatchObject({
+      'Ticket Type': 'VIP',
+      'Custom Q': 'Ethereum + Solana',
+    });
+  });
+
+  it('returns null registeredAt for an unparseable date', async () => {
+    const csv = ['Name,Email,Registered At', 'Alice,alice@example.com,not-a-date'].join('\n');
+    const r = await parseLumaCsv(csv);
+    expect(r.rows[0].registeredAt).toBeNull();
+  });
+});

--- a/server/api/utils/luma-csv.parser.js
+++ b/server/api/utils/luma-csv.parser.js
@@ -1,0 +1,94 @@
+/**
+ * Luma signup CSV parser.
+ *
+ * Luma exports vary by event template, so the parser is forgiving:
+ *   - canonical fields (email, name, wallet, registered_at) are pulled from
+ *     a small synonym list rather than a fixed header set
+ *   - everything else lands in `raw_row` so no data is silently dropped
+ *   - rows missing an email are reported as `skipped`, never inserted
+ *   - email is lowercased and trimmed for dedup
+ *
+ * Sync API: takes a CSV string, returns { rows, errors }. The caller decides
+ * whether to dry-run or commit. Using `csv-parser` (already in deps) via its
+ * Readable-stream form so we don't pull in a second parser.
+ */
+
+import { Readable } from 'node:stream';
+import csv from 'csv-parser';
+
+const norm = (s) => String(s || '').trim().toLowerCase().replace(/[\s_-]+/g, '');
+
+// Synonym groups — left side is canonical, right side is normalized header.
+const EMAIL_HEADERS = ['email', 'emailaddress', 'mail'];
+const NAME_HEADERS = ['name', 'fullname', 'attendeename'];
+const WALLET_HEADERS = ['wallet', 'walletaddress', 'address', 'cryptowallet', 'web3wallet'];
+const REGISTERED_AT_HEADERS = [
+  'registeredat',
+  'registrationtime',
+  'registrationdate',
+  'createdat',
+  'rsvpedat',
+  'approvedat',
+];
+
+const findKey = (row, synonyms) => {
+  for (const k of Object.keys(row)) {
+    if (synonyms.includes(norm(k))) return k;
+  }
+  return null;
+};
+
+const parseDate = (val) => {
+  if (!val) return null;
+  const d = new Date(val);
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+};
+
+/**
+ * Parse a Luma signup CSV into normalized rows + skipped row count.
+ *
+ * @param {string} csvText
+ * @returns {Promise<{ rows: Array<{ email, name, wallet, registeredAt, rawRow }>, skipped: number, totalParsed: number }>}
+ */
+export async function parseLumaCsv(csvText) {
+  if (typeof csvText !== 'string' || !csvText.trim()) {
+    return { rows: [], skipped: 0, totalParsed: 0 };
+  }
+
+  return new Promise((resolve, reject) => {
+    const rows = [];
+    let skipped = 0;
+    let totalParsed = 0;
+    let emailKey = null;
+    let nameKey = null;
+    let walletKey = null;
+    let registeredAtKey = null;
+
+    Readable.from(csvText)
+      .pipe(csv())
+      .on('data', (row) => {
+        totalParsed += 1;
+        if (emailKey === null) {
+          emailKey = findKey(row, EMAIL_HEADERS);
+          nameKey = findKey(row, NAME_HEADERS);
+          walletKey = findKey(row, WALLET_HEADERS);
+          registeredAtKey = findKey(row, REGISTERED_AT_HEADERS);
+        }
+        const emailRaw = emailKey ? row[emailKey] : '';
+        const email = String(emailRaw || '').trim().toLowerCase();
+        if (!email || !email.includes('@')) {
+          skipped += 1;
+          return;
+        }
+        rows.push({
+          email,
+          name: nameKey ? String(row[nameKey] || '').trim() || null : null,
+          wallet: walletKey ? String(row[walletKey] || '').trim() || null : null,
+          registeredAt: registeredAtKey ? parseDate(row[registeredAtKey]) : null,
+          rawRow: row,
+        });
+      })
+      .on('end', () => resolve({ rows, skipped, totalParsed }))
+      .on('error', reject);
+  });
+}

--- a/supabase/migrations/20260520600000_program_signups.sql
+++ b/supabase/migrations/20260520600000_program_signups.sql
@@ -1,0 +1,25 @@
+-- Program signups (Luma / external CSV imports).
+-- Captures the raw "who registered for the event" list from Luma exports so
+-- admins can track headcount and follow-ups independently of project-level
+-- program_applications. A signup is a person; an application is a project.
+--
+-- raw_row preserves any columns the Luma CSV had that we don't model
+-- explicitly (custom Q&A, ticket type, etc.) so we never lose data.
+--
+-- Additive and idempotent — safe to re-run.
+
+CREATE TABLE IF NOT EXISTS program_signups (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  program_id      TEXT NOT NULL REFERENCES programs(id) ON DELETE CASCADE,
+  email           TEXT NOT NULL,
+  name            TEXT,
+  wallet          TEXT,
+  registered_at   TIMESTAMPTZ,
+  source          TEXT NOT NULL DEFAULT 'luma',
+  raw_row         JSONB,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT program_signups_email_per_program UNIQUE (program_id, email)
+);
+
+CREATE INDEX IF NOT EXISTS idx_program_signups_program_id
+  ON program_signups(program_id);


### PR DESCRIPTION
B of the three-part admin UX request (after #102's sponsors). Lets per-event admins upload a Luma event-registrations CSV and store who signed up — distinct from project-level `program_applications`. Two cleanly separated concepts: an **application** is a project applying with team + project pages; a **signup** is a person who registered for the event via the Luma form.

## Schema (`20260520600000_program_signups.sql`)

`program_signups` (id, program_id FK on delete cascade, email NOT NULL, name, wallet, registered_at, source DEFAULT 'luma', raw_row JSONB, created_at) + `UNIQUE (program_id, email)` so re-importing the same CSV is idempotent + idx on program_id.

`raw_row` is JSONB so any unmodelled Luma columns (custom Q&A, ticket type, approval status, …) are preserved verbatim — no silent data loss.

## Server

- `luma-csv.parser`: tolerant header-synonym mapping. Canonical fields (`email`, `name`, `wallet`, `registered_at`) are pulled from a small synonym list rather than a fixed header set — `Email Address`, `Full Name`, `Crypto Wallet`, `Registration Date`, etc. all resolve. Lowercased dedup email, skipped count for rows missing a valid email. Streams via `csv-parser` (already in deps).
- `program-signup.{repository,service}`: list / count / findById / insertMany / delete. `planImport()` classifies parsed rows as new vs duplicate without writing; `commitImport()` writes only the non-duplicates.
- `program.controller`: `listSignups` / `importSignups` / `deleteSignup`. Import accepts EITHER `text/csv` raw body OR JSON `{csv:'...'}` — the admin form uses JSON, an operator with `curl` can pipe raw CSV. `?dry_run=true` plans without inserting, otherwise commits. `deleteSignup` cross-checks programId so a signup from program A can't be deleted via program B's slug.
- `program.routes`: `GET` / `POST .../import` / `DELETE` all behind `requireProgramAdmin('slug')` — per-event admins manage their own program's signups. CSV body is parsed by route-scoped `express.text({limit:'5mb'})` + `express.json({limit:'5mb'})` middleware stack so the server-wide 100kb json default is not bumped. Stacks with the existing SIWS auth header.
- `statements`: `Import program signups on Stadium` added so SIWS messages for the import pass `validateStatement`.

## Tests

Two new files, **14 new test cases**:

`luma-csv.parser.test.js` (6 cases)
- empty input → no rows / no skips / total 0
- canonical `Name,Email,Wallet,Registered At` parses cleanly; emails are lowercased
- header synonyms (`Full Name`, `Email Address`, `Crypto Wallet`, `Registration Date`) all resolve to canonical fields
- rows missing `@` in email are counted as `skipped`, not inserted
- unmodelled columns (`Ticket Type`, `Custom Q`) land in `rawRow`
- unparseable date → `registeredAt: null`, row otherwise preserved

`program-signup.test.js` (8 cases)
- listSignups 404 on unknown program; happy path returns `meta.count`
- importSignups 422 when body has neither csv text nor a csv field
- importSignups 422 when csv body is whitespace
- `?dry_run=true` routes to `planImport` and never inserts; payload omits verbose `newRows` array
- absent `dry_run` routes to `commitImport` and returns `inserted`
- deleteSignup 404 when signup belongs to a different program
- deleteSignup 204 happy path

Full server suite: **191 / 191 passing** (was 177; +14 new).

## Client

- `ApiProgramSignup` + `ProgramSignupImportSummary` types
- `api.ts`: `listProgramSignups` / `importProgramSignups({dryRun})` / `deleteProgramSignup` with full mock-mode parity. `mockPrograms` exposes `importMockSignups()` that runs a tiny CSV parser locally so previews can demo the flow without a backend.
- `siwsUtils`: `import-program-signups` action → matching server statement
- `ProgramSignupsSection`: file picker + preview-then-import flow.
  - Counters: parsed / new / duplicates / skipped (no-email)
  - Sample of first 5 new rows for sanity-check
  - Import button only enables when preview shows `newCount > 0`, so accidental dupe re-imports are a no-op
  - Per-row delete with browser confirm
  - Header chip shows the live total
- `AdminProgramPage` mounts the new section right after the admins panel.

## Verification

- `cd server && npm test` → 191 / 191
- `cd client && npm run build` → clean (tsc + vite)
- `cd client && npm run lint --max-warnings 0` → 0 warnings / 0 errors

## Test scenarios

- On `/admin/programs/bitrefill-2026` as a global admin, scroll to the new SIGNUPS panel. The counter chip reads `0`. Click CHOOSE CSV, pick a Luma export, click PREVIEW → one signature → counters populate, sample of first 5 appears, IMPORT button enables. Click IMPORT → one signature → inserted rows prepend the list, counter chip increments, file selection clears.
- Re-import the same CSV → PREVIEW shows `new: 0, duplicates: N` and IMPORT stays disabled.
- Click the trash icon on any signup → confirm dialog → one signature → row disappears, counter decrements.
- A CSV with header variants (`Email Address`, `Full Name`, `Crypto Wallet`, `Registration Date`) maps to the canonical fields. A row with no email is counted in SKIPPED, never inserted.
- A non-admin wallet hitting `POST /api/programs/bitrefill-2026/signups/import` gets `403` from `requireProgramAdmin` — the route gate is the existing one, no new auth surface.
- Mock-mode preview (`VITE_USE_MOCK_DATA=true`): the entire flow runs against an in-memory CSV parser. No network calls.

## Migration & deploy

Apply `20260520600000_program_signups.sql` on a Supabase branch first to confirm the additive DDL is clean, then on prod. The composite unique constraint `(program_id, email)` is the only thing that could fail at apply time — and only if a prior import had already populated dups, which is impossible on a brand-new table.

Targets `develop`. Draft for review.

## Out of scope (separate PRs)

- A: admin session token (eliminate per-action signing)
- Cross-referencing signups with project applications or wallet-contacts
- Bulk re-import / re-sync from a Luma API token (this PR is CSV-only)