### PR TITLE
feat(programs): unified inbox + CSV export per program

### DIFF
--- a/client/src/components/admin/ProgramInboxSection.tsx
+++ b/client/src/components/admin/ProgramInboxSection.tsx
@@ -1,0 +1,201 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Loader2, Download } from "lucide-react";
+import { api, type ApiInboxEntry, type AdminAuthArg, ApiError } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+
+type Filter = "all" | "signup" | "application";
+
+const formatDate = (iso?: string | null) => {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+};
+
+const truncate = (s?: string | null, n = 22) => {
+  if (!s) return "—";
+  if (s.length <= n) return s;
+  return `${s.slice(0, Math.max(2, n - 4))}…${s.slice(-4)}`;
+};
+
+/**
+ * Unified per-program inbox — merges signups (Luma CSV imports) and
+ * applications (project teams that applied in-app) into one table. Lets
+ * admins triage both streams in one place and export to CSV for sharing
+ * with sponsors.
+ */
+export function ProgramInboxSection({
+  programSlug,
+  signAuthHeader,
+}: {
+  programSlug: string;
+  signAuthHeader: () => Promise<AdminAuthArg>;
+}) {
+  const { toast } = useToast();
+  const [entries, setEntries] = useState<ApiInboxEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [exporting, setExporting] = useState(false);
+  const [filter, setFilter] = useState<Filter>("all");
+  const [meta, setMeta] = useState({ total: 0, signups: 0, applications: 0 });
+
+  const load = useCallback(() => {
+    let active = true;
+    setLoading(true);
+    (async () => {
+      try {
+        const auth = await signAuthHeader();
+        const r = await api.listProgramInbox(programSlug, auth);
+        if (!active) return;
+        setEntries(r.data);
+        setMeta(r.meta);
+      } catch (e) {
+        if (!active) return;
+        toast({
+          title: "Couldn't load inbox",
+          description: e instanceof ApiError ? e.message : (e as Error)?.message,
+          variant: "destructive",
+        });
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => { active = false; };
+  }, [programSlug, signAuthHeader, toast]);
+
+  useEffect(() => {
+    const cleanup = load();
+    return cleanup;
+  }, [load]);
+
+  const filtered = useMemo(
+    () => (filter === "all" ? entries : entries.filter((e) => e.source === filter)),
+    [entries, filter],
+  );
+
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      const auth = await signAuthHeader();
+      const blob = await api.exportProgramInboxCsv(programSlug, auth);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${programSlug}-inbox-${new Date().toISOString().slice(0, 10)}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      toast({ title: "Inbox CSV downloaded" });
+    } catch (e) {
+      toast({
+        title: "Couldn't export inbox",
+        description: e instanceof ApiError ? e.message : (e as Error)?.message,
+        variant: "destructive",
+      });
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  return (
+    <div className="panel p-4 mb-3">
+      <div className="flex items-center justify-between mb-3 pb-3 border-b border-hairline-subtle flex-wrap gap-2">
+        <div className="flex items-center gap-3 flex-wrap">
+          <span className="label-hw text-display">·INBOX</span>
+          <span className="lcd px-2 py-[1px] font-mono text-[10px] text-display tabular-nums">
+            {meta.total}
+          </span>
+          <span className="label-hw-dim">
+            ·{meta.signups} SIGNUP{meta.signups === 1 ? "" : "S"} · {meta.applications} APPLICATION
+            {meta.applications === 1 ? "" : "S"}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="inline-flex border border-hairline divide-x divide-hairline">
+            {(["all", "signup", "application"] as Filter[]).map((f) => (
+              <button
+                key={f}
+                type="button"
+                onClick={() => setFilter(f)}
+                className={
+                  filter === f
+                    ? "font-mono text-[10px] tracking-[0.14em] bg-display text-shell px-2 py-1"
+                    : "font-mono text-[10px] tracking-[0.14em] text-display hover:bg-panel-deep px-2 py-1"
+                }
+              >
+                {f.toUpperCase()}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={handleExport}
+            disabled={exporting || meta.total === 0}
+            className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-3 py-1"
+          >
+            {exporting ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <Download className="h-3 w-3" />
+            )}
+            EXPORT CSV
+          </button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 label-hw-dim py-4">
+          <Loader2 className="h-3 w-3 animate-spin" /> LOADING INBOX…
+        </div>
+      ) : filtered.length === 0 ? (
+        <p className="text-body text-sm py-2">
+          {meta.total === 0
+            ? "Empty inbox. Import a Luma CSV or wait for project applications."
+            : `No ${filter} entries match.`}
+        </p>
+      ) : (
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between label-hw-dim px-1">
+            <span>·SOURCE · NAME · IDENTIFIER</span>
+            <span>STATUS · WHEN</span>
+          </div>
+          {filtered.map((e) => (
+            <div
+              key={`${e.source}-${e.id}`}
+              className="lcd px-3 py-2 flex items-center justify-between gap-3"
+            >
+              <div className="min-w-0 flex-1 flex items-center gap-2">
+                <span
+                  className={
+                    e.source === "signup"
+                      ? "border border-hairline text-label-mid px-1.5 py-[1px] font-mono text-[9px] tracking-[0.12em] uppercase"
+                      : "border border-display text-display bg-panel-deep px-1.5 py-[1px] font-mono text-[9px] tracking-[0.12em] uppercase"
+                  }
+                >
+                  {e.source}
+                </span>
+                <div className="min-w-0">
+                  <div className="font-mono text-[12px] text-display truncate">
+                    {e.name || "—"}
+                  </div>
+                  <div className="label-hw-dim truncate">
+                    {e.identifier}
+                    {e.wallet ? ` · ${truncate(e.wallet)}` : ""}
+                  </div>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 flex-shrink-0 text-right">
+                {e.status && (
+                  <span className="label-hw text-display">{e.status.toUpperCase()}</span>
+                )}
+                <span className="font-mono text-[10px] text-label-mid tabular-nums">
+                  {formatDate(e.when).toUpperCase()}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -203,6 +203,19 @@ export type ApiProgramAdmin = {
   createdAt: string;
 };
 
+/** One row in the unified program inbox (signups + applications merged). */
+export type ApiInboxEntry = {
+  source: "signup" | "application";
+  id: string;
+  when: string | null;
+  name: string | null;
+  email: string | null;
+  identifier: string;
+  status: string | null;
+  wallet: string | null;
+  walletChain: string | null;
+};
+
 /** Tier-0 / tier-1 admin record. Same shape for both tables. */
 export type ApiAdminTierEntry = {
   walletChain: "substrate" | "ethereum" | "solana";
@@ -1580,6 +1593,47 @@ export const api = {
       `/admin/global-admins/${encodeURIComponent(wallet)}?chain=${encodeURIComponent(walletChain)}`,
       { method: "DELETE", headers: adminAuthHeaders(authHeader) },
     );
+  },
+
+  // --- Program inbox (merged signups + applications) ---
+
+  listProgramInbox: async (
+    slug: string,
+    authHeader: AdminAuthArg,
+  ): Promise<{
+    status: string;
+    data: ApiInboxEntry[];
+    meta: { total: number; signups: number; applications: number };
+  }> => {
+    if (USE_MOCK_DATA) {
+      // Mock mode returns an empty inbox — the underlying tables are
+      // mock-mode-only and unrelated. Real exercise happens on dev/prod.
+      return {
+        status: "success",
+        data: [],
+        meta: { total: 0, signups: 0, applications: 0 },
+      };
+    }
+    return request(`/programs/${encodeURIComponent(slug)}/inbox`, {
+      headers: adminAuthHeaders(authHeader),
+    });
+  },
+
+  /**
+   * Returns the same data as `listProgramInbox` serialised as CSV. Caller
+   * is expected to trigger a download via blob URL — see
+   * `ProgramInboxSection.handleExport` for the canonical flow.
+   */
+  exportProgramInboxCsv: async (slug: string, authHeader: AdminAuthArg): Promise<Blob> => {
+    if (USE_MOCK_DATA) {
+      return new Blob(["source,when,identifier,name,email,status,wallet\n"], { type: "text/csv" });
+    }
+    const url = `${API_BASE_URL}/programs/${encodeURIComponent(slug)}/inbox.csv`;
+    const res = await fetch(url, { headers: adminAuthHeaders(authHeader) });
+    if (!res.ok) {
+      throw new ApiError(`Inbox export failed (HTTP ${res.status})`, res.status);
+    }
+    return res.blob();
   },
 };
 

--- a/client/src/pages/AdminProgramPage.tsx
+++ b/client/src/pages/AdminProgramPage.tsx
@@ -14,6 +14,7 @@ import { ApplicationCard } from "@/components/admin/ApplicationCard";
 import { ProgramAdminsSection } from "@/components/admin/ProgramAdminsSection";
 import { ProgramSponsorsSection } from "@/components/admin/ProgramSponsorsSection";
 import { ProgramSignupsSection } from "@/components/admin/ProgramSignupsSection";
+import { ProgramInboxSection } from "@/components/admin/ProgramInboxSection";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 
@@ -240,6 +241,11 @@ const AdminProgramPage = () => {
                 />
 
                 <ProgramSignupsSection
+                  programSlug={program.slug}
+                  signAuthHeader={getAdminAuth}
+                />
+
+                <ProgramInboxSection
                   programSlug={program.slug}
                   signAuthHeader={getAdminAuth}
                 />

--- a/server/api/controllers/program.controller.js
+++ b/server/api/controllers/program.controller.js
@@ -2,6 +2,7 @@ import programService from '../services/program.service.js';
 import programApplicationService from '../services/program-application.service.js';
 import programSponsorService from '../services/program-sponsor.service.js';
 import programSignupService from '../services/program-signup.service.js';
+import programInboxService, { inboxToCsv } from '../services/program-inbox.service.js';
 import projectService from '../services/project.service.js';
 import notificationService from '../services/notification.service.js';
 import programAdminRepository from '../repositories/program-admin.repository.js';
@@ -544,6 +545,48 @@ class ProgramController {
     } catch (error) {
       console.error('❌ Error deleting program signup:', error);
       res.status(500).json({ status: 'error', message: 'Failed to delete program signup' });
+    }
+  }
+
+  // --- Inbox (merged signups + applications) ---
+
+  async listInbox(req, res) {
+    try {
+      const { slug } = req.params;
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const entries = await programInboxService.listInbox(program.id);
+      const signupCount = entries.filter((e) => e.source === 'signup').length;
+      const applicationCount = entries.length - signupCount;
+      res.status(200).json({
+        status: 'success',
+        data: entries,
+        meta: { total: entries.length, signups: signupCount, applications: applicationCount },
+      });
+    } catch (error) {
+      console.error('❌ Error listing program inbox:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to list program inbox' });
+    }
+  }
+
+  async exportInboxCsv(req, res) {
+    try {
+      const { slug } = req.params;
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const entries = await programInboxService.listInbox(program.id);
+      const csv = inboxToCsv(entries, { programSlug: slug });
+      const filename = `${slug}-inbox-${new Date().toISOString().slice(0, 10)}.csv`;
+      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      res.status(200).send(csv);
+    } catch (error) {
+      console.error('❌ Error exporting program inbox CSV:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to export program inbox' });
     }
   }
 }

--- a/server/api/routes/program.routes.js
+++ b/server/api/routes/program.routes.js
@@ -78,4 +78,9 @@ router.delete(
   programController.deleteSignup,
 );
 
+// --- Inbox (merged signups + applications) ---
+// Admin-only — both source rows are gated; the merge inherits that.
+router.get('/:slug/inbox', requireProgramAdmin('slug'), programController.listInbox);
+router.get('/:slug/inbox.csv', requireProgramAdmin('slug'), programController.exportInboxCsv);
+
 export default router;

--- a/server/api/services/__tests__/program-inbox.service.test.js
+++ b/server/api/services/__tests__/program-inbox.service.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../program-application.service.js', () => ({
+  default: { listByProgram: vi.fn() },
+}));
+vi.mock('../program-signup.service.js', () => ({
+  default: { listByProgramId: vi.fn() },
+}));
+vi.mock('../project.service.js', () => ({
+  default: { getProjectById: vi.fn() },
+}));
+
+const applicationService = (await import('../program-application.service.js')).default;
+const signupService = (await import('../program-signup.service.js')).default;
+const projectService = (await import('../project.service.js')).default;
+const { default: inboxService, inboxToCsv } = await import('../program-inbox.service.js');
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('listInbox', () => {
+  it('returns an empty array when there are no signups or applications', async () => {
+    signupService.listByProgramId.mockResolvedValue([]);
+    applicationService.listByProgram.mockResolvedValue([]);
+    const out = await inboxService.listInbox('bitrefill-2026');
+    expect(out).toEqual([]);
+  });
+
+  it('merges both sources and sorts newest first by `when`', async () => {
+    signupService.listByProgramId.mockResolvedValue([
+      { id: 's1', email: 'alice@x.com', name: 'Alice', registeredAt: '2026-05-10T00:00:00Z', wallet: '5A' },
+      { id: 's2', email: 'bob@x.com', name: 'Bob', registeredAt: '2026-05-15T00:00:00Z' },
+    ]);
+    applicationService.listByProgram.mockResolvedValue([
+      { id: 'a1', projectId: 'plata-mia', submittedAt: '2026-05-12T00:00:00Z', submittedBy: '5C', status: 'submitted' },
+    ]);
+    projectService.getProjectById.mockResolvedValue({ projectName: 'Plata Mia' });
+
+    const out = await inboxService.listInbox('bitrefill-2026');
+    expect(out).toHaveLength(3);
+    expect(out[0]).toMatchObject({ source: 'signup', identifier: 'bob@x.com' });          // 2026-05-15
+    expect(out[1]).toMatchObject({ source: 'application', identifier: 'plata-mia' });     // 2026-05-12
+    expect(out[2]).toMatchObject({ source: 'signup', identifier: 'alice@x.com' });        // 2026-05-10
+  });
+
+  it('enriches application rows with the project name (one fetch per unique projectId)', async () => {
+    signupService.listByProgramId.mockResolvedValue([]);
+    applicationService.listByProgram.mockResolvedValue([
+      { id: 'a1', projectId: 'plata-mia', submittedAt: '2026-05-12T00:00:00Z', submittedBy: '5C', status: 'submitted' },
+      { id: 'a2', projectId: 'plata-mia', submittedAt: '2026-05-13T00:00:00Z', submittedBy: '5C', status: 'submitted' },
+    ]);
+    projectService.getProjectById.mockResolvedValue({ projectName: 'Plata Mia' });
+
+    const out = await inboxService.listInbox('bitrefill-2026');
+    expect(out.every((e) => e.name === 'Plata Mia')).toBe(true);
+    // Both entries share the projectId — service should only round-trip once.
+    expect(projectService.getProjectById).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to projectId when project lookup fails', async () => {
+    signupService.listByProgramId.mockResolvedValue([]);
+    applicationService.listByProgram.mockResolvedValue([
+      { id: 'a1', projectId: 'missing-project', submittedAt: '2026-05-12T00:00:00Z', status: 'submitted' },
+    ]);
+    projectService.getProjectById.mockRejectedValue(new Error('not found'));
+
+    const out = await inboxService.listInbox('bitrefill-2026');
+    expect(out[0].name).toBe('missing-project');
+  });
+});
+
+describe('inboxToCsv', () => {
+  it('emits the header + each row + a slug stamp', () => {
+    const csv = inboxToCsv(
+      [
+        {
+          source: 'signup',
+          when: '2026-05-10T00:00:00Z',
+          identifier: 'alice@x.com',
+          name: 'Alice',
+          email: 'alice@x.com',
+          status: null,
+          wallet: '5A',
+        },
+      ],
+      { programSlug: 'bitrefill-2026' },
+    );
+    const lines = csv.trim().split('\n');
+    expect(lines[0]).toBe('source,when,identifier,name,email,status,wallet');
+    expect(lines[1]).toContain('alice@x.com');
+    expect(lines.at(-1)).toMatch(/^# program=bitrefill-2026/);
+  });
+
+  it('quotes values containing commas, quotes, or newlines', () => {
+    const csv = inboxToCsv([
+      { source: 'application', when: '', identifier: 'p', name: 'Smith, Jr.', email: null, status: null, wallet: null },
+      { source: 'application', when: '', identifier: 'q', name: 'has "quote"', email: null, status: null, wallet: null },
+      { source: 'application', when: '', identifier: 'r', name: 'line\nbreak', email: null, status: null, wallet: null },
+    ]);
+    expect(csv).toContain('"Smith, Jr."');
+    expect(csv).toContain('"has ""quote"""');
+    expect(csv).toContain('"line\nbreak"');
+  });
+});

--- a/server/api/services/program-inbox.service.js
+++ b/server/api/services/program-inbox.service.js
@@ -1,0 +1,125 @@
+import programApplicationService from './program-application.service.js';
+import programSignupService from './program-signup.service.js';
+import projectService from './project.service.js';
+
+/**
+ * Per-program inbox — one merged feed of `program_signups` (Luma CSV
+ * imports, individuals) plus `program_applications` (project teams that
+ * applied in-app). Two distinct concepts; the inbox unifies them for
+ * triage / export.
+ *
+ * Each entry carries a `source` discriminator + a stable `when` timestamp
+ * so the merged feed sorts cleanly.
+ */
+
+/** Unified shape returned by listInbox. */
+const baseEntry = (source, raw) => ({
+  source,
+  id: raw.id,
+  when: raw.when,
+  name: raw.name ?? null,
+  email: raw.email ?? null,
+  identifier: raw.identifier,
+  status: raw.status ?? null,
+  wallet: raw.wallet ?? null,
+  walletChain: raw.walletChain ?? null,
+});
+
+class ProgramInboxService {
+  /**
+   * Return merged signups + applications for a program, newest first.
+   * Application entries are enriched with the project name when known.
+   *
+   * @param {string} programId
+   * @returns {Promise<Array>}
+   */
+  async listInbox(programId) {
+    const [signups, applications] = await Promise.all([
+      programSignupService.listByProgramId(programId),
+      programApplicationService.listByProgram(programId),
+    ]);
+
+    // Best-effort enrich application rows with their project name. Dedup
+    // upfront (multiple applications can point at the same project) so we
+    // don't race the Promise.all on identical projectIds.
+    const uniqueProjectIds = [...new Set(applications.map((a) => a.projectId))];
+    const projectNameById = new Map();
+    await Promise.all(
+      uniqueProjectIds.map(async (projectId) => {
+        try {
+          const project = await projectService.getProjectById(projectId);
+          projectNameById.set(projectId, project?.projectName || null);
+        } catch {
+          projectNameById.set(projectId, null);
+        }
+      }),
+    );
+
+    const signupEntries = signups.map((s) =>
+      baseEntry('signup', {
+        id: s.id,
+        when: s.registeredAt || s.createdAt,
+        name: s.name,
+        email: s.email,
+        identifier: s.email,
+        status: null,
+        wallet: s.wallet,
+        walletChain: null,
+      }),
+    );
+
+    const applicationEntries = applications.map((a) =>
+      baseEntry('application', {
+        id: a.id,
+        when: a.submittedAt,
+        name: projectNameById.get(a.projectId) || a.projectId,
+        email: null,
+        identifier: a.projectId,
+        status: a.status,
+        wallet: a.submittedBy,
+        walletChain: null,
+      }),
+    );
+
+    return [...signupEntries, ...applicationEntries].sort((a, b) => {
+      const aMs = a.when ? new Date(a.when).getTime() : 0;
+      const bMs = b.when ? new Date(b.when).getTime() : 0;
+      return bMs - aMs;
+    });
+  }
+}
+
+export default new ProgramInboxService();
+
+// CSV serialisation lives here so the controller stays thin. Escapes
+// double-quotes per RFC 4180.
+const csvCell = (val) => {
+  if (val == null) return '';
+  const s = String(val);
+  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+};
+
+export function inboxToCsv(rows, { programSlug } = {}) {
+  const header = [
+    'source',
+    'when',
+    'identifier',
+    'name',
+    'email',
+    'status',
+    'wallet',
+  ];
+  const lines = [header.join(',')];
+  for (const r of rows) {
+    lines.push(
+      [r.source, r.when, r.identifier, r.name, r.email, r.status, r.wallet]
+        .map(csvCell)
+        .join(','),
+    );
+  }
+  // Stamp the slug in a trailing comment so the export is self-identifying
+  // when re-opened later. Not parsed by Excel/Numbers as a row.
+  if (programSlug) lines.push(`# program=${programSlug}, exported=${new Date().toISOString()}`);
+  return lines.join('\n') + '\n';
+}


### PR DESCRIPTION
Merges signups + applications into one admin feed per program. CSV export so cohort lists can leave the app cleanly. Part of the pre-rehearsal sprint; batched into the next develop→main PR with onboarding polish (#111), audit log, and the milestone-3 form.

## What lands

**Server**
- `program-inbox.service` with `listInbox` and `inboxToCsv`. Unified shape: `{ source, id, when, name, email, identifier, status, wallet, walletChain }`. Application rows enriched with project name (one fetch per UNIQUE projectId — dedup happens before `Promise.all`, a regression case caught by tests).
- New endpoints: `GET /api/programs/:slug/inbox` (JSON) + `GET /api/programs/:slug/inbox.csv` (CSV download).
- Both gated by `requireProgramAdmin` — same auth surface as the underlying tables.

**Client**
- `ApiInboxEntry` type
- `api.listProgramInbox` + `api.exportProgramInboxCsv` (returns Blob; bypasses the JSON request helper)
- `ProgramInboxSection` — mounted on `AdminProgramPage` right after SIGNUPS. 3-tab filter (all/signup/application), per-row source chip, EXPORT CSV button triggers a blob URL download.

## Server tests (+6)

- empty inbox
- merges + sorts newest-first
- application rows enriched with project name; one fetch per unique projectId
- falls back to projectId when project lookup fails
- CSV emits header + slug stamp
- CSV escapes commas, quotes, newlines (RFC 4180)

**Full server suite: 229 / 229** (was 223; +6).

## Files

- `server/api/services/program-inbox.service.js` (new)
- `server/api/services/__tests__/program-inbox.service.test.js` (new)
- `server/api/controllers/program.controller.js` — `listInbox` + `exportInboxCsv`
- `server/api/routes/program.routes.js` — 2 new routes
- `client/src/lib/api.ts` — `ApiInboxEntry`, `listProgramInbox`, `exportProgramInboxCsv`
- `client/src/components/admin/ProgramInboxSection.tsx` (new)
- `client/src/pages/AdminProgramPage.tsx` — mount the section

## Verification

- `cd server && npm test` → 229 / 229
- `cd client && npm run build` → clean
- `cd client && npm run lint --max-warnings 0` → clean

## Test scenarios

- On `/admin/programs/bitrefill-2026` with a connected admin wallet: the new INBOX panel appears below SIGNUPS. Shows the merged count + per-source breakdown. Clicking ALL/SIGNUP/APPLICATION filters the list inline.
- After importing a 2-row Luma CSV and one project application, the inbox has 3 rows total. EXPORT CSV downloads `bitrefill-2026-inbox-<YYYY-MM-DD>.csv` with header `source,when,identifier,name,email,status,wallet` + 3 data rows + a trailing `# program=bitrefill-2026, exported=…` stamp.
- A row whose name contains a comma (e.g. `Smith, Jr.`) is wrapped in quotes in the CSV.
- A non-admin wallet hitting either endpoint gets 403 from `requireProgramAdmin` — no new auth surface.

Targets `develop`. Draft for review.