### PR TITLE
fix(programs): chain picker + visible feedback on Apply CTA (#106)

### DIFF
--- a/client/src/pages/ProgramDetailPage.tsx
+++ b/client/src/pages/ProgramDetailPage.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { Navigation } from "@/components/Navigation";
 import { RotateCw } from "lucide-react";
+import { ChainPicker } from "@/components/auth/ChainPicker";
+import { getProvider } from "@/lib/auth/registry";
 import {
   api,
   type ApiProgram,
@@ -113,9 +115,27 @@ const ProgramDetailPage = () => {
   };
 
   const connectWallet = async () => {
+    const providerLabel = getProvider(auth.chain)?.label || "Wallet";
+    if (!auth.isAvailable) {
+      toast({
+        title: `${providerLabel} extension not detected`,
+        description:
+          "Install the wallet extension for your selected chain, then refresh and try again.",
+        variant: "destructive",
+      });
+      return;
+    }
     try {
       const found = await auth.connect();
-      if (found[0]) auth.selectAccount(found[0]);
+      if (!found.length) {
+        toast({
+          title: `No accounts found in ${providerLabel}`,
+          description: "Open your wallet, create or unlock an account, then try again.",
+          variant: "destructive",
+        });
+        return;
+      }
+      auth.selectAccount(found[0]);
     } catch (e) {
       toast({
         title: "Couldn't connect wallet",
@@ -168,10 +188,22 @@ const ProgramDetailPage = () => {
     }
 
     if (!connectedAddress) {
+      const providerLabel = getProvider(auth.chain)?.label || "Wallet";
       return (
-        <RackButton onClick={connectWallet} disabled={auth.isConnecting}>
-          {auth.isConnecting ? "CONNECTING…" : "SIGN IN TO APPLY"}
-        </RackButton>
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="label-hw-dim">CHAIN</span>
+            <ChainPicker value={auth.chain} onChange={auth.setChain} />
+          </div>
+          <RackButton onClick={connectWallet} disabled={auth.isConnecting}>
+            {auth.isConnecting ? "CONNECTING…" : "SIGN IN TO APPLY"}
+          </RackButton>
+          {!auth.isAvailable && (
+            <p className="label-hw-dim">
+              {providerLabel.toUpperCase()} EXTENSION NOT DETECTED — INSTALL IT, THEN REFRESH.
+            </p>
+          )}
+        </div>
       );
     }
 


### PR DESCRIPTION
Closes #106. Reproduced live on prod with Playwright: clicking SIGN IN TO APPLY on `/programs/dogfooding` with no Polkadot-JS extension produced **zero user-visible feedback**. And anyone with only an Ethereum or Solana wallet had no way to even pick their chain — `useWalletAuth` defaults to substrate and no `ChainPicker` was mounted on this page despite the registry supporting all three.

## Fix

1. Mount the existing `ChainPicker` inside the disconnected-state apply CTA — mirrors the pattern from `AdminPage`. Substrate / Ethereum / Solana all now reachable from `/programs/:slug`.
2. Inline 'X extension not detected — install it, then refresh' hint under the button when the selected chain's wallet isn't available. Same idiom as `AdminPage`'s 'POLKADOT EXTENSION NOT DETECTED' line.
3. Harden `connectWallet()`:
   - Pre-check `auth.isAvailable`; if false, toast immediately. Guaranteed user feedback even if the provider's `connect()` doesn't then throw for some reason.
   - Handle the empty-array success case (extensions enabled but no accounts) with a dedicated toast.
   - Preserve the existing catch toast for any thrown error.

The provider still throws when `web3Enable` returns `[]`; the pre-check is defensive — guaranteed user feedback regardless of which layer fails.

## Files

- `client/src/pages/ProgramDetailPage.tsx` — only file touched (36 insertions, 4 deletions)

## Verification

- `npm run build` → clean
- `npm run lint --max-warnings 0` → 0 warnings / 0 errors
- Plata Mia path (substrate-only) is preserved: ChainPicker defaults to Substrate, SIGN IN TO APPLY opens Polkadot-JS as before.

## Test scenarios

- `/programs/dogfooding` with **no wallet extension**: ChainPicker renders; picking any chain shows the 'X EXTENSION NOT DETECTED' hint; clicking SIGN IN TO APPLY surfaces a destructive toast within 1s.
- `/programs/dogfooding` with **only Polkadot-JS** installed: ChainPicker defaults to Substrate; SIGN IN TO APPLY opens the wallet popup; no regression for the alpha-cohort path.
- `/programs/dogfooding` with **only MetaMask** installed: pick 'Ethereum' in the ChainPicker; SIGN IN TO APPLY opens MetaMask; after approval APPLY WITH MY PROJECT becomes available.

Time-critical: alpha rehearsal target 2026-05-23, day 2 of 2.