### PR TITLE
release: fix(programs) chain picker on Apply CTA (#106)

### DIFF
--- a/client/src/pages/ProgramDetailPage.tsx
+++ b/client/src/pages/ProgramDetailPage.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { Navigation } from "@/components/Navigation";
 import { RotateCw } from "lucide-react";
+import { ChainPicker } from "@/components/auth/ChainPicker";
+import { getProvider } from "@/lib/auth/registry";
 import {
   api,
   type ApiProgram,
@@ -113,9 +115,27 @@ const ProgramDetailPage = () => {
   };
 
   const connectWallet = async () => {
+    const providerLabel = getProvider(auth.chain)?.label || "Wallet";
+    if (!auth.isAvailable) {
+      toast({
+        title: `${providerLabel} extension not detected`,
+        description:
+          "Install the wallet extension for your selected chain, then refresh and try again.",
+        variant: "destructive",
+      });
+      return;
+    }
     try {
       const found = await auth.connect();
-      if (found[0]) auth.selectAccount(found[0]);
+      if (!found.length) {
+        toast({
+          title: `No accounts found in ${providerLabel}`,
+          description: "Open your wallet, create or unlock an account, then try again.",
+          variant: "destructive",
+        });
+        return;
+      }
+      auth.selectAccount(found[0]);
     } catch (e) {
       toast({
         title: "Couldn't connect wallet",
@@ -168,10 +188,22 @@ const ProgramDetailPage = () => {
     }
 
     if (!connectedAddress) {
+      const providerLabel = getProvider(auth.chain)?.label || "Wallet";
       return (
-        <RackButton onClick={connectWallet} disabled={auth.isConnecting}>
-          {auth.isConnecting ? "CONNECTING…" : "SIGN IN TO APPLY"}
-        </RackButton>
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="label-hw-dim">CHAIN</span>
+            <ChainPicker value={auth.chain} onChange={auth.setChain} />
+          </div>
+          <RackButton onClick={connectWallet} disabled={auth.isConnecting}>
+            {auth.isConnecting ? "CONNECTING…" : "SIGN IN TO APPLY"}
+          </RackButton>
+          {!auth.isAvailable && (
+            <p className="label-hw-dim">
+              {providerLabel.toUpperCase()} EXTENSION NOT DETECTED — INSTALL IT, THEN REFRESH.
+            </p>
+          )}
+        </div>
       );
     }
 


### PR DESCRIPTION
Promotes the #107 fix to prod. Single-commit release.

## What lands

- **#107** (closes #106) — `/programs/:slug` Apply CTA now mounts the `ChainPicker`, shows an inline 'extension not detected' hint, and toasts on connect failure. Reproduced live on prod yesterday: silent failure when no Polkadot-JS extension installed. Fix verified locally; deployment promotes it to https://stadium.joinwebzero.com/programs/dogfooding.

## No schema / env changes

Client-only change; no migrations, no Railway env vars, no Vercel env vars.

## Test scenarios (post-deploy)

- Open https://stadium.joinwebzero.com/programs/dogfooding in incognito (no wallet extension). Expect: ChainPicker visible above SIGN IN TO APPLY; 'POLKADOT EXTENSION NOT DETECTED — INSTALL IT, THEN REFRESH' hint under the button. Clicking the button fires a destructive toast within ~1s.
- Plata Mia path (substrate, Polkadot-JS installed): ChainPicker defaults to Substrate; SIGN IN TO APPLY opens the wallet popup as before. **No regression.**
- MetaMask-only browser: pick 'Ethereum' in the picker; SIGN IN TO APPLY opens MetaMask.

Vercel auto-deploys client on merge to main. Verify after ~30s with a hard reload.

Targets `main`. Draft for review.