### PR TITLE
feat(admin): app_admins + global_admins tiers + CSV staleness signal

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -15,6 +15,7 @@ import WinnersPage from "./pages/WinnersPage";
 import ProgramsPage from "./pages/ProgramsPage";
 import ProgramDetailPage from "./pages/ProgramDetailPage";
 import AdminProgramPage from "./pages/AdminProgramPage";
+import AppAdminsPage from "./pages/AppAdminsPage";
 
 // Redirect component for old project routes
 const ProjectRedirect = () => {
@@ -49,6 +50,7 @@ const App = () => {
               <Route path="m2-program/:id" element={<ProjectDetailsPage />} />
               <Route path="programs/:slug" element={<ProgramDetailPage />} />
               <Route path="admin/programs/:slug" element={<AdminProgramPage />} />
+              <Route path="admin/app-admins" element={<AppAdminsPage />} />
               <Route path="winners/:hackathon" element={<WinnersPage />} />
               {/* Redirect old project detail route */}
               <Route path="projects/:id" element={<ProjectRedirect />} />

--- a/client/src/components/admin/AdminTierSection.tsx
+++ b/client/src/components/admin/AdminTierSection.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useState, useCallback } from "react";
+import { Trash2, Loader2 } from "lucide-react";
+import { api, type ApiAdminTierEntry, type AdminAuthArg, ApiError } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+
+type ChainOption = ApiAdminTierEntry["walletChain"];
+
+/**
+ * Shared editor for `app_admins` (tier 0) and `global_admins` (tier 1).
+ * Identical UI; the parent supplies the API methods to call.
+ */
+export function AdminTierSection({
+  title,
+  description,
+  emptyHint,
+  load,
+  add,
+  remove,
+  signAuthHeader,
+}: {
+  title: string;
+  description?: string;
+  emptyHint: string;
+  load: (auth: AdminAuthArg) => Promise<{ data: ApiAdminTierEntry[] }>;
+  add: (
+    payload: Pick<ApiAdminTierEntry, "walletChain" | "wallet" | "label">,
+    auth: AdminAuthArg,
+  ) => Promise<{ data: ApiAdminTierEntry }>;
+  remove: (wallet: string, walletChain: ChainOption, auth: AdminAuthArg) => Promise<void>;
+  signAuthHeader: () => Promise<AdminAuthArg>;
+}) {
+  const { toast } = useToast();
+  const [entries, setEntries] = useState<ApiAdminTierEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [adding, setAdding] = useState(false);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [wallet, setWallet] = useState("");
+  const [label, setLabel] = useState("");
+  const [chain, setChain] = useState<ChainOption>("substrate");
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const auth = await signAuthHeader();
+      const res = await load(auth);
+      setEntries(res.data);
+    } catch (e) {
+      toast({
+        title: `Couldn't load ${title.toLowerCase()}`,
+        description: (e as Error)?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [load, signAuthHeader, title, toast]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const handleAdd = async () => {
+    if (!wallet.trim()) return;
+    setAdding(true);
+    try {
+      const auth = await signAuthHeader();
+      const res = await add(
+        { walletChain: chain, wallet: wallet.trim(), label: label.trim() || null },
+        auth,
+      );
+      setEntries((prev) => {
+        if (prev.some((a) => a.wallet === res.data.wallet && a.walletChain === res.data.walletChain)) {
+          return prev;
+        }
+        return [...prev, res.data];
+      });
+      setWallet("");
+      setLabel("");
+      toast({ title: `${title} added` });
+    } catch (e) {
+      toast({
+        title: `Couldn't add to ${title.toLowerCase()}`,
+        description: e instanceof ApiError ? e.message : (e as Error)?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setAdding(false);
+    }
+  };
+
+  const handleRemove = async (entry: ApiAdminTierEntry) => {
+    const key = `${entry.walletChain}:${entry.wallet}`;
+    if (!confirm(`Remove ${entry.label || entry.wallet}?`)) return;
+    setBusyKey(key);
+    try {
+      const auth = await signAuthHeader();
+      await remove(entry.wallet, entry.walletChain, auth);
+      setEntries((prev) =>
+        prev.filter((a) => !(a.wallet === entry.wallet && a.walletChain === entry.walletChain)),
+      );
+      toast({ title: `${title} removed` });
+    } catch (e) {
+      toast({
+        title: `Couldn't remove`,
+        description: e instanceof ApiError ? e.message : (e as Error)?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  return (
+    <section className="panel p-4 mb-3">
+      <header className="mb-3 flex items-baseline justify-between gap-3">
+        <div className="label-hw text-display">·{title.toUpperCase()}</div>
+        {description && <p className="label-hw-dim hidden md:block max-w-md text-right">{description}</p>}
+      </header>
+
+      {loading ? (
+        <div className="flex items-center gap-2 label-hw-dim py-3">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+          Loading…
+        </div>
+      ) : entries.length === 0 ? (
+        <p className="label-hw-dim py-3">{emptyHint}</p>
+      ) : (
+        <ul className="divide-y divide-hairline">
+          {entries.map((a) => {
+            const key = `${a.walletChain}:${a.wallet}`;
+            return (
+              <li key={key} className="flex items-center justify-between gap-3 py-2">
+                <div className="min-w-0">
+                  <p className="truncate font-mono text-[12px] text-display">{a.wallet}</p>
+                  <p className="label-hw-dim">
+                    {a.walletChain.toUpperCase()}
+                    {a.label ? ` · ${a.label}` : ""}
+                    {a.addedBy ? ` · ADDED BY ${a.addedBy.toUpperCase()}` : ""}
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => handleRemove(a)}
+                  disabled={busyKey === key}
+                  aria-label={`Remove ${a.wallet}`}
+                  className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-destructive hover:bg-destructive/10 disabled:opacity-50 px-2 py-1 inline-flex items-center gap-1"
+                >
+                  {busyKey === key ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
+                  REMOVE
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div className="mt-4 grid gap-2 border-t border-hairline pt-4 md:grid-cols-[1fr_140px_160px_auto]">
+        <input
+          placeholder="Wallet address"
+          value={wallet}
+          onChange={(e) => setWallet(e.target.value)}
+          className="font-mono text-[12px] bg-panel-deep border border-hairline text-display px-2 py-1.5 focus:outline-none focus:border-display"
+        />
+        <select
+          value={chain}
+          onChange={(e) => setChain(e.target.value as ChainOption)}
+          className="font-mono text-[11px] tracking-[0.14em] bg-panel-deep border border-hairline text-display px-2 py-1.5 focus:outline-none focus:border-display"
+        >
+          <option value="substrate">SUBSTRATE</option>
+          <option value="ethereum">ETHEREUM</option>
+          <option value="solana">SOLANA</option>
+        </select>
+        <input
+          placeholder="Label (optional)"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          className="font-mono text-[12px] bg-panel-deep border border-hairline text-display px-2 py-1.5 focus:outline-none focus:border-display"
+        />
+        <button
+          type="button"
+          onClick={handleAdd}
+          disabled={adding || !wallet.trim()}
+          className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-4 py-1.5"
+        >
+          {adding ? "ADDING…" : `ADD ${title.toUpperCase()}`}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/admin/ProgramSignupsSection.tsx
+++ b/client/src/components/admin/ProgramSignupsSection.tsx
@@ -31,6 +31,7 @@ export function ProgramSignupsSection({ programSlug, signAuthHeader }: Props) {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const [signups, setSignups] = useState<ApiProgramSignup[]>([]);
+  const [lastImportedAt, setLastImportedAt] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [busyId, setBusyId] = useState<string | null>(null);
 
@@ -47,7 +48,10 @@ export function ProgramSignupsSection({ programSlug, signAuthHeader }: Props) {
       try {
         const authHeader = await signAuthHeader();
         const r = await api.listProgramSignups(programSlug, authHeader);
-        if (active) setSignups(r.data);
+        if (active) {
+          setSignups(r.data);
+          setLastImportedAt(r.meta?.lastImportedAt ?? null);
+        }
       } catch (e) {
         if (active) {
           toast({
@@ -151,17 +155,45 @@ export function ProgramSignupsSection({ programSlug, signAuthHeader }: Props) {
 
   const signupCount = useMemo(() => signups.length, [signups]);
 
+  // Staleness: render "X days ago" off lastImportedAt; nudge yellow once it
+  // crosses STALE_DAYS so the admin knows to pull a fresh CSV from Luma.
+  const STALE_DAYS = 7;
+  const daysSinceImport = useMemo(() => {
+    if (!lastImportedAt) return null;
+    const ms = Date.now() - new Date(lastImportedAt).getTime();
+    if (!Number.isFinite(ms) || ms < 0) return null;
+    return Math.floor(ms / (1000 * 60 * 60 * 24));
+  }, [lastImportedAt]);
+  const isStale = daysSinceImport !== null && daysSinceImport >= STALE_DAYS;
+  const lastImportedLabel = (() => {
+    if (!lastImportedAt) return "NEVER IMPORTED";
+    if (daysSinceImport === 0) return "LAST IMPORTED TODAY";
+    if (daysSinceImport === 1) return "LAST IMPORTED 1 DAY AGO";
+    return `LAST IMPORTED ${daysSinceImport} DAYS AGO`;
+  })();
+
   return (
     <div className="panel p-4 mb-3">
       <div className="flex items-center justify-between mb-3 pb-3 border-b border-hairline-subtle">
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 flex-wrap">
           <span className="label-hw text-display">·SIGNUPS</span>
           <span className="lcd px-2 py-[1px] font-mono text-[10px] text-display tabular-nums">
             {signupCount}
           </span>
+          <span className={isStale ? "label-hw text-amber-500" : "label-hw-dim"}>
+            ·{lastImportedLabel}
+          </span>
         </div>
         <span className="label-hw-dim">LUMA CSV IMPORT</span>
       </div>
+
+      {isStale && (
+        <div className="lcd p-3 mb-3 border border-amber-500/40">
+          <p className="label-hw text-amber-500">
+            ·LUMA MAY HAVE NEW SIGNUPS — PULL A FRESH CSV AND RE-IMPORT.
+          </p>
+        </div>
+      )}
 
       {/* CSV picker + preview / commit */}
       <div className="lcd p-3 space-y-3 mb-4">

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -203,6 +203,15 @@ export type ApiProgramAdmin = {
   createdAt: string;
 };
 
+/** Tier-0 / tier-1 admin record. Same shape for both tables. */
+export type ApiAdminTierEntry = {
+  walletChain: "substrate" | "ethereum" | "solana";
+  wallet: string;
+  label?: string | null;
+  addedBy?: string | null;
+  createdAt?: string;
+};
+
 /** Shape of a row in the `programs` table (Phase 1 revamp). */
 export type ApiProgram = {
   id: string;
@@ -247,6 +256,7 @@ export type ApiProgramSignup = {
   registeredAt?: string | null;
   source: string;
   rawRow?: Record<string, unknown> | null;
+  importedInBatchAt?: string | null;
   createdAt?: string;
 };
 
@@ -1181,11 +1191,20 @@ export const api = {
   listProgramSignups: async (
     slug: string,
     authHeader?: AdminAuthArg,
-  ): Promise<{ status: string; data: ApiProgramSignup[]; meta: { count: number } }> => {
+  ): Promise<{
+    status: string;
+    data: ApiProgramSignup[];
+    meta: { count: number; lastImportedAt: string | null };
+  }> => {
     if (USE_MOCK_DATA) {
       const { mockProgramSignups } = await import("./mockPrograms");
       const list = mockProgramSignups[slug] || [];
-      return { status: "success", data: list, meta: { count: list.length } };
+      const lastImportedAt = list.reduce<string | null>((acc, s) => {
+        if (!s.importedInBatchAt) return acc;
+        if (!acc || s.importedInBatchAt > acc) return s.importedInBatchAt;
+        return acc;
+      }, null);
+      return { status: "success", data: list, meta: { count: list.length, lastImportedAt } };
     }
     return request(`/programs/${encodeURIComponent(slug)}/signups`, {
       headers: adminAuthHeaders(authHeader),
@@ -1492,6 +1511,74 @@ export const api = {
         method: "DELETE",
         headers: adminAuthHeaders(authHeader),
       },
+    );
+  },
+
+  // --- Admin tiers (app_admins / global_admins) ---
+
+  /**
+   * Self-check: is the connected wallet an app_admin? Cheap probe used to
+   * decide whether to show the /admin/app-admins nav entry.
+   */
+  getMyAdminTier: async (
+    authHeader: AdminAuthArg,
+  ): Promise<{ status: string; data: { isAppAdmin: boolean; chain: string; address: string } }> => {
+    return request(`/admin/me/tier`, { headers: adminAuthHeaders(authHeader) });
+  },
+
+  listAppAdmins: async (
+    authHeader: AdminAuthArg,
+  ): Promise<{ status: string; data: ApiAdminTierEntry[] }> => {
+    return request(`/admin/app-admins`, { headers: adminAuthHeaders(authHeader) });
+  },
+
+  addAppAdmin: async (
+    payload: Pick<ApiAdminTierEntry, "walletChain" | "wallet" | "label">,
+    authHeader: AdminAuthArg,
+  ): Promise<{ status: string; data: ApiAdminTierEntry }> => {
+    return request(`/admin/app-admins`, {
+      method: "POST",
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  },
+
+  removeAppAdmin: async (
+    wallet: string,
+    walletChain: ApiAdminTierEntry["walletChain"],
+    authHeader: AdminAuthArg,
+  ): Promise<void> => {
+    await request(
+      `/admin/app-admins/${encodeURIComponent(wallet)}?chain=${encodeURIComponent(walletChain)}`,
+      { method: "DELETE", headers: adminAuthHeaders(authHeader) },
+    );
+  },
+
+  listGlobalAdmins: async (
+    authHeader: AdminAuthArg,
+  ): Promise<{ status: string; data: ApiAdminTierEntry[] }> => {
+    return request(`/admin/global-admins`, { headers: adminAuthHeaders(authHeader) });
+  },
+
+  addGlobalAdmin: async (
+    payload: Pick<ApiAdminTierEntry, "walletChain" | "wallet" | "label">,
+    authHeader: AdminAuthArg,
+  ): Promise<{ status: string; data: ApiAdminTierEntry }> => {
+    return request(`/admin/global-admins`, {
+      method: "POST",
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  },
+
+  removeGlobalAdmin: async (
+    wallet: string,
+    walletChain: ApiAdminTierEntry["walletChain"],
+    authHeader: AdminAuthArg,
+  ): Promise<void> => {
+    await request(
+      `/admin/global-admins/${encodeURIComponent(wallet)}?chain=${encodeURIComponent(walletChain)}`,
+      { method: "DELETE", headers: adminAuthHeaders(authHeader) },
     );
   },
 };

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from "react";
+import { Link } from "react-router-dom";
 import { Navigation } from "@/components/Navigation";
 import { Loader2, LogOut, Wallet, CheckCircle, Plus } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
@@ -367,6 +368,13 @@ const AdminPage = () => {
                 <Plus className="h-3 w-3" /> CREATE PROJECT
               </RackBtn>
             )}
+            <Link
+              to="/admin/app-admins"
+              className="inline-flex items-center gap-1 font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep px-3 py-1.5"
+              title="Manage app + global admins (app admins only)"
+            >
+              ADMIN TIERS ▸
+            </Link>
             <RackBtn onClick={() => setShowTestPaymentModal(true)}>TEST PAYMENT</RackBtn>
             <div className="lcd px-3 py-1.5 label-hw text-display">
               {(auth.account?.label || "ADMIN").toUpperCase()} · {formatAddress(auth.account?.address || "")}

--- a/client/src/pages/AppAdminsPage.tsx
+++ b/client/src/pages/AppAdminsPage.tsx
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Navigation } from "@/components/Navigation";
+import { AdminTierSection } from "@/components/admin/AdminTierSection";
+import { useWalletAuth } from "@/lib/auth/useWalletAuth";
+import { api, ApiError } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+
+/**
+ * Tier-0 admin console. Only app_admins can see / use this. The page first
+ * probes `/admin/me/tier`; if the connected wallet isn't an app_admin, it
+ * redirects back to /admin with a toast.
+ */
+const AppAdminsPage = () => {
+  const auth = useWalletAuth();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const [tierStatus, setTierStatus] = useState<"checking" | "ok" | "denied" | "unauthenticated">(
+    "checking",
+  );
+
+  const { getAdminBearerHeaders, account } = auth;
+  const getAuth = useCallback(() => getAdminBearerHeaders(), [getAdminBearerHeaders]);
+
+  // Tier probe — gates the rest of the page.
+  useEffect(() => {
+    let cancelled = false;
+    if (!account) {
+      setTierStatus("unauthenticated");
+      return;
+    }
+    (async () => {
+      try {
+        const auth = await getAuth();
+        const res = await api.getMyAdminTier(auth);
+        if (cancelled) return;
+        if (res.data.isAppAdmin) {
+          setTierStatus("ok");
+        } else {
+          setTierStatus("denied");
+          toast({
+            title: "Not authorized",
+            description: "Only app admins can manage the admin tiers.",
+            variant: "destructive",
+          });
+          setTimeout(() => navigate("/admin"), 1200);
+        }
+      } catch (e) {
+        if (cancelled) return;
+        setTierStatus("denied");
+        toast({
+          title: "Couldn't check admin tier",
+          description: e instanceof ApiError ? e.message : (e as Error)?.message || "Unknown error",
+          variant: "destructive",
+        });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [account, getAuth, navigate, toast]);
+
+  const connectWallet = async () => {
+    try {
+      const found = await auth.connect();
+      if (found[0]) auth.selectAccount(found[0]);
+    } catch (e) {
+      toast({
+        title: "Couldn't connect wallet",
+        description: (e as Error)?.message || "Unknown error",
+        variant: "destructive",
+      });
+    }
+  };
+
+  return (
+    <div className="min-h-screen scanlines">
+      <Navigation />
+      <main className="container mx-auto px-4 py-6 max-w-3xl">
+        <div className="mb-6">
+          <Link
+            to="/admin"
+            className="label-hw-dim hover:text-display transition-colors duration-150 inline-flex items-center gap-1"
+          >
+            ◂ BACK TO ADMIN
+          </Link>
+        </div>
+
+        <header className="mb-6">
+          <div className="label-hw-dim mb-2">·ADMIN / APP ADMINS</div>
+          <h1 className="font-display text-4xl md:text-5xl uppercase tracking-tight text-display leading-[0.95] mb-3">
+            Admin Tiers
+          </h1>
+          <p className="text-body text-sm max-w-2xl">
+            Tier 0 (App Admins) manage who is in either tier. Tier 1 (Global Admins) can administer
+            every program in Stadium. Tier 2 (Program Admins) are scoped to a single program and
+            managed from each program's admin page.
+          </p>
+        </header>
+
+        {tierStatus === "unauthenticated" && (
+          <section className="panel p-6 text-center">
+            <div className="label-hw text-display mb-3">·CONNECT YOUR WALLET</div>
+            <p className="text-body text-sm mb-4">
+              Only app admins can view this page. Connect to verify.
+            </p>
+            <button
+              type="button"
+              onClick={connectWallet}
+              disabled={auth.isConnecting}
+              className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-4 py-2"
+            >
+              {auth.isConnecting ? "CONNECTING…" : "CONNECT WALLET"}
+            </button>
+          </section>
+        )}
+
+        {tierStatus === "checking" && (
+          <p className="label-hw-dim">CHECKING TIER…</p>
+        )}
+
+        {tierStatus === "denied" && (
+          <section className="panel p-6 text-center">
+            <div className="label-hw text-destructive mb-2">·NOT AN APP ADMIN</div>
+            <p className="text-body text-sm">Redirecting…</p>
+          </section>
+        )}
+
+        {tierStatus === "ok" && (
+          <>
+            <AdminTierSection
+              title="App Admins"
+              description="Tier 0 — manage admin lists themselves. Cannot remove the last one."
+              emptyHint="No app admins. This should be impossible — bootstrap script must have run."
+              load={(a) => api.listAppAdmins(a)}
+              add={(p, a) => api.addAppAdmin(p, a)}
+              remove={(w, c, a) => api.removeAppAdmin(w, c, a)}
+              signAuthHeader={getAuth}
+            />
+            <AdminTierSection
+              title="Global Admins"
+              description="Tier 1 — administer every program. Initial entries seeded from AUTHORIZED_SIGNERS env at bootstrap."
+              emptyHint="No global admins yet. Add wallets that should administer every program."
+              load={(a) => api.listGlobalAdmins(a)}
+              add={(p, a) => api.addGlobalAdmin(p, a)}
+              remove={(w, c, a) => api.removeGlobalAdmin(w, c, a)}
+              signAuthHeader={getAuth}
+            />
+          </>
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default AppAdminsPage;

--- a/server/.env.example
+++ b/server/.env.example
@@ -22,6 +22,14 @@ NODE_ENV=development
 ADMIN_SESSION_SECRET=
 ADMIN_SESSION_TTL_SECONDS=900
 
+# Admin tiers — DB-managed now. AUTHORIZED_SIGNERS above stays as a
+# fallback so an unsynced DB never locks out the team. To add your first
+# app admin, run (one-time):
+#   npm run bootstrap:app-admin -- --chain substrate --address <YOUR_ADDR> --label "Sacha"
+# The bootstrap script also seeds AUTHORIZED_SIGNERS values into
+# global_admins, attributed to the new app_admin. After that, manage all
+# tiers in-app at /admin/app-admins.
+
 # Substrate network config
 NETWORK_ENV=testnet
 AUTHORIZED_SIGNERS=

--- a/server/api/controllers/__tests__/admin-tiers.test.js
+++ b/server/api/controllers/__tests__/admin-tiers.test.js
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../repositories/app-admin.repository.js', () => ({
+  default: {
+    list: vi.fn(),
+    add: vi.fn(),
+    remove: vi.fn(),
+    count: vi.fn(),
+    isAppAdmin: vi.fn(),
+  },
+}));
+vi.mock('../../repositories/global-admin.repository.js', () => ({
+  default: { list: vi.fn(), add: vi.fn(), remove: vi.fn() },
+}));
+
+const appRepo = (await import('../../repositories/app-admin.repository.js')).default;
+const globalRepo = (await import('../../repositories/global-admin.repository.js')).default;
+const ctrl = await import('../admin-tiers.controller.js');
+
+const res = () => {
+  const r = {};
+  r.status = vi.fn(() => r);
+  r.json = vi.fn(() => r);
+  r.end = vi.fn(() => r);
+  return r;
+};
+
+const REQUESTING_ADMIN = { user: { chain: 'substrate', address: '5Alice', tier: 'app' } };
+
+describe('admin-tiers.controller — app admins', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('lists app admins', async () => {
+    appRepo.list.mockResolvedValue([{ wallet: '5A', label: 'Sacha' }]);
+    const r = res();
+    await ctrl.listAppAdmins({ ...REQUESTING_ADMIN }, r);
+    expect(r.status).toHaveBeenCalledWith(200);
+    expect(r.json).toHaveBeenCalledWith({ status: 'success', data: [{ wallet: '5A', label: 'Sacha' }] });
+  });
+
+  it('rejects add with invalid chain', async () => {
+    const r = res();
+    await ctrl.addAppAdmin(
+      { ...REQUESTING_ADMIN, body: { walletChain: 'bitcoin', wallet: '5A' } },
+      r,
+    );
+    expect(r.status).toHaveBeenCalledWith(422);
+    expect(appRepo.add).not.toHaveBeenCalled();
+  });
+
+  it('rejects add with empty wallet', async () => {
+    const r = res();
+    await ctrl.addAppAdmin(
+      { ...REQUESTING_ADMIN, body: { walletChain: 'substrate', wallet: '' } },
+      r,
+    );
+    expect(r.status).toHaveBeenCalledWith(422);
+  });
+
+  it('returns 422 when repo rejects address normalization', async () => {
+    appRepo.add.mockResolvedValue(null);
+    const r = res();
+    await ctrl.addAppAdmin(
+      { ...REQUESTING_ADMIN, body: { walletChain: 'ethereum', wallet: 'not-an-address' } },
+      r,
+    );
+    expect(r.status).toHaveBeenCalledWith(422);
+  });
+
+  it('records addedBy from the calling admin', async () => {
+    appRepo.add.mockImplementation((p) => Promise.resolve({ ...p }));
+    const r = res();
+    await ctrl.addAppAdmin(
+      { ...REQUESTING_ADMIN, body: { walletChain: 'substrate', wallet: '5Bob', label: 'Bob' } },
+      r,
+    );
+    expect(appRepo.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        walletChain: 'substrate',
+        wallet: '5Bob',
+        label: 'Bob',
+        addedBy: 'substrate:5Alice',
+      }),
+    );
+    expect(r.status).toHaveBeenCalledWith(201);
+  });
+
+  it('refuses to remove the last app admin', async () => {
+    appRepo.count.mockResolvedValue(1);
+    const r = res();
+    await ctrl.removeAppAdmin(
+      { params: { wallet: '5Alice' }, query: { chain: 'substrate' }, user: REQUESTING_ADMIN.user },
+      r,
+    );
+    expect(r.status).toHaveBeenCalledWith(409);
+    expect(appRepo.remove).not.toHaveBeenCalled();
+  });
+
+  it('allows removing one when ≥ 2 app admins exist', async () => {
+    appRepo.count.mockResolvedValue(2);
+    appRepo.remove.mockResolvedValue(true);
+    const r = res();
+    await ctrl.removeAppAdmin(
+      { params: { wallet: '5Bob' }, query: { chain: 'substrate' }, user: REQUESTING_ADMIN.user },
+      r,
+    );
+    expect(appRepo.remove).toHaveBeenCalledWith('substrate', '5Bob');
+    expect(r.status).toHaveBeenCalledWith(204);
+  });
+});
+
+describe('admin-tiers.controller — global admins', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('lists global admins', async () => {
+    globalRepo.list.mockResolvedValue([{ wallet: '5G' }]);
+    const r = res();
+    await ctrl.listGlobalAdmins({ ...REQUESTING_ADMIN }, r);
+    expect(r.status).toHaveBeenCalledWith(200);
+  });
+
+  it('does NOT enforce a last-one guard on global admins', async () => {
+    // Distinct from app_admins — global_admins can be cleared, env fallback
+    // still provides at least one admin path.
+    globalRepo.remove.mockResolvedValue(true);
+    const r = res();
+    await ctrl.removeGlobalAdmin(
+      { params: { wallet: '5Bob' }, query: { chain: 'substrate' }, user: REQUESTING_ADMIN.user },
+      r,
+    );
+    expect(appRepo.count).not.toHaveBeenCalled();
+    expect(globalRepo.remove).toHaveBeenCalled();
+    expect(r.status).toHaveBeenCalledWith(204);
+  });
+});

--- a/server/api/controllers/__tests__/program-signup.test.js
+++ b/server/api/controllers/__tests__/program-signup.test.js
@@ -13,7 +13,7 @@ vi.mock('../../services/program-signup.service.js', () => ({
   },
 }));
 vi.mock('../../repositories/program-signup.repository.js', () => ({
-  default: { findById: vi.fn() },
+  default: { findById: vi.fn(), lastImportedAt: vi.fn().mockResolvedValue(null) },
 }));
 vi.mock('../../services/program-application.service.js', () => ({
   default: { listByProgram: vi.fn(), listByProject: vi.fn(), findOne: vi.fn(), create: vi.fn() },

--- a/server/api/controllers/admin-tiers.controller.js
+++ b/server/api/controllers/admin-tiers.controller.js
@@ -1,0 +1,108 @@
+import appAdminRepository from '../repositories/app-admin.repository.js';
+import globalAdminRepository from '../repositories/global-admin.repository.js';
+
+const VALID_CHAINS = ['substrate', 'ethereum', 'solana'];
+
+function pickRepo(tier) {
+  if (tier === 'app') return appAdminRepository;
+  if (tier === 'global') return globalAdminRepository;
+  return null;
+}
+
+function listFor(tier) {
+  const repo = pickRepo(tier);
+  return async (req, res) => {
+    try {
+      const rows = await repo.list();
+      res.status(200).json({ status: 'success', data: rows });
+    } catch (error) {
+      console.error(`❌ Error listing ${tier} admins:`, error);
+      res.status(500).json({ status: 'error', message: `Failed to list ${tier} admins` });
+    }
+  };
+}
+
+function addFor(tier) {
+  const repo = pickRepo(tier);
+  return async (req, res) => {
+    try {
+      const { walletChain, wallet, label } = req.body || {};
+      if (!VALID_CHAINS.includes(walletChain)) {
+        return res.status(422).json({
+          status: 'error',
+          message: `walletChain must be one of: ${VALID_CHAINS.join(', ')}`,
+        });
+      }
+      if (typeof wallet !== 'string' || !wallet.trim()) {
+        return res.status(422).json({ status: 'error', message: 'wallet is required' });
+      }
+      if (label !== undefined && label !== null && (typeof label !== 'string' || label.length > 100)) {
+        return res.status(422).json({ status: 'error', message: 'label must be ≤ 100 chars' });
+      }
+      const addedBy = req.user
+        ? `${req.user.chain || 'unknown'}:${req.user.address}`
+        : null;
+      const created = await repo.add({
+        walletChain,
+        wallet: wallet.trim(),
+        label: label?.trim() || null,
+        addedBy,
+      });
+      if (!created) {
+        return res.status(422).json({
+          status: 'error',
+          message: `Invalid ${walletChain} wallet address`,
+        });
+      }
+      res.status(201).json({ status: 'success', data: created });
+    } catch (error) {
+      console.error(`❌ Error adding ${tier} admin:`, error);
+      res.status(500).json({ status: 'error', message: `Failed to add ${tier} admin` });
+    }
+  };
+}
+
+function removeFor(tier) {
+  const repo = pickRepo(tier);
+  return async (req, res) => {
+    try {
+      const { wallet } = req.params;
+      const walletChain = req.query.chain;
+      if (!VALID_CHAINS.includes(walletChain)) {
+        return res.status(422).json({
+          status: 'error',
+          message: `chain query param must be one of: ${VALID_CHAINS.join(', ')}`,
+        });
+      }
+      // Tier-0 self-removal guard: don't let the last app_admin remove themselves.
+      if (tier === 'app') {
+        const count = await appAdminRepository.count();
+        if (count <= 1) {
+          return res.status(409).json({
+            status: 'error',
+            message: 'Cannot remove the last app admin. Add another one first.',
+          });
+        }
+      }
+      const removed = await repo.remove(walletChain, wallet);
+      if (!removed) {
+        return res.status(422).json({
+          status: 'error',
+          message: `Invalid ${walletChain} wallet address`,
+        });
+      }
+      res.status(204).end();
+    } catch (error) {
+      console.error(`❌ Error removing ${tier} admin:`, error);
+      res.status(500).json({ status: 'error', message: `Failed to remove ${tier} admin` });
+    }
+  };
+}
+
+export const listAppAdmins = listFor('app');
+export const addAppAdmin = addFor('app');
+export const removeAppAdmin = removeFor('app');
+
+export const listGlobalAdmins = listFor('global');
+export const addGlobalAdmin = addFor('global');
+export const removeGlobalAdmin = removeFor('global');

--- a/server/api/controllers/program.controller.js
+++ b/server/api/controllers/program.controller.js
@@ -464,10 +464,11 @@ class ProgramController {
         return res.status(404).json({ status: 'error', message: 'Program not found' });
       }
       const signups = await programSignupService.listByProgramId(program.id);
+      const lastImportedAt = await programSignupRepository.lastImportedAt(program.id);
       res.status(200).json({
         status: 'success',
         data: signups,
-        meta: { count: signups.length },
+        meta: { count: signups.length, lastImportedAt },
       });
     } catch (error) {
       console.error('❌ Error listing program signups:', error);

--- a/server/api/middleware/__tests__/auth.middleware.test.js
+++ b/server/api/middleware/__tests__/auth.middleware.test.js
@@ -62,6 +62,18 @@ vi.mock('../../repositories/program-admin.repository.js', () => ({
   },
 }));
 
+vi.mock('../../repositories/app-admin.repository.js', () => ({
+  default: {
+    isAppAdmin: vi.fn().mockResolvedValue(false),
+  },
+}));
+
+vi.mock('../../repositories/global-admin.repository.js', () => ({
+  default: {
+    isGlobalAdmin: vi.fn().mockResolvedValue(false),
+  },
+}));
+
 // Now import what we need
 import { verifySIWS, parseMessage } from '@talismn/siws';
 import { signatureVerify, decodeAddress } from '@polkadot/util-crypto';

--- a/server/api/middleware/__tests__/wallet-contact.middleware.test.js
+++ b/server/api/middleware/__tests__/wallet-contact.middleware.test.js
@@ -45,6 +45,14 @@ vi.mock('../../repositories/program.repository.js', () => ({
   default: { findBySlug: vi.fn() },
 }));
 
+vi.mock('../../repositories/app-admin.repository.js', () => ({
+  default: { isAppAdmin: vi.fn().mockResolvedValue(false) },
+}));
+
+vi.mock('../../repositories/global-admin.repository.js', () => ({
+  default: { isGlobalAdmin: vi.fn().mockResolvedValue(false) },
+}));
+
 vi.mock('../../repositories/program-admin.repository.js', () => ({
   default: { isAdmin: vi.fn() },
 }));

--- a/server/api/middleware/auth.middleware.js
+++ b/server/api/middleware/auth.middleware.js
@@ -25,6 +25,20 @@ import { consumeNonce } from '../auth/nonceStore.js';
 import { extractBearerToken, verifySessionToken } from '../auth/sessionToken.js';
 import programRepository from '../repositories/program.repository.js';
 import programAdminRepository from '../repositories/program-admin.repository.js';
+import appAdminRepository from '../repositories/app-admin.repository.js';
+import globalAdminRepository from '../repositories/global-admin.repository.js';
+
+/**
+ * Admin = signer is an app_admin (tier 0) OR a global_admin (tier 1)
+ * OR an entry in the legacy AUTHORIZED_SIGNERS env. Env stays as a
+ * fallback so an unsynced DB never locks out the team.
+ */
+async function isAdminWallet(chain, address) {
+  if (isAuthorizedSigner(chain, address)) return true;
+  if (await appAdminRepository.isAppAdmin(chain, address)) return true;
+  if (await globalAdminRepository.isGlobalAdmin(chain, address)) return true;
+  return false;
+}
 
 dotenv.config();
 
@@ -261,22 +275,50 @@ export const requireAdmin = async (req, res, next) => {
   }
 
   const signerAddress = auth.parsed.address;
-  if (!isAuthorizedSigner(auth.chain, signerAddress)) {
-    logError(`Authorization failed: ${signerAddress} is not authorized for multisig ${CURRENT_MULTISIG}`);
+  if (!(await isAdminWallet(auth.chain, signerAddress))) {
+    logError(`Authorization failed: ${signerAddress} is not an admin (app/global/env)`);
     return res.status(403).json({
       status: 'error',
-      message: 'Address is not authorized to sign for the multisig',
+      message: 'Address is not authorized as an admin',
       multisig: CURRENT_MULTISIG,
       network: NETWORK_CONFIG.networkName,
     });
   }
 
-  logSuccess(`Authorized signer ${signerAddress} can sign for multisig ${CURRENT_MULTISIG}`);
+  logSuccess(`Admin ${signerAddress} authorized`);
   req.user = {
     address: signerAddress,
     multisig: CURRENT_MULTISIG,
     network: NETWORK_CONFIG.environment,
   };
+  return next();
+};
+
+/**
+ * App admin only — tier 0. Used by the `/api/app-admins` routes that
+ * manage the admin lists themselves.
+ */
+export const requireAppAdmin = async (req, res, next) => {
+  log(`Initiating app-admin verification for ${req.method} ${req.originalUrl}`);
+  const auth = await resolveAuthIdentity(req, { checkDomain: true });
+  if (!auth.ok) {
+    return res.status(auth.status).json(auth.body);
+  }
+  if (auth.devBypass) {
+    req.user = { address: auth.parsed.address, chain: 'substrate', tier: 'app' };
+    return next();
+  }
+  const signerAddress = auth.parsed.address;
+  const ok = await appAdminRepository.isAppAdmin(auth.chain, signerAddress);
+  if (!ok) {
+    logError(`${signerAddress} is not an app_admin`);
+    return res.status(403).json({
+      status: 'error',
+      message: 'Only app admins can manage the admin lists',
+    });
+  }
+  logSuccess(`App admin ${signerAddress} authorized`);
+  req.user = { address: signerAddress, chain: auth.chain, tier: 'app' };
   return next();
 };
 
@@ -306,9 +348,9 @@ export const requireTeamMemberOrAdmin = async (req, res, next) => {
 
   const signerAddress = auth.parsed.address;
 
-  // Authorized multisig signers are always allowed.
-  if (isAuthorizedSigner(auth.chain, signerAddress)) {
-    logSuccess(`Signer ${signerAddress} is authorized for multisig. Granting access.`);
+  // Any admin tier (app/global/env) is always allowed.
+  if (await isAdminWallet(auth.chain, signerAddress)) {
+    logSuccess(`Signer ${signerAddress} is an admin. Granting access.`);
     req.user = {
       address: signerAddress,
       multisig: CURRENT_MULTISIG,
@@ -428,8 +470,8 @@ export const requireProgramAdmin = (slugParam = 'slug') => async (req, res, next
 
   const signerAddress = auth.parsed.address;
 
-  // Global authorized signers always pass.
-  if (isAuthorizedSigner(auth.chain, signerAddress)) {
+  // Any admin tier (app/global/env) always passes.
+  if (await isAdminWallet(auth.chain, signerAddress)) {
     logSuccess(`Global admin ${signerAddress} accessing program "${slug}".`);
     req.user = { address: signerAddress, chain: auth.chain, programSlug: slug, isGlobalAdmin: true };
     return next();

--- a/server/api/repositories/app-admin.repository.js
+++ b/server/api/repositories/app-admin.repository.js
@@ -1,0 +1,79 @@
+import { supabase } from '../../db.js';
+import { normalizeAddress } from '../auth/normalize.js';
+
+const transform = (row) => {
+  if (!row) return null;
+  return {
+    walletChain: row.wallet_chain,
+    wallet: row.wallet,
+    label: row.label,
+    addedBy: row.added_by,
+    createdAt: row.created_at,
+  };
+};
+
+class AppAdminRepository {
+  async list() {
+    const { data, error } = await supabase
+      .from('app_admins')
+      .select('*')
+      .order('created_at', { ascending: true });
+    if (error) throw error;
+    return (data || []).map(transform);
+  }
+
+  async add({ walletChain, wallet, label, addedBy }) {
+    const normalized = normalizeAddress(walletChain, wallet);
+    if (!normalized) return null;
+    const { data, error } = await supabase
+      .from('app_admins')
+      .upsert(
+        {
+          wallet_chain: walletChain,
+          wallet: normalized,
+          label: label ?? null,
+          added_by: addedBy ?? null,
+        },
+        { onConflict: 'wallet_chain,wallet' },
+      )
+      .select('*')
+      .single();
+    if (error) throw error;
+    return transform(data);
+  }
+
+  async remove(walletChain, wallet) {
+    const normalized = normalizeAddress(walletChain, wallet);
+    if (!normalized) return false;
+    const { error } = await supabase
+      .from('app_admins')
+      .delete()
+      .eq('wallet_chain', walletChain)
+      .eq('wallet', normalized);
+    if (error) throw error;
+    return true;
+  }
+
+  async isAppAdmin(walletChain, wallet) {
+    const normalized = normalizeAddress(walletChain, wallet);
+    if (!normalized) return false;
+    const { data, error } = await supabase
+      .from('app_admins')
+      .select('wallet')
+      .eq('wallet_chain', walletChain)
+      .eq('wallet', normalized)
+      .maybeSingle();
+    if (error) throw error;
+    return !!data;
+  }
+
+  async count() {
+    const { count, error } = await supabase
+      .from('app_admins')
+      .select('*', { count: 'exact', head: true });
+    if (error) throw error;
+    return count ?? 0;
+  }
+}
+
+export default new AppAdminRepository();

--- a/server/api/repositories/global-admin.repository.js
+++ b/server/api/repositories/global-admin.repository.js
@@ -1,0 +1,71 @@
+import { supabase } from '../../db.js';
+import { normalizeAddress } from '../auth/normalize.js';
+
+const transform = (row) => {
+  if (!row) return null;
+  return {
+    walletChain: row.wallet_chain,
+    wallet: row.wallet,
+    label: row.label,
+    addedBy: row.added_by,
+    createdAt: row.created_at,
+  };
+};
+
+class GlobalAdminRepository {
+  async list() {
+    const { data, error } = await supabase
+      .from('global_admins')
+      .select('*')
+      .order('created_at', { ascending: true });
+    if (error) throw error;
+    return (data || []).map(transform);
+  }
+
+  async add({ walletChain, wallet, label, addedBy }) {
+    const normalized = normalizeAddress(walletChain, wallet);
+    if (!normalized) return null;
+    const { data, error } = await supabase
+      .from('global_admins')
+      .upsert(
+        {
+          wallet_chain: walletChain,
+          wallet: normalized,
+          label: label ?? null,
+          added_by: addedBy ?? null,
+        },
+        { onConflict: 'wallet_chain,wallet' },
+      )
+      .select('*')
+      .single();
+    if (error) throw error;
+    return transform(data);
+  }
+
+  async remove(walletChain, wallet) {
+    const normalized = normalizeAddress(walletChain, wallet);
+    if (!normalized) return false;
+    const { error } = await supabase
+      .from('global_admins')
+      .delete()
+      .eq('wallet_chain', walletChain)
+      .eq('wallet', normalized);
+    if (error) throw error;
+    return true;
+  }
+
+  async isGlobalAdmin(walletChain, wallet) {
+    const normalized = normalizeAddress(walletChain, wallet);
+    if (!normalized) return false;
+    const { data, error } = await supabase
+      .from('global_admins')
+      .select('wallet')
+      .eq('wallet_chain', walletChain)
+      .eq('wallet', normalized)
+      .maybeSingle();
+    if (error) throw error;
+    return !!data;
+  }
+}
+
+export default new GlobalAdminRepository();

--- a/server/api/repositories/program-signup.repository.js
+++ b/server/api/repositories/program-signup.repository.js
@@ -11,6 +11,7 @@ const transformSignup = (row) => {
     registeredAt: row.registered_at,
     source: row.source,
     rawRow: row.raw_row,
+    importedInBatchAt: row.imported_in_batch_at,
     createdAt: row.created_at,
   };
 };
@@ -53,6 +54,9 @@ class ProgramSignupRepository {
    */
   async insertMany(rows) {
     if (!rows.length) return [];
+    // Stamp every row in a batch with the same timestamp so admins can read
+    // "last imported X days ago" off MAX(imported_in_batch_at).
+    const batchAt = new Date().toISOString();
     const payload = rows.map((r) => ({
       program_id: r.programId,
       email: r.email,
@@ -61,6 +65,7 @@ class ProgramSignupRepository {
       registered_at: r.registeredAt ?? null,
       source: r.source || 'luma',
       raw_row: r.rawRow ?? null,
+      imported_in_batch_at: batchAt,
     }));
     const { data, error } = await supabase
       .from('program_signups')
@@ -68,6 +73,19 @@ class ProgramSignupRepository {
       .select('*');
     if (error) throw error;
     return (data || []).map(transformSignup);
+  }
+
+  async lastImportedAt(programId) {
+    const { data, error } = await supabase
+      .from('program_signups')
+      .select('imported_in_batch_at')
+      .eq('program_id', programId)
+      .not('imported_in_batch_at', 'is', null)
+      .order('imported_in_batch_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (error) throw error;
+    return data?.imported_in_batch_at ?? null;
   }
 
   async delete(id) {

--- a/server/api/routes/admin-tiers.routes.js
+++ b/server/api/routes/admin-tiers.routes.js
@@ -1,0 +1,41 @@
+import { Router } from 'express';
+import {
+  listAppAdmins, addAppAdmin, removeAppAdmin,
+  listGlobalAdmins, addGlobalAdmin, removeGlobalAdmin,
+} from '../controllers/admin-tiers.controller.js';
+import { requireAppAdmin } from '../middleware/auth.middleware.js';
+import appAdminRepository from '../repositories/app-admin.repository.js';
+import { resolveAuthIdentity } from '../middleware/auth.middleware.js';
+
+const router = Router();
+
+// Tier 0 — app_admins. Only app_admins can manage app_admins or global_admins.
+router.get('/app-admins', requireAppAdmin, listAppAdmins);
+router.post('/app-admins', requireAppAdmin, addAppAdmin);
+router.delete('/app-admins/:wallet', requireAppAdmin, removeAppAdmin);
+
+// Tier 1 — global_admins. Also gated to app_admins to manage.
+router.get('/global-admins', requireAppAdmin, listGlobalAdmins);
+router.post('/global-admins', requireAppAdmin, addGlobalAdmin);
+router.delete('/global-admins/:wallet', requireAppAdmin, removeGlobalAdmin);
+
+// Convenience: report whether the connected wallet is an app_admin so the
+// client can show/hide the /admin/app-admins nav item without forcing a
+// 403 round-trip. SIWS-gated (any signed-in wallet can ask about itself).
+router.get('/me/tier', async (req, res) => {
+  try {
+    const auth = await resolveAuthIdentity(req, { checkDomain: true });
+    if (!auth.ok) return res.status(auth.status).json(auth.body);
+    const { chain, parsed } = auth;
+    const isApp = await appAdminRepository.isAppAdmin(chain, parsed.address);
+    res.status(200).json({
+      status: 'success',
+      data: { isAppAdmin: isApp, chain, address: parsed.address },
+    });
+  } catch (error) {
+    console.error('❌ Error reading admin tier:', error);
+    res.status(500).json({ status: 'error', message: 'Failed to read admin tier' });
+  }
+});
+
+export default router;

--- a/server/package.json
+++ b/server/package.json
@@ -12,6 +12,7 @@
     "dev": "nodemon server.js",
     "seed:dev": "node scripts/seed-dev.js",
     "seed:dogfooding": "node scripts/seed-dogfooding-program.js",
+    "bootstrap:app-admin": "node scripts/bootstrap-app-admin.js",
     "generate:multisig": "node scripts/generate-multisig.js",
     "generate:test-account": "node scripts/generate-test-account.js",
     "db:purge": "mongosh blockspace-stadium --eval \"db.dropDatabase()\" --quiet",

--- a/server/scripts/bootstrap-app-admin.js
+++ b/server/scripts/bootstrap-app-admin.js
@@ -1,0 +1,136 @@
+/**
+ * One-time bootstrap for the app_admins table.
+ *
+ * Inserts a single wallet into app_admins, then seeds the existing
+ * AUTHORIZED_SIGNERS env values into global_admins (attributed to the new
+ * app_admin) so the in-app UI sees the existing admin whitelist on first
+ * login. Idempotent — safe to re-run.
+ *
+ * Usage:
+ *   node server/scripts/bootstrap-app-admin.js \
+ *     --chain substrate \
+ *     --address 5GrwvaEF... \
+ *     [--label "Sacha"] \
+ *     [--dry-run]
+ *
+ * Env required (from server/.env):
+ *   SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY
+ *
+ * After running once, the in-app `/admin/app-admins` page can add/remove
+ * additional app_admins — no need to re-run this script.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { normalizeAddress } from '../api/auth/normalize.js';
+import { parseAuthorizedSigners } from '../api/auth/authorizedSigners.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: resolve(__dirname, '..', '.env') });
+
+const clean = (s) => (s || '').replace(/[\n\r\s]+/g, '');
+const SUPABASE_URL = clean(process.env.SUPABASE_URL);
+const SUPABASE_KEY = clean(process.env.SUPABASE_SERVICE_ROLE_KEY);
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in server/.env.');
+  process.exit(1);
+}
+
+// --- arg parsing ---
+const args = process.argv.slice(2);
+const flag = (name) => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? args[i + 1] : null;
+};
+const dryRun = args.includes('--dry-run');
+const chain = (flag('chain') || '').toLowerCase();
+const address = flag('address');
+const label = flag('label');
+
+const VALID_CHAINS = ['substrate', 'ethereum', 'solana'];
+if (!VALID_CHAINS.includes(chain)) {
+  console.error(`--chain must be one of: ${VALID_CHAINS.join(', ')}`);
+  process.exit(2);
+}
+if (!address) {
+  console.error('--address is required');
+  process.exit(2);
+}
+const normalized = normalizeAddress(chain, address);
+if (!normalized) {
+  console.error(`Invalid ${chain} address: ${address}`);
+  process.exit(2);
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+async function main() {
+  console.log('--- bootstrap-app-admin ---');
+  console.log(`Mode:    ${dryRun ? 'DRY RUN (no writes)' : 'LIVE'}`);
+  console.log(`Chain:   ${chain}`);
+  console.log(`Wallet:  ${normalized}`);
+  console.log(`Label:   ${label || '(none)'}`);
+  console.log('');
+
+  // 1. Insert the app_admin (idempotent via PK).
+  const appAdminRow = {
+    wallet_chain: chain,
+    wallet: normalized,
+    label: label ?? null,
+    added_by: null, // bootstrap — no prior admin
+  };
+  if (dryRun) {
+    console.log('Would upsert into app_admins:');
+    console.log(`  ${JSON.stringify(appAdminRow)}`);
+  } else {
+    const { error: appErr } = await supabase
+      .from('app_admins')
+      .upsert(appAdminRow, { onConflict: 'wallet_chain,wallet' });
+    if (appErr) {
+      console.error('ERROR inserting app_admin:', appErr);
+      process.exit(3);
+    }
+    console.log(`✓ Upserted ${chain}:${normalized} into app_admins`);
+  }
+
+  // 2. Seed AUTHORIZED_SIGNERS env into global_admins (attributed to this app_admin).
+  const envRaw = process.env.AUTHORIZED_SIGNERS || process.env.ADMIN_WALLETS || '';
+  const envSigners = parseAuthorizedSigners(envRaw);
+  if (envSigners.length === 0) {
+    console.log('');
+    console.log('AUTHORIZED_SIGNERS env is empty; no global_admins to seed.');
+    return;
+  }
+  console.log('');
+  console.log(`Found ${envSigners.length} signer(s) in AUTHORIZED_SIGNERS env.`);
+
+  for (const signer of envSigners) {
+    const row = {
+      wallet_chain: signer.chain,
+      wallet: signer.normalized,
+      label: 'Imported from AUTHORIZED_SIGNERS',
+      added_by: `${chain}:${normalized}`,
+    };
+    if (dryRun) {
+      console.log(`  Would upsert into global_admins: ${signer.chain}:${signer.normalized}`);
+      continue;
+    }
+    const { error: gErr } = await supabase
+      .from('global_admins')
+      .upsert(row, { onConflict: 'wallet_chain,wallet' });
+    if (gErr) {
+      console.error(`  ERROR inserting global_admin ${signer.chain}:${signer.normalized}:`, gErr);
+      continue;
+    }
+    console.log(`  ✓ Upserted ${signer.chain}:${signer.normalized}`);
+  }
+}
+
+main().catch((e) => {
+  console.error('FATAL:', e);
+  process.exit(10);
+});

--- a/server/server.js
+++ b/server/server.js
@@ -5,6 +5,7 @@ import m2ProgramRoutes from './api/routes/m2-program.routes.js';
 import programRoutes from './api/routes/program.routes.js';
 import walletContactRoutes from './api/routes/wallet-contact.routes.js';
 import adminSessionRoutes from './api/routes/admin-session.routes.js';
+import adminTiersRoutes from './api/routes/admin-tiers.routes.js';
 import requestLogger from './api/middleware/logging.middleware.js';
 import { getAuthorizedAddresses, NETWORK_CONFIG } from './config/polkadot-config.js';
 
@@ -48,6 +49,7 @@ app.use('/api/m2-program', m2ProgramRoutes);
 app.use('/api/programs', programRoutes);
 app.use('/api/wallet-contacts', walletContactRoutes);
 app.use('/api/admin/session', adminSessionRoutes);
+app.use('/api/admin', adminTiersRoutes);
 
 // Backward compatibility: Keep old /api/projects route as alias
 // TODO: Remove after frontend migration is stable

--- a/supabase/migrations/20260521000000_app_admins_and_global_admins.sql
+++ b/supabase/migrations/20260521000000_app_admins_and_global_admins.sql
@@ -1,0 +1,47 @@
+-- App-level admin tiers + signup-import staleness signal.
+--
+-- Three-tier model (separate from treasury multisig signers in
+-- AUTHORIZED_SIGNERS env — which stays as a stricter concern):
+--
+--   Tier 0  app_admins      manage admins; bootstrap-seeded once
+--   Tier 1  global_admins   manage all programs across all events
+--   Tier 2  program_admins  manage one program (already exists, #95)
+--
+-- Both new tables use the same chain-tagged (wallet_chain, wallet) shape
+-- as program_admins so lookups stay symmetric.
+--
+-- Additive and idempotent — safe to re-run.
+
+CREATE TABLE IF NOT EXISTS app_admins (
+  wallet_chain TEXT NOT NULL CHECK (wallet_chain IN ('substrate', 'ethereum', 'solana')),
+  wallet       TEXT NOT NULL,
+  label        TEXT,
+  added_by     TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (wallet_chain, wallet)
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_admins_wallet
+  ON app_admins(wallet_chain, wallet);
+
+CREATE TABLE IF NOT EXISTS global_admins (
+  wallet_chain TEXT NOT NULL CHECK (wallet_chain IN ('substrate', 'ethereum', 'solana')),
+  wallet       TEXT NOT NULL,
+  label        TEXT,
+  added_by     TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (wallet_chain, wallet)
+);
+
+CREATE INDEX IF NOT EXISTS idx_global_admins_wallet
+  ON global_admins(wallet_chain, wallet);
+
+-- Signup-import staleness: ProgramSignupsSection shows "last imported X
+-- days ago" so admins know when Luma may have new entries. Existing rows
+-- are backfilled to created_at since that's the closest signal we have.
+ALTER TABLE program_signups
+  ADD COLUMN IF NOT EXISTS imported_in_batch_at TIMESTAMPTZ;
+
+UPDATE program_signups
+   SET imported_in_batch_at = created_at
+ WHERE imported_in_batch_at IS NULL;


### PR DESCRIPTION
Replaces the env-only admin whitelist with an in-app, 3-tier model so onboarding new admins doesn't require a Railway redeploy. Also surfaces CSV-import freshness on the signups section.

## Tiers

| Tier | Table | Role | Managed by |
|---|---|---|---|
| 0 | `app_admins` | Manage admin lists themselves | Bootstrap script, then in-app by other app_admins |
| 1 | `global_admins` | Administer every program | App admins (in-app) |
| 2 | `program_admins` | One program | Global admins (existing UI from #95) |

**Treasury multisig signing** in `payment.service.js` still uses `AUTHORIZED_SIGNERS` env directly — that's a separate concern from 'admin powers' and stays env-gated. The new `isAdminWallet` helper unions all three sources (app/global/env) so the env list keeps working as a fallback for any wallet not yet in the DB.

## Schema (`20260521000000_app_admins_and_global_admins.sql`)

- `app_admins (wallet_chain, wallet)` PK + label + added_by + created_at
- `global_admins` same shape
- `program_signups.imported_in_batch_at` TIMESTAMPTZ (backfilled to `created_at`)

All additive + idempotent.

## Bootstrap

```
npm run bootstrap:app-admin -- \
  --chain substrate --address <YOUR_ADDR> --label "Sacha"
```

One-time. Seeds you as the first app_admin, then walks `AUTHORIZED_SIGNERS` env and seeds each into `global_admins` attributed to the new app_admin (audit trail). After this, all tiers are managed in-app at `/admin/app-admins`.

## Server

- New repos: `app-admin.repository.js`, `global-admin.repository.js`
- `auth.middleware.js`:
  - `isAdminWallet(chain, address)` helper unions app + global + env
  - `requireAdmin` / `requireTeamMemberOrAdmin` / `requireProgramAdmin` promoted from `isAuthorizedSigner` → `isAdminWallet`
  - new `requireAppAdmin` for the `/admin/app-admins` routes
- `admin-tiers.controller.js` + `admin-tiers.routes.js` — list/add/remove for both tiers; tier-0 self-remove guard ('cannot remove the last app admin'); plus `GET /admin/me/tier` for the client nav probe (any signed-in wallet can ask if it's an app_admin)
- `program.controller.listSignups` returns `meta.lastImportedAt`
- `program-signup.repository.lastImportedAt(programId)` + every `insertMany` batch stamps `imported_in_batch_at = NOW()`

## Server tests

- `admin-tiers.test.js` (**9 cases**): list, add validation (chain / empty / malformed address), `addedBy` stamping, last-app-admin guard, global admins NOT subject to that guard.
- `auth.middleware.test.js` + `wallet-contact.middleware.test.js`: added mocks for app/global repos so the eager Supabase clients aren't built during test load.
- `program-signup.test.js` mock extended for `lastImportedAt`.
- **223 / 223** server tests passing (was 214; +9 new).

## Client

- New page `/admin/app-admins` (`AppAdminsPage.tsx`) — tier-0 console. Probes `/admin/me/tier` on mount; redirects non-app-admins to `/admin` with a toast. When ok, renders two `AdminTierSection` editors backed by the new API methods.
- `AdminTierSection.tsx` — shared editor; same chrome as `ProgramAdminsSection`; per-row label; confirm-before-delete; busy state per row.
- Nav link from `/admin` header (`ADMIN TIERS ▸`) — visible to everyone but the page itself gates.
- `ProgramSignupsSection` — reads `meta.lastImportedAt`; chips header with 'LAST IMPORTED X DAYS AGO'; once ≥ 7 days, switches to amber + shows a 'Luma may have new signups — pull a fresh CSV and re-import' block above the import form.
- `api.ts`: `getMyAdminTier`, `listAppAdmins` / `addAppAdmin` / `removeAppAdmin`, `listGlobalAdmins` / `addGlobalAdmin` / `removeGlobalAdmin`. All accept the same `AdminAuthArg` (bearer or one-shot SIWS) used elsewhere.
- `ApiProgramSignup` gains `importedInBatchAt`; mock `listProgramSignups` computes the MAX in JS for preview-mode parity.

## Verification

- `cd client && npm run build` → clean (tsc + vite)
- `cd client && npm run lint --max-warnings 0` → 0 warnings / 0 errors
- `cd server && npm test` → 223 / 223

## Migration + deploy steps

1. Apply `20260521000000_app_admins_and_global_admins.sql` to prod Supabase (`supabase db push --linked`)
2. Merge this PR; Railway auto-deploys server code
3. **Run bootstrap-app-admin against prod ONCE** to seed yourself + migrate env to global_admins
4. `/admin/app-admins` page is live for that wallet

The env fallback (`AUTHORIZED_SIGNERS`) keeps every existing flow working even before step 3 — no rush window where prod is locked out.

## Test scenarios

- After bootstrap: visit `/admin` with your wallet → see 'ADMIN TIERS ▸' link → click it → `/admin/app-admins` renders both tiers; first list shows you, second list shows the seeded global admins.
- Add a wallet to global_admins → they can immediately administer every program.
- Try to remove the last app_admin → 409 'Cannot remove the last app admin'. Add a second one first → removing either now works.
- A non-app-admin wallet visiting `/admin/app-admins` → toast + redirect to `/admin` within ~1s.
- On `/admin/programs/bitrefill-2026`, the SIGNUPS section header shows 'LAST IMPORTED N DAYS AGO'. Manually backdate a row's `imported_in_batch_at` by 8 days → amber 'Luma may have new signups' nudge appears. Import a fresh CSV → chip resets to TODAY, nudge gone.

## Risks

- **Bootstrap script must run on prod.** Until it does, the new `/admin/app-admins` page returns 403 to everyone (no app_admins exist yet). The rest of the system keeps working via the env fallback.
- **Schema migration is required.** Without it, the new endpoints 500. Same operational discipline as #102 / #103 / #105.

Targets `develop`. Draft for review.