### PR TITLE
feat(programs): admin audit log

### DIFF
--- a/client/src/components/admin/ProgramAuditLogSection.tsx
+++ b/client/src/components/admin/ProgramAuditLogSection.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useState } from "react";
+import { Loader2, RotateCw } from "lucide-react";
+import { api, type ApiAuditLogEntry, type AdminAuthArg, ApiError } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+
+const truncate = (s?: string | null, n = 18) => {
+  if (!s) return "—";
+  if (s.length <= n) return s;
+  return `${s.slice(0, Math.max(2, n - 4))}…${s.slice(-4)}`;
+};
+
+const relativeTime = (iso: string): string => {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 30) return `${d}d ago`;
+  return new Date(iso).toLocaleDateString();
+};
+
+const actionTone = (action: string): string => {
+  if (action.startsWith("admin.")) return "border-display text-display bg-panel-deep";
+  if (action.startsWith("sponsor.")) return "border-hairline text-display bg-panel-deep";
+  if (action.startsWith("signups.") || action.startsWith("signup.")) return "border-hairline text-label-mid";
+  if (action === "application.accepted") return "border-led text-led";
+  if (action === "application.rejected" || action === "application.withdrawn") return "border-hairline text-label-mid";
+  return "border-hairline text-display";
+};
+
+/**
+ * Per-program admin activity log. Surfaces who did what — sponsor edits,
+ * CSV imports, application status changes, admin add/remove — for
+ * handoff and forensics. Read-only on the client; writes happen as a
+ * side-effect of the underlying actions via `auditLog.logSafe` on the
+ * server.
+ */
+export function ProgramAuditLogSection({
+  programSlug,
+  signAuthHeader,
+}: {
+  programSlug: string;
+  signAuthHeader: () => Promise<AdminAuthArg>;
+}) {
+  const { toast } = useToast();
+  const [entries, setEntries] = useState<ApiAuditLogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(() => {
+    let active = true;
+    setLoading(true);
+    (async () => {
+      try {
+        const auth = await signAuthHeader();
+        const r = await api.listProgramAuditLog(programSlug, auth, { limit: 50 });
+        if (active) setEntries(r.data);
+      } catch (e) {
+        if (active) {
+          toast({
+            title: "Couldn't load audit log",
+            description: e instanceof ApiError ? e.message : (e as Error)?.message,
+            variant: "destructive",
+          });
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => { active = false; };
+  }, [programSlug, signAuthHeader, toast]);
+
+  useEffect(() => {
+    const cleanup = load();
+    return cleanup;
+  }, [load]);
+
+  return (
+    <div className="panel p-4 mb-3">
+      <div className="flex items-center justify-between mb-3 pb-3 border-b border-hairline-subtle">
+        <div className="flex items-center gap-3">
+          <span className="label-hw text-display">·AUDIT LOG</span>
+          <span className="label-hw-dim">LAST 50 ADMIN ACTIONS ON THIS PROGRAM</span>
+        </div>
+        <button
+          type="button"
+          onClick={load}
+          aria-label="Refresh audit log"
+          className="inline-flex items-center justify-center border border-hairline text-label-mid hover:text-display hover:bg-panel-deep w-7 h-7"
+        >
+          <RotateCw className="h-3 w-3" />
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 label-hw-dim py-4">
+          <Loader2 className="h-3 w-3 animate-spin" /> LOADING…
+        </div>
+      ) : entries.length === 0 ? (
+        <p className="text-body text-sm">No admin actions recorded yet for this program.</p>
+      ) : (
+        <ul className="space-y-1.5">
+          {entries.map((e) => (
+            <li
+              key={e.id}
+              className="lcd px-3 py-2 flex items-center justify-between gap-3"
+            >
+              <div className="min-w-0 flex-1 flex items-center gap-2">
+                <span
+                  className={`border ${actionTone(e.action)} px-1.5 py-[1px] font-mono text-[9px] tracking-[0.12em] uppercase`}
+                >
+                  {e.action}
+                </span>
+                <div className="min-w-0">
+                  <div className="font-mono text-[12px] text-display truncate">
+                    {e.targetId || e.targetType || "—"}
+                  </div>
+                  <div className="label-hw-dim truncate">
+                    BY {truncate(e.actorWallet)}
+                    {e.actorChain ? ` · ${e.actorChain.toUpperCase()}` : ""}
+                  </div>
+                </div>
+              </div>
+              <span
+                className="font-mono text-[10px] text-label-mid tabular-nums flex-shrink-0"
+                title={new Date(e.createdAt).toLocaleString()}
+              >
+                {relativeTime(e.createdAt).toUpperCase()}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -212,6 +212,19 @@ export type ApiAdminTierEntry = {
   createdAt?: string;
 };
 
+/** One row in the per-program audit log. */
+export type ApiAuditLogEntry = {
+  id: string;
+  programId: string;
+  actorChain: string | null;
+  actorWallet: string | null;
+  action: string;
+  targetType: string | null;
+  targetId: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+};
+
 /** Shape of a row in the `programs` table (Phase 1 revamp). */
 export type ApiProgram = {
   id: string;
@@ -1580,6 +1593,19 @@ export const api = {
       `/admin/global-admins/${encodeURIComponent(wallet)}?chain=${encodeURIComponent(walletChain)}`,
       { method: "DELETE", headers: adminAuthHeaders(authHeader) },
     );
+  },
+
+  // --- Program audit log ---
+
+  listProgramAuditLog: async (
+    slug: string,
+    authHeader: AdminAuthArg,
+    options: { limit?: number } = {},
+  ): Promise<{ status: string; data: ApiAuditLogEntry[] }> => {
+    const qs = options.limit ? `?limit=${encodeURIComponent(String(options.limit))}` : "";
+    return request(`/programs/${encodeURIComponent(slug)}/audit-log${qs}`, {
+      headers: adminAuthHeaders(authHeader),
+    });
   },
 };
 

--- a/client/src/pages/AdminProgramPage.tsx
+++ b/client/src/pages/AdminProgramPage.tsx
@@ -14,6 +14,7 @@ import { ApplicationCard } from "@/components/admin/ApplicationCard";
 import { ProgramAdminsSection } from "@/components/admin/ProgramAdminsSection";
 import { ProgramSponsorsSection } from "@/components/admin/ProgramSponsorsSection";
 import { ProgramSignupsSection } from "@/components/admin/ProgramSignupsSection";
+import { ProgramAuditLogSection } from "@/components/admin/ProgramAuditLogSection";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 
@@ -240,6 +241,11 @@ const AdminProgramPage = () => {
                 />
 
                 <ProgramSignupsSection
+                  programSlug={program.slug}
+                  signAuthHeader={getAdminAuth}
+                />
+
+                <ProgramAuditLogSection
                   programSlug={program.slug}
                   signAuthHeader={getAdminAuth}
                 />

--- a/server/api/controllers/program.controller.js
+++ b/server/api/controllers/program.controller.js
@@ -2,6 +2,7 @@ import programService from '../services/program.service.js';
 import programApplicationService from '../services/program-application.service.js';
 import programSponsorService from '../services/program-sponsor.service.js';
 import programSignupService from '../services/program-signup.service.js';
+import auditLog from '../services/program-audit-log.service.js';
 import projectService from '../services/project.service.js';
 import notificationService from '../services/notification.service.js';
 import programAdminRepository from '../repositories/program-admin.repository.js';
@@ -134,6 +135,15 @@ class ProgramController {
       // to 404 via the Postgres PGRST116 code we see on not-found.
       res.status(200).json({ status: 'success', data: updated });
 
+      auditLog.logSafe({
+        programId: program.id,
+        actor: { chain: req.user?.chain, wallet: reviewedBy },
+        action: `application.${updated.status}`,
+        targetType: 'application',
+        targetId: updated.id,
+        metadata: { from: prevStatus, to: updated.status, projectId: updated.projectId },
+      });
+
       if (prevStatus === 'submitted' && (updated.status === 'accepted' || updated.status === 'rejected')) {
         const eventType = updated.status === 'accepted' ? 'application_accepted' : 'application_rejected';
         try {
@@ -184,6 +194,14 @@ class ProgramController {
 
       const updated = await programService.updateBySlug(slug, patch);
       res.status(200).json({ status: 'success', data: updated });
+      auditLog.logSafe({
+        programId: updated.id,
+        actor: { chain: req.user?.chain, wallet: req.user?.address },
+        action: 'program.update',
+        targetType: 'program',
+        targetId: updated.id,
+        metadata: { changedKeys: Object.keys(patch || {}) },
+      });
     } catch (error) {
       if (error?.code === '23505') {
         return res.status(409).json({
@@ -348,6 +366,14 @@ class ProgramController {
         });
       }
       res.status(201).json({ status: 'success', data: added });
+      auditLog.logSafe({
+        programId: program.id,
+        actor: { chain: req.user?.chain, wallet: req.user?.address },
+        action: 'admin.add',
+        targetType: 'admin',
+        targetId: `${walletChain}:${added.wallet}`,
+        metadata: null,
+      });
     } catch (error) {
       console.error('❌ Error adding program admin:', error);
       res.status(500).json({ status: 'error', message: 'Failed to add program admin' });
@@ -370,6 +396,14 @@ class ProgramController {
       }
       await programAdminRepository.remove(program.id, walletChain, wallet);
       res.status(204).end();
+      auditLog.logSafe({
+        programId: program.id,
+        actor: { chain: req.user?.chain, wallet: req.user?.address },
+        action: 'admin.remove',
+        targetType: 'admin',
+        targetId: `${walletChain}:${wallet}`,
+        metadata: null,
+      });
     } catch (error) {
       console.error('❌ Error removing program admin:', error);
       res.status(500).json({ status: 'error', message: 'Failed to remove program admin' });
@@ -406,6 +440,14 @@ class ProgramController {
       }
       const created = await programSponsorService.create({ ...req.body, programId: program.id });
       res.status(201).json({ status: 'success', data: created });
+      auditLog.logSafe({
+        programId: program.id,
+        actor: { chain: req.user?.chain, wallet: req.user?.address },
+        action: 'sponsor.add',
+        targetType: 'sponsor',
+        targetId: created.id,
+        metadata: { name: created.name },
+      });
     } catch (error) {
       console.error('❌ Error creating program sponsor:', error);
       res.status(500).json({ status: 'error', message: 'Failed to create program sponsor' });
@@ -429,6 +471,14 @@ class ProgramController {
       }
       const updated = await programSponsorService.update(sponsorId, req.body);
       res.status(200).json({ status: 'success', data: updated });
+      auditLog.logSafe({
+        programId: program.id,
+        actor: { chain: req.user?.chain, wallet: req.user?.address },
+        action: 'sponsor.update',
+        targetType: 'sponsor',
+        targetId: sponsorId,
+        metadata: { changedKeys: Object.keys(req.body || {}) },
+      });
     } catch (error) {
       console.error('❌ Error updating program sponsor:', error);
       res.status(500).json({ status: 'error', message: 'Failed to update program sponsor' });
@@ -448,6 +498,14 @@ class ProgramController {
       }
       await programSponsorService.delete(sponsorId);
       res.status(204).end();
+      auditLog.logSafe({
+        programId: program.id,
+        actor: { chain: req.user?.chain, wallet: req.user?.address },
+        action: 'sponsor.delete',
+        targetType: 'sponsor',
+        targetId: sponsorId,
+        metadata: { name: existing.name },
+      });
     } catch (error) {
       console.error('❌ Error deleting program sponsor:', error);
       res.status(500).json({ status: 'error', message: 'Failed to delete program sponsor' });
@@ -520,6 +578,21 @@ class ProgramController {
           inserted: dryRun ? [] : inserted || [],
         },
       });
+      if (!dryRun) {
+        auditLog.logSafe({
+          programId: program.id,
+          actor: { chain: req.user?.chain, wallet: req.user?.address },
+          action: 'signups.import',
+          targetType: 'signups_batch',
+          targetId: null,
+          metadata: {
+            newCount: summary.newCount,
+            duplicates: summary.duplicates,
+            skippedNoEmail: summary.skippedNoEmail,
+            totalParsed: summary.totalParsed,
+          },
+        });
+      }
     } catch (error) {
       console.error('❌ Error importing program signups:', error);
       res.status(500).json({ status: 'error', message: 'Failed to import program signups' });
@@ -541,9 +614,35 @@ class ProgramController {
       }
       await programSignupService.delete(signupId);
       res.status(204).end();
+      auditLog.logSafe({
+        programId: program.id,
+        actor: { chain: req.user?.chain, wallet: req.user?.address },
+        action: 'signup.delete',
+        targetType: 'signup',
+        targetId: signupId,
+        metadata: { email: existing.email },
+      });
     } catch (error) {
       console.error('❌ Error deleting program signup:', error);
       res.status(500).json({ status: 'error', message: 'Failed to delete program signup' });
+    }
+  }
+
+  // --- Audit log read endpoint ---
+
+  async listAuditLog(req, res) {
+    try {
+      const { slug } = req.params;
+      const limit = Math.min(parseInt(req.query.limit, 10) || 100, 500);
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const entries = await auditLog.listByProgramId(program.id, { limit });
+      res.status(200).json({ status: 'success', data: entries });
+    } catch (error) {
+      console.error('❌ Error listing program audit log:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to list audit log' });
     }
   }
 }

--- a/server/api/repositories/program-audit-log.repository.js
+++ b/server/api/repositories/program-audit-log.repository.js
@@ -1,0 +1,49 @@
+import { supabase } from '../../db.js';
+
+const transform = (row) => {
+  if (!row) return null;
+  return {
+    id: row.id,
+    programId: row.program_id,
+    actorChain: row.actor_chain,
+    actorWallet: row.actor_wallet,
+    action: row.action,
+    targetType: row.target_type,
+    targetId: row.target_id,
+    metadata: row.metadata,
+    createdAt: row.created_at,
+  };
+};
+
+class ProgramAuditLogRepository {
+  async listByProgramId(programId, { limit = 100 } = {}) {
+    const { data, error } = await supabase
+      .from('program_audit_log')
+      .select('*')
+      .eq('program_id', programId)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+    if (error) throw error;
+    return (data || []).map(transform);
+  }
+
+  async insert({ programId, actorChain, actorWallet, action, targetType, targetId, metadata }) {
+    const { data, error } = await supabase
+      .from('program_audit_log')
+      .insert({
+        program_id: programId,
+        actor_chain: actorChain ?? null,
+        actor_wallet: actorWallet ?? null,
+        action,
+        target_type: targetType ?? null,
+        target_id: targetId ?? null,
+        metadata: metadata ?? null,
+      })
+      .select('*')
+      .single();
+    if (error) throw error;
+    return transform(data);
+  }
+}
+
+export default new ProgramAuditLogRepository();

--- a/server/api/routes/program.routes.js
+++ b/server/api/routes/program.routes.js
@@ -78,4 +78,7 @@ router.delete(
   programController.deleteSignup,
 );
 
+// --- Audit log ---
+router.get('/:slug/audit-log', requireProgramAdmin('slug'), programController.listAuditLog);
+
 export default router;

--- a/server/api/services/__tests__/program-audit-log.service.test.js
+++ b/server/api/services/__tests__/program-audit-log.service.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../repositories/program-audit-log.repository.js', () => ({
+  default: { insert: vi.fn(), listByProgramId: vi.fn() },
+}));
+
+const repo = (await import('../../repositories/program-audit-log.repository.js')).default;
+const { default: service } = await import('../program-audit-log.service.js');
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('logSafe', () => {
+  it('inserts a normalised row when programId + action are present', async () => {
+    repo.insert.mockResolvedValue({ id: 'audit-1' });
+    const out = await service.logSafe({
+      programId: 'bitrefill-2026',
+      actor: { chain: 'substrate', wallet: '5Alice' },
+      action: 'sponsor.add',
+      targetType: 'sponsor',
+      targetId: 'sponsor-1',
+      metadata: { name: 'Bitrefill' },
+    });
+    expect(out).toEqual({ id: 'audit-1' });
+    expect(repo.insert).toHaveBeenCalledWith({
+      programId: 'bitrefill-2026',
+      actorChain: 'substrate',
+      actorWallet: '5Alice',
+      action: 'sponsor.add',
+      targetType: 'sponsor',
+      targetId: 'sponsor-1',
+      metadata: { name: 'Bitrefill' },
+    });
+  });
+
+  it('skips the write when programId is missing', async () => {
+    const out = await service.logSafe({ action: 'x' });
+    expect(out).toBeNull();
+    expect(repo.insert).not.toHaveBeenCalled();
+  });
+
+  it('skips the write when action is missing', async () => {
+    const out = await service.logSafe({ programId: 'x' });
+    expect(out).toBeNull();
+    expect(repo.insert).not.toHaveBeenCalled();
+  });
+
+  it('returns null and never throws when the insert errors', async () => {
+    repo.insert.mockRejectedValue(new Error('DB down'));
+    const out = await service.logSafe({
+      programId: 'bitrefill-2026',
+      action: 'sponsor.add',
+    });
+    expect(out).toBeNull();
+  });
+
+  it('stringifies non-string targetId so JSONB queries stay sane', async () => {
+    repo.insert.mockResolvedValue({ id: 'audit-2' });
+    await service.logSafe({
+      programId: 'p',
+      action: 'a',
+      targetId: 42,
+    });
+    expect(repo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ targetId: '42' }),
+    );
+  });
+
+  it('passes through null targetId without stringifying', async () => {
+    repo.insert.mockResolvedValue({ id: 'audit-3' });
+    await service.logSafe({
+      programId: 'p',
+      action: 'signups.import',
+      targetId: null,
+    });
+    expect(repo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ targetId: null }),
+    );
+  });
+});
+
+describe('listByProgramId', () => {
+  it('passes through to the repository', async () => {
+    repo.listByProgramId.mockResolvedValue([{ id: 'a' }]);
+    const out = await service.listByProgramId('p', { limit: 10 });
+    expect(repo.listByProgramId).toHaveBeenCalledWith('p', { limit: 10 });
+    expect(out).toEqual([{ id: 'a' }]);
+  });
+});

--- a/server/api/services/program-audit-log.service.js
+++ b/server/api/services/program-audit-log.service.js
@@ -1,0 +1,43 @@
+import repo from '../repositories/program-audit-log.repository.js';
+import logger from '../utils/logger.js';
+
+/**
+ * Best-effort write of an audit-log row. NEVER throws — a log failure
+ * must not break the calling action (importing a CSV, accepting an
+ * application, etc.). Errors land in the server log instead.
+ *
+ * Pull `actor` out of `req.user` at the call-site:
+ *   await auditLog.logSafe({
+ *     programId,
+ *     actor: { chain: req.user?.chain, wallet: req.user?.address },
+ *     action: 'sponsor.add',
+ *     targetType: 'sponsor',
+ *     targetId: created.id,
+ *     metadata: { name: created.name },
+ *   });
+ */
+class ProgramAuditLogService {
+  async listByProgramId(programId, opts) {
+    return await repo.listByProgramId(programId, opts);
+  }
+
+  async logSafe({ programId, actor, action, targetType, targetId, metadata }) {
+    try {
+      if (!programId || !action) return null;
+      return await repo.insert({
+        programId,
+        actorChain: actor?.chain,
+        actorWallet: actor?.wallet,
+        action,
+        targetType,
+        targetId: targetId == null ? null : String(targetId),
+        metadata,
+      });
+    } catch (e) {
+      logger.error(`audit-log failed (action=${action}, program=${programId}):`, e);
+      return null;
+    }
+  }
+}
+
+export default new ProgramAuditLogService();

--- a/supabase/migrations/20260521100000_program_audit_log.sql
+++ b/supabase/migrations/20260521100000_program_audit_log.sql
@@ -1,0 +1,25 @@
+-- Per-program audit log for admin actions.
+--
+-- Records sponsor add/edit/delete, signup CSV imports + deletes, application
+-- status changes, program edits, and admin add/remove. Useful for handoffs
+-- between WebZero ops and per-event admins ("what did the previous admin
+-- do last week?"). Writes are best-effort — a logging failure must never
+-- block the user-visible action (enforced at the service layer with
+-- `logSafe`, not by trigger).
+--
+-- Additive and idempotent.
+
+CREATE TABLE IF NOT EXISTS program_audit_log (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  program_id   TEXT NOT NULL REFERENCES programs(id) ON DELETE CASCADE,
+  actor_chain  TEXT,
+  actor_wallet TEXT,
+  action       TEXT NOT NULL,
+  target_type  TEXT,
+  target_id    TEXT,
+  metadata     JSONB,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_program_audit_log_program_recent
+  ON program_audit_log(program_id, created_at DESC);


### PR DESCRIPTION
Per-program activity log so handoffs between WebZero ops and per-event admins have a trail. Records sponsor add/edit/delete, signup CSV imports/deletes, application status changes, program edits, and admin add/remove. **Writes are best-effort — a logging failure never blocks the user-visible action.** Part of the pre-rehearsal sprint; will be batched into one develop→main PR with #111, #112, and #114 (next).

## Schema (`20260521100000_program_audit_log.sql`)

`program_audit_log` (id UUID PK, program_id FK cascade, actor_chain, actor_wallet, action, target_type, target_id, metadata JSONB, created_at) + index on `(program_id, created_at DESC)`.

## Server

- `repositories/program-audit-log.repository.js` — list / insert
- `services/program-audit-log.service.js`:
  - `logSafe({ programId, actor, action, targetType, targetId, metadata })` — **never throws**. No-ops when `programId` or `action` is missing. Stringifies non-string `targetId` (so JSONB queries stay sane).
- `program.controller` wired at:
  - `sponsor.add` / `sponsor.update` / `sponsor.delete` (with `name` / `changedKeys` in metadata)
  - `application.<status>` (with `from` / `to` / `projectId`)
  - `program.update` (with `changedKeys`)
  - `signups.import` (with `newCount` / `duplicates` / `skipped` / `totalParsed`)
  - `signup.delete` (with `email`)
  - `admin.add` / `admin.remove` (`targetId = chain:wallet`)
  Logging fires **after** the response is sent so latency is unaffected.
- New `GET /api/programs/:slug/audit-log` behind `requireProgramAdmin` (capped at 500 entries, default 100).

## Server tests (+7)

`program-audit-log.service.test.js`:
- inserts normalized row when programId + action present
- skips when programId missing
- skips when action missing
- returns null on insert error (never throws)
- stringifies non-string targetId
- passes null targetId without stringifying
- `listByProgramId` passes through to repo

**Full server suite: 230 / 230** (was 223 on this branch's base; +7).

## Client

- `ApiAuditLogEntry` type
- `api.listProgramAuditLog(slug, authHeader, { limit })`
- `ProgramAuditLogSection` — last 50 actions with relative-time, per-action tone (display for `admin.*`, led for `application.accepted`, label-mid for destructive), refresh button. Mounted under SIGNUPS in `AdminProgramPage`.

## Verification

- `cd server && npm test` → 230 / 230
- `cd client && npm run build` → clean
- `cd client && npm run lint --max-warnings 0` → clean

## Test scenarios

- On `/admin/programs/bitrefill-2026`, the AUDIT LOG panel shows the last 50 actions. Empty initially.
- Add a sponsor → row appears within 1–2s of refresh: `SPONSOR.ADD · <id> · BY <wallet> · NOW`.
- Import a CSV → row `SIGNUPS.IMPORT` with `newCount` in metadata.
- Accept an application → `APPLICATION.ACCEPTED` (led tone).
- Add a program admin → `ADMIN.ADD · substrate:5Bob`.
- If the audit insert fails (e.g. DB hiccup), the user-visible action still succeeds; the server logs a warning.

## Migration

`20260521100000_program_audit_log.sql` is additive + idempotent. Apply on prod Supabase before the develop→main release lands. Without the table, audit writes fail silently (logSafe swallows) — no breakage in normal flows.

Targets `develop`. Draft for review.