### PR TITLE
feat(admin): onboarding empty-state + invite-copy button

### DIFF
--- a/client/src/components/admin/AdminTierSection.tsx
+++ b/client/src/components/admin/AdminTierSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
-import { Trash2, Loader2 } from "lucide-react";
+import { Trash2, Loader2, Copy, Check } from "lucide-react";
 import { api, type ApiAdminTierEntry, type AdminAuthArg, ApiError } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
 
@@ -34,6 +34,7 @@ export function AdminTierSection({
   const [loading, setLoading] = useState(false);
   const [adding, setAdding] = useState(false);
   const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
   const [wallet, setWallet] = useState("");
   const [label, setLabel] = useState("");
   const [chain, setChain] = useState<ChainOption>("substrate");
@@ -88,6 +89,32 @@ export function AdminTierSection({
     }
   };
 
+  const handleCopyInvite = async (entry: ApiAdminTierEntry) => {
+    const key = `${entry.walletChain}:${entry.wallet}`;
+    const origin = typeof window !== "undefined" ? window.location.origin : "https://stadium.joinwebzero.com";
+    const tierLabel = title.toLowerCase();
+    const message =
+      `You're an admin on Stadium 🛰️\n\n` +
+      `Tier: ${tierLabel}\n` +
+      `Chain: ${entry.walletChain}\n` +
+      `Wallet: ${entry.wallet}\n` +
+      `Sign in: ${origin}/admin\n\n` +
+      `If you haven't already, install the wallet extension for your chain (Polkadot-JS, MetaMask, or Phantom) ` +
+      `and connect on the admin page. From there you can manage programs, sponsors, and signups.`;
+    try {
+      await navigator.clipboard.writeText(message);
+      setCopiedKey(key);
+      toast({ title: "Invite copied to clipboard" });
+      setTimeout(() => setCopiedKey((k) => (k === key ? null : k)), 2000);
+    } catch {
+      toast({
+        title: "Couldn't copy",
+        description: "Clipboard access denied — copy the wallet manually.",
+        variant: "destructive",
+      });
+    }
+  };
+
   const handleRemove = async (entry: ApiAdminTierEntry) => {
     const key = `${entry.walletChain}:${entry.wallet}`;
     if (!confirm(`Remove ${entry.label || entry.wallet}?`)) return;
@@ -138,16 +165,28 @@ export function AdminTierSection({
                     {a.addedBy ? ` · ADDED BY ${a.addedBy.toUpperCase()}` : ""}
                   </p>
                 </div>
-                <button
-                  type="button"
-                  onClick={() => handleRemove(a)}
-                  disabled={busyKey === key}
-                  aria-label={`Remove ${a.wallet}`}
-                  className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-destructive hover:bg-destructive/10 disabled:opacity-50 px-2 py-1 inline-flex items-center gap-1"
-                >
-                  {busyKey === key ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
-                  REMOVE
-                </button>
+                <div className="flex items-center gap-1.5 flex-shrink-0">
+                  <button
+                    type="button"
+                    onClick={() => handleCopyInvite(a)}
+                    aria-label={`Copy invite for ${a.wallet}`}
+                    title="Copy a pre-formatted invite message"
+                    className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep px-2 py-1 inline-flex items-center gap-1"
+                  >
+                    {copiedKey === key ? <Check className="h-3 w-3 text-led" /> : <Copy className="h-3 w-3" />}
+                    {copiedKey === key ? "COPIED" : "COPY INVITE"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(a)}
+                    disabled={busyKey === key}
+                    aria-label={`Remove ${a.wallet}`}
+                    className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-destructive hover:bg-destructive/10 disabled:opacity-50 px-2 py-1 inline-flex items-center gap-1"
+                  >
+                    {busyKey === key ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
+                    REMOVE
+                  </button>
+                </div>
               </li>
             );
           })}

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -393,6 +393,37 @@ const AdminPage = () => {
           <LCDStat value={fmtUSD(totalPaidUsd)} label="Paid Out" size="sm" showLED />
         </div>
 
+        {/* Empty-state CTA — only shown when there are no projects yet. Gives
+            a fresh admin (or a first-time event organiser) a single obvious
+            place to start instead of an empty PROGRAMS table. */}
+        {!loading && projects.length === 0 && (
+          <section className="panel p-6 mb-4 text-center">
+            <div className="label-hw-dim mb-3">·WELCOME, ADMIN</div>
+            <h2 className="font-display text-2xl md:text-3xl uppercase tracking-tight text-display mb-3">
+              Create your first event
+            </h2>
+            <p className="text-body text-sm max-w-md mx-auto mb-5">
+              Stadium tracks events end-to-end: applications, sponsors, signups, payouts.
+              Spin up your program now and start onboarding builders.
+            </p>
+            <div className="flex flex-wrap gap-2 justify-center">
+              <button
+                type="button"
+                onClick={() => setShowCreateProjectModal(true)}
+                className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim px-4 py-2"
+              >
+                <Plus className="h-3 w-3" /> CREATE PROJECT
+              </button>
+              <Link
+                to="/admin/app-admins"
+                className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep px-4 py-2"
+              >
+                ADMIN TIERS ▸
+              </Link>
+            </div>
+          </section>
+        )}
+
         {/* Pending Review */}
         <section className="panel p-4 mb-4">
           <div className="flex items-center gap-2 mb-3 pb-3 border-b border-hairline-subtle">


### PR DESCRIPTION
Two small adds for fresh-admin onboarding. Part of the pre-rehearsal sprint; will be batched into one develop→main release PR with the next 3 features.

## What changed

1. **Empty-state CTA on `/admin`** when there are no projects yet — instead of showing an empty programs table, renders a centered 'Create your first event' card with CREATE PROJECT + ADMIN TIERS buttons.
2. **COPY INVITE button** next to every entry on `/admin/app-admins` (for both tiers). Copies a pre-formatted plain-text invite to the clipboard (tier, chain, wallet, sign-in URL, install hint). Brief 'COPIED' confirmation; destructive toast if browser denies clipboard access.

## Files

- `client/src/pages/AdminPage.tsx` — empty-state section
- `client/src/components/admin/AdminTierSection.tsx` — `handleCopyInvite` + per-row button

No schema, no env, no API surface change.

## Verification

- `npm run build` → clean
- `npm run lint --max-warnings 0` → 0 warnings / 0 errors

Targets `develop`. Draft for review.