### PR TITLE
feat(auth): admin session tokens — one sign per session, not per action

### DIFF
--- a/client/src/components/admin/ApplicationCard.tsx
+++ b/client/src/components/admin/ApplicationCard.tsx
@@ -1,10 +1,7 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { CheckCircle2, XCircle, ExternalLink, Loader2 } from "lucide-react";
-import { web3Enable, web3Accounts, web3FromSource } from "@polkadot/extension-dapp";
-import { SiwsMessage } from "@talismn/siws";
-import { generateSiwsStatement } from "@/lib/siwsUtils";
-import { api, type ApiProgramApplication } from "@/lib/api";
+import { api, type ApiProgramApplication, type AdminAuthArg } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
 
 const statusBadge = (status: ApiProgramApplication["status"]) => {
@@ -30,12 +27,16 @@ const truncateAddress = (addr?: string | null) => {
 export function ApplicationCard({
   application,
   programSlug,
-  connectedAddress,
+  signAuthHeader,
   onUpdated,
 }: {
   application: ApiProgramApplication;
   programSlug: string;
-  connectedAddress: string;
+  /**
+   * Returns admin auth headers — either a cached session bearer or a fresh
+   * one-shot SIWS payload. Same shape as `useWalletAuth.getAdminBearerHeaders`.
+   */
+  signAuthHeader: () => Promise<AdminAuthArg>;
   onUpdated: (next: ApiProgramApplication) => void;
 }) {
   const [working, setWorking] = useState<"accept" | "reject" | null>(null);
@@ -44,28 +45,7 @@ export function ApplicationCard({
   const doUpdate = async (next: ApiProgramApplication["status"]) => {
     setWorking(next === "accepted" ? "accept" : "reject");
     try {
-      await web3Enable("Stadium");
-      const accounts = await web3Accounts();
-      const account = accounts.find((a) => a.address === connectedAddress) || accounts[0];
-      if (!account) throw new Error("No wallet account found");
-
-      const siws = new SiwsMessage({
-        domain: window.location.hostname,
-        uri: window.location.origin,
-        address: account.address,
-        nonce: Math.random().toString(36).slice(2),
-        statement: generateSiwsStatement({ action: "review-application" }),
-      });
-      const injector = await web3FromSource(account.meta.source);
-      const signed = (await siws.sign(injector)) as unknown as { signature: string; message?: string };
-      const messageStr =
-        typeof signed.message === "string" && signed.message
-          ? signed.message
-          : (siws as unknown as { toString: () => string }).toString();
-      const authHeader = btoa(
-        JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address }),
-      );
-
+      const authHeader = await signAuthHeader();
       const res = await api.updateApplicationStatus(
         programSlug,
         application.id,

--- a/client/src/components/admin/ProgramAdminsSection.tsx
+++ b/client/src/components/admin/ProgramAdminsSection.tsx
@@ -19,7 +19,7 @@ export function ProgramAdminsSection({
   isGlobalAdmin,
 }: {
   programSlug: string;
-  signAuthHeader: () => Promise<string>;
+  signAuthHeader: () => Promise<import("@/lib/api").AdminAuthArg>;
   isGlobalAdmin: boolean;
 }) {
   const { toast } = useToast();

--- a/client/src/components/admin/ProgramSignupsSection.tsx
+++ b/client/src/components/admin/ProgramSignupsSection.tsx
@@ -23,7 +23,7 @@ const truncateAddress = (addr?: string | null) => {
 
 interface Props {
   programSlug: string;
-  signAuthHeader: () => Promise<string>;
+  signAuthHeader: () => Promise<import("@/lib/api").AdminAuthArg>;
 }
 
 export function ProgramSignupsSection({ programSlug, signAuthHeader }: Props) {

--- a/client/src/components/admin/ProgramSponsorsSection.tsx
+++ b/client/src/components/admin/ProgramSponsorsSection.tsx
@@ -157,7 +157,7 @@ export function ProgramSponsorsSection({
   signAuthHeader,
 }: {
   programSlug: string;
-  signAuthHeader: () => Promise<string>;
+  signAuthHeader: () => Promise<import("@/lib/api").AdminAuthArg>;
 }) {
   const { toast } = useToast();
   const [sponsors, setSponsors] = useState<ApiProgramSponsor[]>([]);

--- a/client/src/components/admin/WinnersTable.tsx
+++ b/client/src/components/admin/WinnersTable.tsx
@@ -87,7 +87,12 @@ interface WinnersTableProps {
   projects: any[];
   onRefresh: () => void;
   connectedAddress?: string;
-  signAdminAction: (action?: string) => Promise<string>;
+  /**
+   * Returns admin auth headers — cached session bearer when available, or
+   * a fresh one-shot SIWS payload. Use the same callback for every admin
+   * write below to share the cache.
+   */
+  signAdminAction: () => Promise<import("@/lib/api").AdminAuthArg>;
 }
 
 type WinnerFilter = "all" | "main-track" | "bounty";
@@ -214,7 +219,7 @@ export function WinnersTable({ projects, onRefresh, connectedAddress, signAdminA
     setSaving("status");
     
     try {
-      const authHeader = await signAdminAction('admin-action');
+      const authHeader = await signAdminAction();
       
       const updateData: Record<string, any> = {
         projectState: manageModal.projectState,
@@ -250,7 +255,7 @@ export function WinnersTable({ projects, onRefresh, connectedAddress, signAdminA
     setSaving("agreement");
     
     try {
-      const authHeader = await signAdminAction('admin-action');
+      const authHeader = await signAdminAction();
       
       // Parse line-separated strings into arrays
       const agreedFeatures = manageModal.agreedFeatures
@@ -308,7 +313,7 @@ export function WinnersTable({ projects, onRefresh, connectedAddress, signAdminA
     setSaving("deliverables");
     
     try {
-      const authHeader = await signAdminAction('admin-action');
+      const authHeader = await signAdminAction();
       
       // Validate
       if (!manageModal.repoUrl) {
@@ -361,7 +366,7 @@ export function WinnersTable({ projects, onRefresh, connectedAddress, signAdminA
     setSaving("payment");
     
     try {
-      const authHeader = await signAdminAction('admin-action');
+      const authHeader = await signAdminAction();
       
       // Validate
       if (!manageModal.paymentAmount || manageModal.paymentAmount <= 0) {
@@ -412,7 +417,7 @@ export function WinnersTable({ projects, onRefresh, connectedAddress, signAdminA
     let failCount = 0;
     
     try {
-      const authHeader = await signAdminAction('admin-action');
+      const authHeader = await signAdminAction();
       
       for (const project of unpaidProjects) {
         try {

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -50,6 +50,27 @@ const mapStatusToMessage = (status: number) => {
   }
 };
 
+/**
+ * Auth credentials accepted by admin-mutating API methods.
+ *
+ * - `string` (legacy) — treated as a one-shot SIWS payload; sent as
+ *   `x-siws-auth: <value>`. All existing callers pass this shape.
+ * - `Record<string,string>` (modern) — pre-built header map. Used by
+ *   `useWalletAuth.getAdminBearerHeaders()` which returns either
+ *   `{ Authorization: 'Bearer …' }` (session token) or `{ 'x-siws-auth': … }`
+ *   (one-shot fallback when the session exchange fails).
+ *
+ * `undefined` means no auth header is sent (caller is responsible).
+ */
+export type AdminAuthArg = string | Record<string, string> | undefined;
+
+/** Convert AdminAuthArg → header entries that can be spread into a fetch. */
+export const adminAuthHeaders = (a: AdminAuthArg): Record<string, string> => {
+  if (!a) return {};
+  if (typeof a === "string") return { "x-siws-auth": a };
+  return a;
+};
+
 const request = async (endpoint: string, options: RequestInit = {}) => {
   const url = `${API_BASE_URL}${endpoint}`;
   if (typeof window !== "undefined" && import.meta.env.DEV) {
@@ -352,7 +373,7 @@ export const api = {
     }
     return request(`/m2-program/${projectId}/team`, {
       method: "POST",
-      headers: { "x-siws-auth": authHeader },
+      headers: adminAuthHeaders(authHeader),
       body: JSON.stringify({ teamMembers }),
     });
   },
@@ -367,7 +388,7 @@ export const api = {
     }
     return request(`/m2-program/${projectId}`, {
       method: "PATCH",
-      headers: { "x-siws-auth": authHeader, "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify({ categories }),
     });
   },
@@ -377,7 +398,7 @@ export const api = {
     demoUrl: string;
     docsUrl: string;
     summary: string;
-  }, authHeader?: string) => {
+  }, authHeader?: AdminAuthArg) => {
     if (USE_MOCK_DATA) {
       // Simulate API delay
       await new Promise(resolve => setTimeout(resolve, 500));
@@ -413,7 +434,7 @@ export const api = {
     // Real API call (server route is submit-m2, not submit-review)
     return request(`/m2-program/${projectId}/submit-m2`, {
       method: 'POST',
-      headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify(submission)
     });
   },
@@ -431,7 +452,7 @@ export const api = {
     }>;
     donationAddress?: string;
     donationChain?: 'substrate' | 'ethereum' | 'solana';
-  }, authHeader?: string) => {
+  }, authHeader?: AdminAuthArg) => {
     if (USE_MOCK_DATA) {
       // Simulate API delay
       await new Promise(resolve => setTimeout(resolve, 500));
@@ -456,7 +477,7 @@ export const api = {
     // Real API call - update team members
     const teamResult = await request(`/m2-program/${projectId}/team`, {
       method: 'POST',
-      headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify({ teamMembers: data.teamMembers })
     });
 
@@ -464,7 +485,7 @@ export const api = {
     if (data.donationAddress) {
       await request(`/m2-program/${projectId}/payout-address`, {
         method: 'PATCH',
-        headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : { "Content-Type": "application/json" },
+        headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
         body: JSON.stringify({
           donationAddress: data.donationAddress,
           donationChain: data.donationChain || 'substrate',
@@ -475,7 +496,7 @@ export const api = {
     return teamResult;
   },
 
-  webzeroApprove: async (projectId: string, authHeader?: string) => {
+  webzeroApprove: async (projectId: string, authHeader?: AdminAuthArg) => {
     if (USE_MOCK_DATA) {
       await new Promise((resolve) => setTimeout(resolve, 500));
 
@@ -502,7 +523,7 @@ export const api = {
 
     return request(`/m2-program/${projectId}/approve`, {
       method: "POST",
-      headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify({
         m2Status: 'completed',
         webzeroApproved: true,
@@ -511,7 +532,7 @@ export const api = {
     });
   },
 
-  requestChanges: async (projectId: string, feedback: string, authHeader?: string) => {
+  requestChanges: async (projectId: string, feedback: string, authHeader?: AdminAuthArg) => {
     if (USE_MOCK_DATA) {
       await new Promise((resolve) => setTimeout(resolve, 500));
       const requestedDate = new Date().toISOString();
@@ -540,7 +561,7 @@ export const api = {
 
     return request(`/m2-program/${projectId}/request-changes`, {
       method: "POST",
-      headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify({
         feedback,
         requestedChangesDate: new Date().toISOString(),
@@ -554,7 +575,7 @@ export const api = {
     agreedFeatures: string[];
     documentation?: string[];
     successCriteria?: string;
-  }, authHeader?: string) => {
+  }, authHeader?: AdminAuthArg) => {
     if (USE_MOCK_DATA) {
       // Simulate API delay
       await new Promise(resolve => setTimeout(resolve, 500));
@@ -583,7 +604,7 @@ export const api = {
     // Real API call
     return request(`/m2-program/${projectId}/m2-agreement`, {
       method: 'POST',
-      headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify(agreement)
     });
   },
@@ -595,7 +616,7 @@ export const api = {
       documentation: string[];
       successCriteria: string;
     },
-    authHeader?: string
+    authHeader?: AdminAuthArg
   ) => {
     if (USE_MOCK_DATA) {
       // Simulate API delay
@@ -639,12 +660,12 @@ export const api = {
     // Real API call
     return request(`/m2-program/${projectId}/m2-agreement`, {
       method: 'PATCH',
-      headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify(data)
     });
   },
 
-  updateProjectStatus: async (projectId: string, status: 'building' | 'under_review' | 'completed', authHeader?: string) => {
+  updateProjectStatus: async (projectId: string, status: 'building' | 'under_review' | 'completed', authHeader?: AdminAuthArg) => {
     if (USE_MOCK_DATA) {
       // Simulate API delay
       await new Promise(resolve => setTimeout(resolve, 500))
@@ -669,7 +690,7 @@ export const api = {
     // Real API call
     return request(`/m2-program/${projectId}`, {
       method: "PATCH",
-      headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify({
         m2Status: status,
       }),
@@ -687,7 +708,7 @@ export const api = {
       linkedin?: string;
       customUrl?: string;
     }>,
-    authHeader?: string
+    authHeader?: AdminAuthArg
   ) => {
     if (USE_MOCK_DATA) {
       // Simulate API delay
@@ -710,7 +731,7 @@ export const api = {
     // Real API call
     return request(`/m2-program/${projectId}/team`, {
       method: 'POST',
-      headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify({ teamMembers })
     });
   },
@@ -718,7 +739,7 @@ export const api = {
   updatePayoutAddress: async (
     projectId: string,
     donationAddress: string,
-    authHeader?: string,
+    authHeader?: AdminAuthArg,
     donationChain: 'substrate' | 'ethereum' | 'solana' = 'substrate'
   ) => {
     if (USE_MOCK_DATA) {
@@ -742,7 +763,7 @@ export const api = {
     // Real API call
     return request(`/m2-program/${projectId}`, {
       method: 'PATCH',
-      headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify({ donationAddress, donationChain })
     });
   },
@@ -781,7 +802,7 @@ export const api = {
         eventStartedAt?: string;
       };
     },
-    authHeader?: string
+    authHeader?: AdminAuthArg
   ) => {
     if (USE_MOCK_DATA) {
       // Simulate API delay
@@ -804,7 +825,7 @@ export const api = {
     // Real API call
     return request(`/m2-program/${projectId}`, {
       method: 'PATCH',
-      headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify(data)
     });
   },
@@ -818,7 +839,7 @@ export const api = {
       transactionProof: string;
       bountyName?: string; // Required for BOUNTY milestone
     },
-    authHeader?: string
+    authHeader?: AdminAuthArg
   ) => {
     if (USE_MOCK_DATA) {
       if (!['M1', 'M2', 'BOUNTY'].includes(data.milestone)) {
@@ -901,7 +922,7 @@ export const api = {
     // Real API call
     return request(`/m2-program/${projectId}/confirm-payment`, {
       method: 'POST',
-      headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify(data)
     });
   },
@@ -949,7 +970,7 @@ export const api = {
   postProjectUpdate: async (
     projectId: string,
     payload: { body: string; linkUrl?: string | null },
-    authHeader?: string,
+    authHeader?: AdminAuthArg,
   ): Promise<{ status: string; data: ApiProjectUpdate }> => {
     if (USE_MOCK_DATA) {
       const { mockProjectUpdates } = await import("./mockProjectUpdates");
@@ -966,9 +987,7 @@ export const api = {
     }
     return request(`/m2-program/${encodeURIComponent(projectId)}/updates`, {
       method: "POST",
-      headers: authHeader
-        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
-        : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     });
   },
@@ -1001,7 +1020,7 @@ export const api = {
       amountRange?: string | null;
       description?: string | null;
     },
-    authHeader?: string,
+    authHeader?: AdminAuthArg,
   ): Promise<{ status: string; data: ApiFundingSignal }> => {
     if (USE_MOCK_DATA) {
       const { mockFundingSignals } = await import("./mockFundingSignals");
@@ -1019,9 +1038,7 @@ export const api = {
     }
     return request(`/m2-program/${encodeURIComponent(projectId)}/funding-signal`, {
       method: "PATCH",
-      headers: authHeader
-        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
-        : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     });
   },
@@ -1031,7 +1048,7 @@ export const api = {
    */
   createProgram: async (
     payload: Partial<ApiProgram> & { name: string; slug: string; programType: ApiProgram["programType"]; status: ApiProgram["status"] },
-    authHeader?: string,
+    authHeader?: AdminAuthArg,
   ): Promise<{ status: string; data: ApiProgram }> => {
     if (USE_MOCK_DATA) {
       const { mockPrograms } = await import("./mockPrograms");
@@ -1057,9 +1074,7 @@ export const api = {
     }
     return request(`/programs`, {
       method: "POST",
-      headers: authHeader
-        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
-        : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     });
   },
@@ -1067,7 +1082,7 @@ export const api = {
   updateProgram: async (
     slug: string,
     patch: Partial<ApiProgram>,
-    authHeader?: string,
+    authHeader?: AdminAuthArg,
   ): Promise<{ status: string; data: ApiProgram }> => {
     if (USE_MOCK_DATA) {
       const { mockPrograms } = await import("./mockPrograms");
@@ -1082,9 +1097,7 @@ export const api = {
     }
     return request(`/programs/${encodeURIComponent(slug)}`, {
       method: "PATCH",
-      headers: authHeader
-        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
-        : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify(patch),
     });
   },
@@ -1104,7 +1117,7 @@ export const api = {
   createProgramSponsor: async (
     slug: string,
     payload: Omit<ApiProgramSponsor, "id" | "programId" | "createdAt" | "updatedAt">,
-    authHeader?: string,
+    authHeader?: AdminAuthArg,
   ): Promise<{ status: string; data: ApiProgramSponsor }> => {
     if (USE_MOCK_DATA) {
       const { mockProgramSponsors } = await import("./mockPrograms");
@@ -1118,9 +1131,7 @@ export const api = {
     }
     return request(`/programs/${encodeURIComponent(slug)}/sponsors`, {
       method: "POST",
-      headers: authHeader
-        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
-        : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     });
   },
@@ -1129,7 +1140,7 @@ export const api = {
     slug: string,
     sponsorId: string,
     patch: Partial<Omit<ApiProgramSponsor, "id" | "programId" | "createdAt" | "updatedAt">>,
-    authHeader?: string,
+    authHeader?: AdminAuthArg,
   ): Promise<{ status: string; data: ApiProgramSponsor }> => {
     if (USE_MOCK_DATA) {
       const { mockProgramSponsors } = await import("./mockPrograms");
@@ -1142,9 +1153,7 @@ export const api = {
     }
     return request(`/programs/${encodeURIComponent(slug)}/sponsors/${encodeURIComponent(sponsorId)}`, {
       method: "PATCH",
-      headers: authHeader
-        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
-        : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify(patch),
     });
   },
@@ -1152,7 +1161,7 @@ export const api = {
   deleteProgramSponsor: async (
     slug: string,
     sponsorId: string,
-    authHeader?: string,
+    authHeader?: AdminAuthArg,
   ): Promise<{ status: string }> => {
     if (USE_MOCK_DATA) {
       const { mockProgramSponsors } = await import("./mockPrograms");
@@ -1162,7 +1171,7 @@ export const api = {
     }
     await request(`/programs/${encodeURIComponent(slug)}/sponsors/${encodeURIComponent(sponsorId)}`, {
       method: "DELETE",
-      headers: authHeader ? { "x-siws-auth": authHeader } : undefined,
+      headers: adminAuthHeaders(authHeader),
     });
     return { status: "success" };
   },
@@ -1171,7 +1180,7 @@ export const api = {
 
   listProgramSignups: async (
     slug: string,
-    authHeader?: string,
+    authHeader?: AdminAuthArg,
   ): Promise<{ status: string; data: ApiProgramSignup[]; meta: { count: number } }> => {
     if (USE_MOCK_DATA) {
       const { mockProgramSignups } = await import("./mockPrograms");
@@ -1179,7 +1188,7 @@ export const api = {
       return { status: "success", data: list, meta: { count: list.length } };
     }
     return request(`/programs/${encodeURIComponent(slug)}/signups`, {
-      headers: authHeader ? { "x-siws-auth": authHeader } : undefined,
+      headers: adminAuthHeaders(authHeader),
     });
   },
 
@@ -1187,7 +1196,7 @@ export const api = {
     slug: string,
     csv: string,
     options: { dryRun: boolean },
-    authHeader?: string,
+    authHeader?: AdminAuthArg,
   ): Promise<{ status: string; data: ProgramSignupImportSummary }> => {
     if (USE_MOCK_DATA) {
       const { mockProgramSignups, importMockSignups } = await import("./mockPrograms");
@@ -1204,9 +1213,7 @@ export const api = {
     const qs = options.dryRun ? "?dry_run=true" : "";
     return request(`/programs/${encodeURIComponent(slug)}/signups/import${qs}`, {
       method: "POST",
-      headers: authHeader
-        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
-        : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify({ csv }),
     });
   },
@@ -1214,7 +1221,7 @@ export const api = {
   deleteProgramSignup: async (
     slug: string,
     signupId: string,
-    authHeader?: string,
+    authHeader?: AdminAuthArg,
   ): Promise<{ status: string }> => {
     if (USE_MOCK_DATA) {
       const { mockProgramSignups } = await import("./mockPrograms");
@@ -1224,7 +1231,7 @@ export const api = {
     }
     await request(`/programs/${encodeURIComponent(slug)}/signups/${encodeURIComponent(signupId)}`, {
       method: "DELETE",
-      headers: authHeader ? { "x-siws-auth": authHeader } : undefined,
+      headers: adminAuthHeaders(authHeader),
     });
     return { status: "success" };
   },
@@ -1234,7 +1241,7 @@ export const api = {
    */
   createProject: async (
     payload: Partial<ApiProject> & { projectName: string },
-    authHeader?: string,
+    authHeader?: AdminAuthArg,
   ): Promise<{ status: string; data: ApiProject }> => {
     if (USE_MOCK_DATA) {
       const { mockWinningProjects } = await import("./mockWinners");
@@ -1266,9 +1273,7 @@ export const api = {
     }
     return request(`/m2-program`, {
       method: "POST",
-      headers: authHeader
-        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
-        : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     });
   },
@@ -1312,7 +1317,7 @@ export const api = {
   /** Admin-only: list all applications for a program. */
   listProgramApplications: async (
     slug: string,
-    authHeader?: string,
+    authHeader?: AdminAuthArg,
   ): Promise<{ status: string; data: ApiProgramApplication[] }> => {
     if (USE_MOCK_DATA) {
       const { mockProgramApplications } = await import("./mockProgramApplications");
@@ -1325,7 +1330,7 @@ export const api = {
       };
     }
     return request(`/programs/${encodeURIComponent(slug)}/applications`, {
-      headers: authHeader ? { "x-siws-auth": authHeader, "Content-Type": "application/json" } : undefined,
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
     });
   },
 
@@ -1333,7 +1338,7 @@ export const api = {
     slug: string,
     applicationId: string,
     patch: { status: ApiProgramApplication["status"]; reviewNotes?: string | null },
-    authHeader?: string,
+    authHeader?: AdminAuthArg,
   ): Promise<{ status: string; data: ApiProgramApplication }> => {
     if (USE_MOCK_DATA) {
       const { mockProgramApplications } = await import("./mockProgramApplications");
@@ -1351,9 +1356,7 @@ export const api = {
     }
     return request(`/programs/${encodeURIComponent(slug)}/applications/${encodeURIComponent(applicationId)}`, {
       method: "PATCH",
-      headers: authHeader
-        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
-        : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify(patch),
     });
   },
@@ -1379,7 +1382,7 @@ export const api = {
   updateWalletContact: async (
     address: string,
     payload: { email?: string | null; notificationsEnabled?: boolean },
-    authHeader?: string,
+    authHeader?: AdminAuthArg,
   ): Promise<{ email_set: boolean; notifications_enabled: boolean }> => {
     if (USE_MOCK_DATA) {
       const { mockWalletContacts } = await import("./mockWalletContacts");
@@ -1393,9 +1396,7 @@ export const api = {
     }
     const res = await request(`/wallet-contacts/${encodeURIComponent(address)}`, {
       method: "PUT",
-      headers: authHeader
-        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
-        : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify({ email: payload.email, notifications_enabled: payload.notificationsEnabled }),
     });
     return res.data;
@@ -1404,7 +1405,7 @@ export const api = {
   applyToProgram: async (
     slug: string,
     payload: { project_id: string; application_fields: Record<string, unknown> },
-    authHeader?: string,
+    authHeader?: AdminAuthArg,
   ): Promise<{ status: string; data: ApiProgramApplication }> => {
     if (USE_MOCK_DATA) {
       const { mockProgramApplications } = await import("./mockProgramApplications");
@@ -1435,9 +1436,7 @@ export const api = {
     }
     return request(`/programs/${encodeURIComponent(slug)}/applications`, {
       method: "POST",
-      headers: authHeader
-        ? { "x-siws-auth": authHeader, "Content-Type": "application/json" }
-        : { "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     });
   },
@@ -1455,7 +1454,7 @@ export const api = {
       return { status: "success", data: [] };
     }
     return request(`/programs/${encodeURIComponent(slug)}/admins`, {
-      headers: { "x-siws-auth": authHeader },
+      headers: adminAuthHeaders(authHeader),
     });
   },
 
@@ -1475,7 +1474,7 @@ export const api = {
     }
     return request(`/programs/${encodeURIComponent(slug)}/admins`, {
       method: "POST",
-      headers: { "x-siws-auth": authHeader, "Content-Type": "application/json" },
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     });
   },
@@ -1491,7 +1490,7 @@ export const api = {
       `/programs/${encodeURIComponent(slug)}/admins/${encodeURIComponent(wallet)}?chain=${encodeURIComponent(walletChain)}`,
       {
         method: "DELETE",
-        headers: { "x-siws-auth": authHeader },
+        headers: adminAuthHeaders(authHeader),
       },
     );
   },

--- a/client/src/lib/auth/adminSession.ts
+++ b/client/src/lib/auth/adminSession.ts
@@ -1,0 +1,86 @@
+/**
+ * Client-side store for the admin session bearer token.
+ *
+ * After one SIWS sign exchanged via POST /api/admin/session, the server
+ * returns a short-lived HMAC-signed token. We stash it in sessionStorage
+ * keyed by (chain,address) so subsequent admin requests in this tab can
+ * just attach `Authorization: Bearer <token>` without a wallet popup.
+ *
+ * Expiry is enforced client-side too: if `expiresAt` has passed, we treat
+ * the cache as empty and the caller signs again. The server treats the
+ * same token as expired independently.
+ */
+
+const STORAGE_KEY = 'stadium_admin_session_v1';
+// Refresh a little before the server-side TTL fires so the caller doesn't
+// race expiry on a 14:59 minute-old token.
+const REFRESH_MARGIN_MS = 30_000;
+
+interface StoredSession {
+  chain: string;
+  address: string;
+  token: string;
+  expiresAt: string; // ISO
+}
+
+function readAll(): StoredSession[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (s): s is StoredSession =>
+        s &&
+        typeof s.chain === "string" &&
+        typeof s.address === "string" &&
+        typeof s.token === "string" &&
+        typeof s.expiresAt === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeAll(list: StoredSession[]) {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  } catch {
+    /* sessionStorage unavailable — token simply won't persist */
+  }
+}
+
+const sameKey = (a: { chain: string; address: string }, b: { chain: string; address: string }) =>
+  a.chain === b.chain && a.address.toLowerCase() === b.address.toLowerCase();
+
+/** Returns the bearer token for the given account if it's still valid. */
+export function readAdminToken(chain: string, address: string): string | null {
+  const list = readAll();
+  const match = list.find((s) => sameKey(s, { chain, address }));
+  if (!match) return null;
+  const expMs = new Date(match.expiresAt).getTime();
+  if (!Number.isFinite(expMs)) return null;
+  if (expMs - REFRESH_MARGIN_MS <= Date.now()) return null;
+  return match.token;
+}
+
+export function writeAdminToken(args: {
+  chain: string;
+  address: string;
+  token: string;
+  expiresAt: string;
+}) {
+  const list = readAll().filter((s) => !sameKey(s, args));
+  list.push(args);
+  writeAll(list);
+}
+
+export function clearAdminToken(chain?: string, address?: string) {
+  if (!chain || !address) {
+    try { sessionStorage.removeItem(STORAGE_KEY); } catch { /* ignore */ }
+    return;
+  }
+  const list = readAll().filter((s) => !sameKey(s, { chain, address }));
+  writeAll(list);
+}

--- a/client/src/lib/auth/useWalletAuth.ts
+++ b/client/src/lib/auth/useWalletAuth.ts
@@ -10,8 +10,15 @@ import { useCallback, useEffect, useState } from 'react'
 import type { Chain, WalletAccount } from './types'
 import { getProvider } from './registry'
 import { generateSiwsStatement, type SiwsContext } from '@/lib/siwsUtils'
+import { readAdminToken, writeAdminToken, clearAdminToken } from './adminSession'
+import { API_BASE_URL } from '@/lib/api'
 
 const SESSION_KEY = 'stadium_wallet_session_v2'
+
+/** Headers an admin caller can attach. Exactly one of these is populated. */
+export type AdminAuthHeaders =
+  | { Authorization: string; 'x-siws-auth'?: never }
+  | { 'x-siws-auth': string; Authorization?: never }
 
 export interface WalletAuth {
   chain: Chain
@@ -28,6 +35,12 @@ export interface WalletAuth {
   selectAccount: (account: WalletAccount) => void
   /** Sign an action; resolves with the base64 `x-siws-auth` header value. */
   signAction: (action: SiwsContext['action'], context?: Partial<SiwsContext>) => Promise<string>
+  /**
+   * Get an admin auth bearer token, signing once + exchanging if the cache
+   * is empty or expired. Resolves with `Authorization: Bearer …` headers so
+   * the caller can spread them straight into a fetch.
+   */
+  getAdminBearerHeaders: () => Promise<AdminAuthHeaders>
   disconnect: () => void
 }
 
@@ -121,7 +134,59 @@ export function useWalletAuth(): WalletAuth {
     [account]
   )
 
+  const getAdminBearerHeaders = useCallback(async (): Promise<AdminAuthHeaders> => {
+    if (!account) throw new Error('Wallet not connected')
+
+    const cached = readAdminToken(account.chain, account.address)
+    if (cached) {
+      return { Authorization: `Bearer ${cached}` }
+    }
+
+    // No valid token — sign once with the existing admin-action statement,
+    // exchange via POST /api/admin/session for a short-lived bearer token,
+    // and cache it for the rest of this session.
+    const provider = getProvider(account.chain)
+    if (!provider) throw new Error(`Unsupported sign-in chain: ${account.chain}`)
+    const statement = generateSiwsStatement({ action: 'admin-action' })
+    const siwsHeader = await provider.signIn({ account, statement })
+
+    try {
+      const res = await fetch(`${API_BASE_URL}/admin/session`, {
+        method: 'POST',
+        headers: { 'x-siws-auth': siwsHeader, 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      })
+      if (!res.ok) {
+        // Session exchange failed — fall back to one-shot SIWS so the action
+        // still goes through. The caller passes the raw SIWS header instead.
+        return { 'x-siws-auth': siwsHeader }
+      }
+      const body = (await res.json()) as {
+        status: string
+        data: { token: string; expiresAt: string; chain: string; address: string }
+      }
+      if (!body?.data?.token) {
+        return { 'x-siws-auth': siwsHeader }
+      }
+      writeAdminToken({
+        chain: account.chain,
+        address: account.address,
+        token: body.data.token,
+        expiresAt: body.data.expiresAt,
+      })
+      return { Authorization: `Bearer ${body.data.token}` }
+    } catch {
+      // Network error — fall back to the SIWS one-shot so the caller still wins.
+      return { 'x-siws-auth': siwsHeader }
+    }
+  }, [account])
+
   const disconnect = useCallback(() => {
+    if (account) {
+      clearAdminToken(account.chain, account.address)
+    } else {
+      clearAdminToken()
+    }
     setAccount(null)
     setAccounts([])
     setError('')
@@ -130,7 +195,7 @@ export function useWalletAuth(): WalletAuth {
     } catch {
       /* ignore */
     }
-  }, [])
+  }, [account])
 
   return {
     chain,
@@ -143,6 +208,7 @@ export function useWalletAuth(): WalletAuth {
     connect,
     selectAccount,
     signAction,
+    getAdminBearerHeaders,
     disconnect,
   }
 }

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -108,10 +108,10 @@ const AdminPage = () => {
   const handleConfirmM1Payout = async (data: any) => {
     if (!selectedProject) return;
     try {
-      const authHeader = await auth.signAction("admin-action");
+      const authHeaders = await auth.getAdminBearerHeaders();
       const response = await fetch(`/api/m2-program/${selectedProject.id}/confirm-payment`, {
         method: "POST",
-        headers: { "Content-Type": "application/json", "x-siws-auth": authHeader },
+        headers: { "Content-Type": "application/json", ...authHeaders },
         credentials: "include",
         body: JSON.stringify(data),
       });
@@ -145,10 +145,10 @@ const AdminPage = () => {
   const handleConfirmPayment = async (data: any) => {
     if (!selectedProject) return;
     try {
-      const authHeader = await auth.signAction("admin-action");
+      const authHeaders = await auth.getAdminBearerHeaders();
       const response = await fetch(`/api/m2-program/${selectedProject.id}/confirm-payment`, {
         method: "POST",
-        headers: { "Content-Type": "application/json", "x-siws-auth": authHeader },
+        headers: { "Content-Type": "application/json", ...authHeaders },
         credentials: "include",
         body: JSON.stringify(data),
       });
@@ -459,7 +459,7 @@ const AdminPage = () => {
             projects={projects}
             onRefresh={loadData}
             connectedAddress={BYPASS_ADMIN_CHECK ? ADMIN_ADDRESSES[0]?.address : auth.account?.address}
-            signAdminAction={auth.signAction}
+            signAdminAction={auth.getAdminBearerHeaders}
           />
         </section>
 

--- a/client/src/pages/AdminProgramPage.tsx
+++ b/client/src/pages/AdminProgramPage.tsx
@@ -46,22 +46,13 @@ const AdminProgramPage = () => {
   const [isProgramAdmin, setIsProgramAdmin] = useState(false);
   const isAdminWallet = isGlobalAdmin || isProgramAdmin;
 
-  // Stabilize per-action signers so child sections that include
-  // `signAuthHeader` in their effect deps don't loop forever — every render
-  // of this page would otherwise produce a fresh `() => auth.signAction(...)`
-  // arrow and re-trigger the wallet popup. `signAction` itself is memoized
-  // in useWalletAuth against `account`, so these stay stable until the user
-  // disconnects or switches account.
-  const { signAction } = auth;
-  const signAdminAction = useCallback(() => signAction("admin-action"), [signAction]);
-  const signUpdateSponsors = useCallback(
-    () => signAction("update-program-sponsors"),
-    [signAction],
-  );
-  const signImportSignups = useCallback(
-    () => signAction("import-program-signups"),
-    [signAction],
-  );
+  // Admin-action auth: hand each section the same `getAdminBearerHeaders`
+  // callback. First call signs once and exchanges via /api/admin/session for
+  // a short-lived bearer; subsequent calls in this tab hit the cache and
+  // return the bearer headers with zero wallet prompts. Stable across
+  // renders because `getAdminBearerHeaders` is memoized against `account`.
+  const { getAdminBearerHeaders } = auth;
+  const getAdminAuth = useCallback(() => getAdminBearerHeaders(), [getAdminBearerHeaders]);
 
   const [program, setProgram] = useState<ApiProgram | null>(null);
   const [applications, setApplications] = useState<ApiProgramApplication[]>([]);
@@ -92,7 +83,7 @@ const AdminProgramPage = () => {
   const loadApplications = async () => {
     if (!slug || !connectedAddress || !isAdminWallet) return;
     try {
-      const authHeader = await signAdminAction();
+      const authHeader = await getAdminAuth();
       const res = await api.listProgramApplications(slug, authHeader);
       setApplications(res.data);
     } catch (e) {
@@ -132,7 +123,9 @@ const AdminProgramPage = () => {
       }
       auth.selectAccount(candidate);
       try {
-        const authHeader = await auth.signAction("admin-action");
+        // First call also primes the admin session cache: signs once,
+        // exchanges via /api/admin/session, caches the bearer for later.
+        const authHeader = await auth.getAdminBearerHeaders();
         await api.listProgramAdmins(slug, authHeader);
         setIsProgramAdmin(true);
       } catch (probeErr) {
@@ -237,18 +230,18 @@ const AdminProgramPage = () => {
               <>
                 <ProgramAdminsSection
                   programSlug={program.slug}
-                  signAuthHeader={signAdminAction}
+                  signAuthHeader={getAdminAuth}
                   isGlobalAdmin={isGlobalAdmin}
                 />
 
                 <ProgramSponsorsSection
                   programSlug={program.slug}
-                  signAuthHeader={signUpdateSponsors}
+                  signAuthHeader={getAdminAuth}
                 />
 
                 <ProgramSignupsSection
                   programSlug={program.slug}
-                  signAuthHeader={signImportSignups}
+                  signAuthHeader={getAdminAuth}
                 />
 
                 <div className="panel px-3 py-2.5 mb-3 flex flex-wrap items-center gap-2">
@@ -286,7 +279,7 @@ const AdminProgramPage = () => {
                         key={a.id}
                         application={a}
                         programSlug={program.slug}
-                        connectedAddress={connectedAddress!}
+                        signAuthHeader={getAdminAuth}
                         onUpdated={handleUpdated}
                       />
                     ))}

--- a/server/.env.example
+++ b/server/.env.example
@@ -13,6 +13,15 @@ EXPECTED_DOMAIN=
 # Runtime
 NODE_ENV=development
 
+# Admin session tokens — issued by POST /api/admin/session after one SIWS
+# sign, then accepted as `Authorization: Bearer …` on subsequent admin
+# requests so admins don't pop a wallet popup per action. The secret signs
+# the HMAC; rotate to invalidate every live session.
+#   ADMIN_SESSION_SECRET: 32+ chars, treat as a high-value secret
+#   ADMIN_SESSION_TTL_SECONDS: defaults to 900 (15 min). Range 1..86400.
+ADMIN_SESSION_SECRET=
+ADMIN_SESSION_TTL_SECONDS=900
+
 # Substrate network config
 NETWORK_ENV=testnet
 AUTHORIZED_SIGNERS=

--- a/server/api/auth/__tests__/sessionToken.test.js
+++ b/server/api/auth/__tests__/sessionToken.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  issueSessionToken,
+  verifySessionToken,
+  extractBearerToken,
+  _resetCacheForTests,
+} from '../sessionToken.js';
+
+const FRESH_SECRET = 'x'.repeat(40);
+
+beforeEach(() => {
+  process.env.ADMIN_SESSION_SECRET = FRESH_SECRET;
+  delete process.env.ADMIN_SESSION_TTL_SECONDS;
+  _resetCacheForTests();
+});
+
+afterEach(() => {
+  delete process.env.ADMIN_SESSION_SECRET;
+  delete process.env.ADMIN_SESSION_TTL_SECONDS;
+  _resetCacheForTests();
+});
+
+describe('issueSessionToken + verifySessionToken', () => {
+  it('round-trips an address + chain through the token', () => {
+    const { token, expiresAt } = issueSessionToken({ address: '5Alice', chain: 'substrate' });
+    expect(token.split('.').length).toBe(2);
+    expect(new Date(expiresAt).getTime()).toBeGreaterThan(Date.now());
+
+    const v = verifySessionToken(token);
+    expect(v).toMatchObject({ valid: true, address: '5Alice', chain: 'substrate' });
+    expect(v.exp).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  it('rejects a tampered payload', () => {
+    const { token } = issueSessionToken({ address: '5Alice', chain: 'substrate' });
+    const [_payload, sig] = token.split('.');
+    void _payload;
+    // Replace the payload with one that says we're Bob — signature won't match.
+    const fakePayload = Buffer.from(
+      JSON.stringify({ address: '5Bob', chain: 'substrate', iat: 0, exp: 9999999999 }),
+    ).toString('base64url');
+    const v = verifySessionToken(`${fakePayload}.${sig}`);
+    expect(v).toMatchObject({ valid: false, reason: 'bad_signature' });
+  });
+
+  it('rejects malformed tokens', () => {
+    expect(verifySessionToken('').valid).toBe(false);
+    expect(verifySessionToken('no-dot').valid).toBe(false);
+    expect(verifySessionToken('a.b').valid).toBe(false);
+  });
+
+  it('rejects a token signed with a different secret', () => {
+    const { token } = issueSessionToken({ address: '5Alice', chain: 'substrate' });
+    process.env.ADMIN_SESSION_SECRET = 'y'.repeat(40);
+    _resetCacheForTests();
+    const v = verifySessionToken(token);
+    expect(v).toMatchObject({ valid: false, reason: 'bad_signature' });
+  });
+
+  it('rejects an expired token', () => {
+    process.env.ADMIN_SESSION_TTL_SECONDS = '1';
+    _resetCacheForTests();
+    const { token } = issueSessionToken({ address: '5Alice', chain: 'substrate' });
+    // Move the clock past the TTL.
+    const original = Date.now;
+    Date.now = () => original.call(Date) + 2000;
+    try {
+      const v = verifySessionToken(token);
+      expect(v).toMatchObject({ valid: false, reason: 'expired' });
+    } finally {
+      Date.now = original;
+    }
+  });
+
+  it('throws on issue when the secret is missing or too short', () => {
+    process.env.ADMIN_SESSION_SECRET = 'short';
+    _resetCacheForTests();
+    expect(() => issueSessionToken({ address: 'a', chain: 'substrate' })).toThrow(
+      /ADMIN_SESSION_SECRET/,
+    );
+  });
+
+  it('uses the configured TTL when present', () => {
+    process.env.ADMIN_SESSION_TTL_SECONDS = '60';
+    _resetCacheForTests();
+    const { token } = issueSessionToken({ address: 'a', chain: 'substrate' });
+    const v = verifySessionToken(token);
+    expect(v.valid).toBe(true);
+    expect(v.exp - Math.floor(Date.now() / 1000)).toBeLessThanOrEqual(60);
+    expect(v.exp - Math.floor(Date.now() / 1000)).toBeGreaterThan(0);
+  });
+});
+
+describe('extractBearerToken', () => {
+  it('reads Authorization: Bearer …', () => {
+    const req = { headers: { authorization: 'Bearer abc.def' } };
+    expect(extractBearerToken(req)).toBe('abc.def');
+  });
+
+  it('returns null when the header is missing or non-bearer', () => {
+    expect(extractBearerToken({ headers: {} })).toBeNull();
+    expect(extractBearerToken({ headers: { authorization: 'Basic abc' } })).toBeNull();
+    expect(extractBearerToken({})).toBeNull();
+  });
+});

--- a/server/api/auth/sessionToken.js
+++ b/server/api/auth/sessionToken.js
@@ -1,0 +1,137 @@
+/**
+ * Admin session tokens — HMAC-signed bearer tokens with TTL.
+ *
+ * Solves the per-action signature popup problem: after one SIWS sign, the
+ * admin trades it for a short-lived bearer token. Subsequent admin actions
+ * send `Authorization: Bearer <token>` and the auth middleware accepts it
+ * without going through the wallet again.
+ *
+ * Why HMAC and not JWT? No dependency churn. Node's crypto is enough and
+ * keeps the verifier surface small. Format:
+ *   base64url(json_payload).base64url(hmac_sha256(secret, payload))
+ *
+ * Payload shape: { address, chain, iat, exp } — exp is unix seconds.
+ *
+ * Secret comes from ADMIN_SESSION_SECRET (require ≥ 32 chars at startup).
+ * TTL is ADMIN_SESSION_TTL_SECONDS, default 900 (15 minutes).
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+const DEFAULT_TTL_SECONDS = 15 * 60;
+const MIN_SECRET_LENGTH = 32;
+
+const b64url = (buf) => Buffer.from(buf).toString('base64url');
+const b64urlDecode = (str) => Buffer.from(str, 'base64url');
+
+let cachedSecret = null;
+function getSecret() {
+  if (cachedSecret) return cachedSecret;
+  const raw = process.env.ADMIN_SESSION_SECRET;
+  if (!raw || raw.length < MIN_SECRET_LENGTH) {
+    throw new Error(
+      `ADMIN_SESSION_SECRET must be set to a string of at least ${MIN_SECRET_LENGTH} characters`,
+    );
+  }
+  cachedSecret = Buffer.from(raw, 'utf8');
+  return cachedSecret;
+}
+
+function getTtlSeconds() {
+  const v = Number(process.env.ADMIN_SESSION_TTL_SECONDS);
+  if (Number.isFinite(v) && v > 0 && v <= 24 * 3600) return v;
+  return DEFAULT_TTL_SECONDS;
+}
+
+/** Allow tests to reset module-scoped caches between cases. */
+export function _resetCacheForTests() {
+  cachedSecret = null;
+}
+
+/**
+ * Issue a session token for an authenticated admin wallet.
+ *
+ * @param {{ address: string, chain: 'substrate'|'ethereum'|'solana' }} subject
+ * @returns {{ token: string, expiresAt: string }}
+ */
+export function issueSessionToken({ address, chain }) {
+  if (!address || typeof address !== 'string') throw new Error('address required');
+  if (!chain || typeof chain !== 'string') throw new Error('chain required');
+  const secret = getSecret();
+  const ttl = getTtlSeconds();
+  const now = Math.floor(Date.now() / 1000);
+  const payload = { address, chain, iat: now, exp: now + ttl };
+  const payloadStr = b64url(JSON.stringify(payload));
+  const sig = b64url(createHmac('sha256', secret).update(payloadStr).digest());
+  return {
+    token: `${payloadStr}.${sig}`,
+    expiresAt: new Date((now + ttl) * 1000).toISOString(),
+  };
+}
+
+/**
+ * Verify a bearer token. Returns `{ valid, reason?, address?, chain?, exp? }`.
+ *
+ * Constant-time signature comparison; no timing oracle on the HMAC. Caller
+ * receives a typed `reason` so failure modes can be distinguished in tests
+ * and logged usefully ('malformed', 'bad_signature', 'expired').
+ */
+export function verifySessionToken(token) {
+  if (typeof token !== 'string' || !token.includes('.')) {
+    return { valid: false, reason: 'malformed' };
+  }
+  const [payloadStr, sigStr] = token.split('.', 2);
+  if (!payloadStr || !sigStr) return { valid: false, reason: 'malformed' };
+
+  let secret;
+  try {
+    secret = getSecret();
+  } catch {
+    return { valid: false, reason: 'no_secret' };
+  }
+
+  const expected = createHmac('sha256', secret).update(payloadStr).digest();
+  let actual;
+  try {
+    actual = b64urlDecode(sigStr);
+  } catch {
+    return { valid: false, reason: 'malformed' };
+  }
+  if (expected.length !== actual.length) return { valid: false, reason: 'bad_signature' };
+  if (!timingSafeEqual(expected, actual)) return { valid: false, reason: 'bad_signature' };
+
+  let payload;
+  try {
+    payload = JSON.parse(b64urlDecode(payloadStr).toString('utf8'));
+  } catch {
+    return { valid: false, reason: 'malformed' };
+  }
+  if (
+    typeof payload.address !== 'string' ||
+    typeof payload.chain !== 'string' ||
+    typeof payload.exp !== 'number'
+  ) {
+    return { valid: false, reason: 'malformed' };
+  }
+
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  if (payload.exp <= nowSeconds) return { valid: false, reason: 'expired' };
+
+  return {
+    valid: true,
+    address: payload.address,
+    chain: payload.chain,
+    exp: payload.exp,
+  };
+}
+
+/**
+ * Read `Authorization: Bearer <token>` from a request. Returns the raw
+ * token string or null if not present.
+ */
+export function extractBearerToken(req) {
+  const header = req?.headers?.authorization || req?.headers?.Authorization;
+  if (typeof header !== 'string') return null;
+  const m = header.match(/^Bearer\s+(\S+)\s*$/);
+  return m ? m[1] : null;
+}

--- a/server/api/controllers/__tests__/admin-session.test.js
+++ b/server/api/controllers/__tests__/admin-session.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const FRESH_SECRET = 'x'.repeat(40);
+
+vi.mock('../../middleware/auth.middleware.js', () => ({
+  authenticateRequest: vi.fn(),
+}));
+
+const { authenticateRequest } = await import('../../middleware/auth.middleware.js');
+const { createAdminSession } = await import('../admin-session.controller.js');
+const { _resetCacheForTests, verifySessionToken } = await import('../../auth/sessionToken.js');
+
+const mockRes = () => {
+  const res = {};
+  res.status = vi.fn(() => res);
+  res.json = vi.fn(() => res);
+  return res;
+};
+
+beforeEach(() => {
+  process.env.ADMIN_SESSION_SECRET = FRESH_SECRET;
+  delete process.env.ADMIN_SESSION_TTL_SECONDS;
+  _resetCacheForTests();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  delete process.env.ADMIN_SESSION_SECRET;
+  _resetCacheForTests();
+});
+
+describe('createAdminSession', () => {
+  it('returns 401 when the SIWS header is missing', async () => {
+    const req = { headers: {} };
+    const res = mockRes();
+    await createAdminSession(req, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(authenticateRequest).not.toHaveBeenCalled();
+  });
+
+  it('forwards authenticateRequest failure status + body verbatim', async () => {
+    authenticateRequest.mockResolvedValue({
+      ok: false,
+      status: 403,
+      body: { status: 'error', message: 'bad signature' },
+    });
+    const req = { headers: { 'x-siws-auth': 'fake' } };
+    const res = mockRes();
+    await createAdminSession(req, res);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ status: 'error', message: 'bad signature' });
+  });
+
+  it('issues a verifiable token on successful SIWS auth', async () => {
+    authenticateRequest.mockResolvedValue({
+      ok: true,
+      chain: 'substrate',
+      parsed: { address: '5Alice' },
+      normalizedAddress: '5alice',
+    });
+    const req = { headers: { 'x-siws-auth': 'good-siws' } };
+    const res = mockRes();
+    await createAdminSession(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const payload = res.json.mock.calls[0][0];
+    expect(payload).toMatchObject({
+      status: 'success',
+      data: expect.objectContaining({
+        token: expect.any(String),
+        address: '5Alice',
+        chain: 'substrate',
+        expiresAt: expect.any(String),
+      }),
+    });
+    const v = verifySessionToken(payload.data.token);
+    expect(v).toMatchObject({ valid: true, address: '5Alice', chain: 'substrate' });
+  });
+});

--- a/server/api/controllers/admin-session.controller.js
+++ b/server/api/controllers/admin-session.controller.js
@@ -1,0 +1,51 @@
+/**
+ * POST /api/admin/session — exchange one SIWS signature for a bearer token.
+ *
+ * The body of the SIWS message must carry the existing
+ * "Perform administrative action on Stadium" statement and an expirationTime;
+ * the same nonce-replay and statement-validation rules apply as for any
+ * admin-gated route. The middleware authorization (= is this wallet an admin)
+ * is intentionally NOT enforced here: the session is for whoever can present a
+ * valid SIWS; downstream middleware still gates per-route based on the
+ * address claimed by the token. (i.e. holding a token does not, by itself,
+ * make you an admin — the route-level requireAdmin / requireProgramAdmin
+ * still runs.)
+ */
+
+import { authenticateRequest } from '../middleware/auth.middleware.js';
+import { issueSessionToken } from '../auth/sessionToken.js';
+
+export async function createAdminSession(req, res) {
+  try {
+    const authHeader = req.headers['x-siws-auth'];
+    if (!authHeader) {
+      return res
+        .status(401)
+        .json({ status: 'error', message: 'Missing SIWS auth header' });
+    }
+
+    // This endpoint takes a one-time SIWS sign (no bearer fallback) so each
+    // session is anchored in a fresh wallet signature. The nonce store will
+    // reject re-use, and the SIWS expirationTime caps how stale the message
+    // can be — both already enforced by authenticateRequest.
+    const auth = await authenticateRequest(authHeader, { checkDomain: true });
+    if (!auth.ok) {
+      return res.status(auth.status).json(auth.body);
+    }
+
+    const { chain, parsed } = auth;
+    const { token, expiresAt } = issueSessionToken({ address: parsed.address, chain });
+    res.status(200).json({
+      status: 'success',
+      data: {
+        token,
+        address: parsed.address,
+        chain,
+        expiresAt,
+      },
+    });
+  } catch (error) {
+    console.error('❌ Error creating admin session:', error);
+    res.status(500).json({ status: 'error', message: 'Failed to create admin session' });
+  }
+}

--- a/server/api/middleware/auth.middleware.js
+++ b/server/api/middleware/auth.middleware.js
@@ -22,6 +22,7 @@ import { getVerifier } from '../auth/verifiers/index.js';
 import { validateStatement } from '../auth/statements.js';
 import { normalizeAddress } from '../auth/normalize.js';
 import { consumeNonce } from '../auth/nonceStore.js';
+import { extractBearerToken, verifySessionToken } from '../auth/sessionToken.js';
 import programRepository from '../repositories/program.repository.js';
 import programAdminRepository from '../repositories/program-admin.repository.js';
 
@@ -54,7 +55,7 @@ const logSuccess = (message) => console.log(chalk.green(`[AuthMiddleware] ${mess
  *   | { ok: false, status: number, body: object }
  * >}
  */
-async function authenticateRequest(authHeader, { checkDomain }) {
+export async function authenticateRequest(authHeader, { checkDomain }) {
   let payload;
   try {
     payload = parsePayload(authHeader);
@@ -174,6 +175,74 @@ async function authenticateRequest(authHeader, { checkDomain }) {
   return { ok: true, chain, parsed, normalizedAddress };
 }
 
+/**
+ * Resolve the authenticated signer of a request, preferring a session bearer
+ * token over a fresh SIWS sign. Returns the same shape as authenticateRequest
+ * (`{ ok, status, body }` on failure; `{ ok, chain, parsed, normalizedAddress }`
+ * on success).
+ *
+ * Bearer path: short-lived HMAC token, valid for ADMIN_SESSION_TTL_SECONDS
+ * after one SIWS sign exchanged via POST /api/admin/session.
+ * SIWS path: unchanged — single-use nonce + expirationTime + statement check.
+ *
+ * The synthetic `parsed` object exposed on the bearer path has just `address`
+ * (other fields are undefined) — downstream middleware only reads `address`
+ * and `chain`, never the other SIWS fields, so the shape is compatible.
+ */
+export async function resolveAuthIdentity(req, { checkDomain }) {
+  const bearer = extractBearerToken(req);
+  if (bearer) {
+    const v = verifySessionToken(bearer);
+    if (v.valid) {
+      const chain = v.chain;
+      let normalizedAddress;
+      try {
+        normalizedAddress = normalizeAddress(chain, v.address);
+      } catch {
+        normalizedAddress = v.address;
+      }
+      logSuccess(`${chain} session bearer accepted for ${v.address}.`);
+      return {
+        ok: true,
+        chain,
+        parsed: { address: v.address, statement: '[session-bearer]', domain: undefined, nonce: undefined },
+        normalizedAddress,
+        viaSession: true,
+      };
+    }
+    logError(`Bearer rejected (${v.reason}).`);
+    return {
+      ok: false,
+      status: 401,
+      body: { status: 'error', message: 'Session token invalid or expired' },
+    };
+  }
+
+  const authHeader = req.headers['x-siws-auth'];
+
+  // DEV MODE BYPASS — preserved so existing local dev workflows keep working.
+  if (process.env.NODE_ENV !== 'production' && authHeader === 'dev-bypass') {
+    log(chalk.yellow('⚠️  DEV MODE: Bypassing SIWS authentication'));
+    return {
+      ok: true,
+      chain: 'substrate',
+      parsed: { address: ADMIN_WALLETS[0] || 'dev-admin', statement: '[dev-bypass]' },
+      normalizedAddress: ADMIN_WALLETS[0] || 'dev-admin',
+      viaSession: false,
+      devBypass: true,
+    };
+  }
+
+  if (!authHeader) {
+    return {
+      ok: false,
+      status: 401,
+      body: { status: 'error', message: 'Missing SIWS auth header' },
+    };
+  }
+  return authenticateRequest(authHeader, { checkDomain });
+}
+
 // --- Middleware ---
 
 /**
@@ -182,23 +251,13 @@ async function authenticateRequest(authHeader, { checkDomain }) {
 export const requireAdmin = async (req, res, next) => {
   log(`Initiating admin verification for ${req.method} ${req.originalUrl}`);
 
-  const authHeader = req.headers['x-siws-auth'];
-
-  // DEV MODE BYPASS: skip auth in development when header is 'dev-bypass'.
-  if (process.env.NODE_ENV !== 'production' && authHeader === 'dev-bypass') {
-    log(chalk.yellow('⚠️  DEV MODE: Bypassing SIWS authentication'));
-    req.adminAddress = ADMIN_WALLETS[0] || 'dev-admin';
-    return next();
-  }
-
-  if (!authHeader) {
-    logError('Verification failed: Missing x-siws-auth header.');
-    return res.status(401).json({ status: 'error', message: 'Missing SIWS auth header' });
-  }
-
-  const auth = await authenticateRequest(authHeader, { checkDomain: true });
+  const auth = await resolveAuthIdentity(req, { checkDomain: true });
   if (!auth.ok) {
     return res.status(auth.status).json(auth.body);
+  }
+  if (auth.devBypass) {
+    req.adminAddress = auth.parsed.address;
+    return next();
   }
 
   const signerAddress = auth.parsed.address;
@@ -233,26 +292,16 @@ export const requireTeamMemberOrAdmin = async (req, res, next) => {
     return res.status(400).json({ status: 'error', message: 'Project ID is required for this operation' });
   }
 
-  const authHeader = req.headers['x-siws-auth'];
-
-  // DEV MODE BYPASS
-  if (process.env.NODE_ENV !== 'production' && authHeader === 'dev-bypass') {
-    log(chalk.yellow('⚠️  DEV MODE: Bypassing SIWS authentication for team/admin'));
-    req.auth = { address: ADMIN_WALLETS[0] || 'dev-admin', isAdmin: true };
-    return next();
-  }
-
-  if (!authHeader) {
-    logError('Verification failed: Missing x-siws-auth header.');
-    return res.status(401).json({ status: 'error', message: 'Missing SIWS auth header' });
-  }
-
   // Domain is verified here too, consistent with requireAdmin / requireOwnWallet.
   // Preview/staging origins are handled by DISABLE_SIWS_DOMAIN_CHECK, not by
   // skipping the check.
-  const auth = await authenticateRequest(authHeader, { checkDomain: true });
+  const auth = await resolveAuthIdentity(req, { checkDomain: true });
   if (!auth.ok) {
     return res.status(auth.status).json(auth.body);
+  }
+  if (auth.devBypass) {
+    req.auth = { address: auth.parsed.address, isAdmin: true };
+    return next();
   }
 
   const signerAddress = auth.parsed.address;
@@ -315,23 +364,13 @@ export const requireTeamMemberOrAdmin = async (req, res, next) => {
 export const requireOwnWallet = async (req, res, next) => {
   log(`Initiating own-wallet verification for ${req.method} ${req.originalUrl}`);
 
-  const authHeader = req.headers['x-siws-auth'];
-
-  // DEV MODE BYPASS
-  if (process.env.NODE_ENV !== 'production' && authHeader === 'dev-bypass') {
-    log(chalk.yellow('⚠️  DEV MODE: Bypassing SIWS authentication for own-wallet'));
-    req.user = { address: req.params.address, chain: 'substrate' };
-    return next();
-  }
-
-  if (!authHeader) {
-    logError('Verification failed: Missing x-siws-auth header.');
-    return res.status(401).json({ status: 'error', message: 'Missing SIWS auth header' });
-  }
-
-  const auth = await authenticateRequest(authHeader, { checkDomain: true });
+  const auth = await resolveAuthIdentity(req, { checkDomain: true });
   if (!auth.ok) {
     return res.status(auth.status).json(auth.body);
+  }
+  if (auth.devBypass) {
+    req.user = { address: req.params.address, chain: 'substrate' };
+    return next();
   }
 
   // The signer's chain governs how the target route param is interpreted.
@@ -378,22 +417,13 @@ export const requireProgramAdmin = (slugParam = 'slug') => async (req, res, next
     return res.status(400).json({ status: 'error', message: `Program ${slugParam} is required` });
   }
 
-  const authHeader = req.headers['x-siws-auth'];
-
-  if (process.env.NODE_ENV !== 'production' && authHeader === 'dev-bypass') {
-    log(chalk.yellow('⚠️  DEV MODE: Bypassing SIWS authentication for program admin'));
-    req.user = { address: ADMIN_WALLETS[0] || 'dev-admin', programSlug: slug, isGlobalAdmin: true };
-    return next();
-  }
-
-  if (!authHeader) {
-    logError('Verification failed: Missing x-siws-auth header.');
-    return res.status(401).json({ status: 'error', message: 'Missing SIWS auth header' });
-  }
-
-  const auth = await authenticateRequest(authHeader, { checkDomain: true });
+  const auth = await resolveAuthIdentity(req, { checkDomain: true });
   if (!auth.ok) {
     return res.status(auth.status).json(auth.body);
+  }
+  if (auth.devBypass) {
+    req.user = { address: auth.parsed.address, programSlug: slug, isGlobalAdmin: true };
+    return next();
   }
 
   const signerAddress = auth.parsed.address;

--- a/server/api/routes/admin-session.routes.js
+++ b/server/api/routes/admin-session.routes.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import { createAdminSession } from '../controllers/admin-session.controller.js';
+
+const router = Router();
+
+// POST /api/admin/session — exchange one SIWS sign for a short-lived bearer
+// token. Body is empty; the SIWS payload travels in the `x-siws-auth` header
+// like every other admin write. Response carries the token + ISO expiresAt.
+router.post('/', createAdminSession);
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -4,6 +4,7 @@ import connectToSupabase, { supabase } from "./db.js";
 import m2ProgramRoutes from './api/routes/m2-program.routes.js';
 import programRoutes from './api/routes/program.routes.js';
 import walletContactRoutes from './api/routes/wallet-contact.routes.js';
+import adminSessionRoutes from './api/routes/admin-session.routes.js';
 import requestLogger from './api/middleware/logging.middleware.js';
 import { getAuthorizedAddresses, NETWORK_CONFIG } from './config/polkadot-config.js';
 
@@ -46,6 +47,7 @@ app.use(requestLogger);
 app.use('/api/m2-program', m2ProgramRoutes);
 app.use('/api/programs', programRoutes);
 app.use('/api/wallet-contacts', walletContactRoutes);
+app.use('/api/admin/session', adminSessionRoutes);
 
 // Backward compatibility: Keep old /api/projects route as alias
 // TODO: Remove after frontend migration is stable


### PR DESCRIPTION
**A of the three-part admin UX request** (after #102 sponsors, #103 signups). You reported popping the wallet for every admin click — load list, edit a sponsor, accept an application, import a CSV — even though you already authenticated this session. Per-action SIWS was deliberate (nonce-replay protection from #88 prevents reuse) but the UX cost is real, especially during a rehearsal with dozens of admin actions.

## Solution

After one SIWS sign, exchange it via `POST /api/admin/session` for a short-lived HMAC-signed bearer token (default 15 min TTL). Subsequent admin requests send `Authorization: Bearer <token>`; the auth middleware accepts either path. The nonce store still consumes each SIWS message once, so this doesn't widen the replay surface — it just amortises the sign cost across a session.

## Server

- `server/api/auth/sessionToken.js` — issue/verify HMAC-SHA256 tokens signed against `ADMIN_SESSION_SECRET`. Payload = base64url JSON `{ address, chain, iat, exp }`. Signature constant-time-compared via `timingSafeEqual`.
- `server/api/controllers/admin-session.controller.js` — `POST /admin/session` takes one fresh SIWS sign through the existing `authenticateRequest` path (consuming the nonce), then issues a token. The route deliberately does NOT accept bearer auth itself — tokens can't mint new tokens.
- `server/api/middleware/auth.middleware.js`:
  - `authenticateRequest` exported (used by the controller above).
  - new `resolveAuthIdentity(req, { checkDomain })` — single entry point that prefers bearer when present, falls back to SIWS, returns the same shape. Dev-bypass surfaced as a flag.
  - `requireAdmin` / `requireTeamMemberOrAdmin` / `requireOwnWallet` / `requireProgramAdmin` all call `resolveAuthIdentity` instead of hand-rolling the same header dance. The authorization checks below (isAuthorizedSigner / team-member match / program_admins lookup) are untouched — bearer just brings the verified identity to the gate.
- `server/.env.example` — documents `ADMIN_SESSION_SECRET` (32+ chars required) + `ADMIN_SESSION_TTL_SECONDS` (default 900s).

## Server tests

- `sessionToken.test.js` (8 cases): round-trip; tampered payload rejected; malformed rejected; wrong-secret rejected; expired rejected; missing/short secret throws; TTL env honoured; `extractBearerToken` happy + null paths.
- `admin-session.test.js` (3 cases): 401 with no SIWS header; forwards `authenticateRequest` failure verbatim; issues a verifiable token on success.
- Full server suite: **214 / 214** (was 202; +12).

## Client

- `src/lib/auth/adminSession.ts` — `sessionStorage`-backed token cache keyed by `(chain, address)`. 30s refresh margin so callers don't race expiry. Cleared on disconnect.
- `useWalletAuth.getAdminBearerHeaders()` — cache hit returns `{ Authorization: 'Bearer …' }` immediately. Cache miss signs admin-action once, POSTs to `/api/admin/session`, caches, returns headers. If the session exchange fails (network/server), falls back to one-shot SIWS so the caller still completes.
- `api.ts` — new `AdminAuthArg = string | Record<string,string>`. Every admin-mutating method widened from `authHeader?: string` to `authHeader?: AdminAuthArg`. **Strict widening** — existing string callers unaffected.
- `AdminProgramPage` — single `getAdminAuth` callback wired to the bearer helper; `ProgramAdminsSection` / `ProgramSponsorsSection` / `ProgramSignupsSection` / `ApplicationCard` all share it. The connect-wallet probe now uses `getAdminBearerHeaders`, priming the cache on first admin connect.
- `AdminPage` — `handleConfirmM1Payout` / `handleConfirmPayment` use bearer headers. `WinnersTable` `signAdminAction` type widened to return `AdminAuthArg`; all five row actions (status / agreement / deliverables / payment / bulk mark-paid) share the cache.
- `ApplicationCard` — inline SIWS dance removed; accepts `signAuthHeader` prop. Drops the Polkadot-direct imports (`web3Enable`, `SiwsMessage`, etc.) from this component.

## Verification

- `cd client && npm run build` → clean (tsc + vite)
- `cd client && npm run lint --max-warnings 0` → 0 warnings / 0 errors
- `cd server && npm test` → 214 / 214

## Test scenarios

- On `/admin/programs/bitrefill-2026` as a global admin, click CONNECT ADMIN WALLET — **exactly one** wallet popup. Subsequent actions in the same session (LOAD APPLICATIONS, ADD SPONSOR, SAVE CHANGES, IMPORT CSV, ACCEPT/REJECT row, MARK ALL AS PAID) trigger zero popups.
- After the configured TTL elapses, the next admin action signs once to mint a fresh token, then continues without popups.
- Set `ADMIN_SESSION_SECRET` to a string < 32 chars → `POST /admin/session` returns 500 (`issueSessionToken` throws). Set long enough → tokens work.
- Tamper a token's payload (swap address) → admin-gated routes return 401 'Session token invalid or expired'.
- **Production fallback path**: without `ADMIN_SESSION_SECRET` set, `POST /admin/session` 500s, but the EXISTING SIWS flow keeps working — clients silently fall back to one-shot SIWS. No regression in flows that never opt into the session path.

## Risks

- **New env var (`ADMIN_SESSION_SECRET`)** must be deployed to Railway prod + dev `.env` files. Without it, the session route 500s and the client transparently falls back to per-action SIWS — same UX as today, no broken admin flows.
- **Cache shape change** in `sessionStorage` (`stadium_admin_session_v1`). Already versioned. Old keys (if any) are ignored.
- **Bearer is admin-scope only**. Team-member writes (post update, edit funding signal, apply to program, update notifications) still take one SIWS per action — unchanged on purpose, those are rare per-session anyway.

Targets `develop`. Draft for review.