### PR TITLE
feat(projects): 'What's next, milestone 3?' continuation form

### DIFF
--- a/client/src/components/project/ProjectContinuationModal.tsx
+++ b/client/src/components/project/ProjectContinuationModal.tsx
@@ -1,0 +1,215 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Loader2 } from "lucide-react";
+import { web3Enable, web3Accounts, web3FromSource } from "@polkadot/extension-dapp";
+import { SiwsMessage } from "@talismn/siws";
+import { generateSiwsStatement } from "@/lib/siwsUtils";
+import { api, type ApiProjectContinuation, ApiError } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+
+const STATUS_MAX = 4000;
+const SUPPORT_MAX = 4000;
+
+export function ProjectContinuationModal({
+  open,
+  onOpenChange,
+  projectId,
+  projectTitle,
+  connectedAddress,
+  onSubmitted,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  projectId: string;
+  projectTitle: string;
+  connectedAddress: string;
+  onSubmitted: (entry: ApiProjectContinuation) => void;
+}) {
+  const { toast } = useToast();
+  const [currentStatus, setCurrentStatus] = useState("");
+  const [wantSupport, setWantSupport] = useState(false);
+  const [supportFor, setSupportFor] = useState("");
+  const [nextStepUrl, setNextStepUrl] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const reset = () => {
+    setCurrentStatus("");
+    setWantSupport(false);
+    setSupportFor("");
+    setNextStepUrl("");
+    setSubmitting(false);
+  };
+
+  const validate = (): string | null => {
+    const status = currentStatus.trim();
+    if (!status) return "Tell us where the project stands today.";
+    if (status.length > STATUS_MAX) return `Current status must be ${STATUS_MAX} chars or fewer.`;
+    if (supportFor.length > SUPPORT_MAX) return `Support details must be ${SUPPORT_MAX} chars or fewer.`;
+    if (nextStepUrl.trim() && !/^https?:\/\//i.test(nextStepUrl.trim())) {
+      return "Next-step URL must start with http:// or https://.";
+    }
+    return null;
+  };
+
+  const handleSubmit = async () => {
+    const error = validate();
+    if (error) {
+      toast({ title: "Check the form", description: error, variant: "destructive" });
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await web3Enable("Stadium");
+      const accounts = await web3Accounts();
+      const account = accounts.find((a) => a.address === connectedAddress) || accounts[0];
+      if (!account) throw new Error("No wallet account found");
+      const siws = new SiwsMessage({
+        domain: window.location.hostname,
+        uri: window.location.origin,
+        address: account.address,
+        nonce: Math.random().toString(36).slice(2),
+        statement: generateSiwsStatement({ action: "submit-continuation", projectTitle }),
+      });
+      const injector = await web3FromSource(account.meta.source);
+      const signed = (await siws.sign(injector)) as unknown as { signature: string; message?: string };
+      const messageStr =
+        typeof signed.message === "string" && signed.message
+          ? signed.message
+          : (siws as unknown as { toString: () => string }).toString();
+      const authHeader = btoa(
+        JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address }),
+      );
+      const res = await api.createProjectContinuation(
+        projectId,
+        {
+          currentStatus: currentStatus.trim(),
+          wantSupport,
+          supportFor: supportFor.trim() || null,
+          nextStepUrl: nextStepUrl.trim() || null,
+        },
+        authHeader,
+      );
+      onSubmitted(res.data);
+      toast({ title: "Submitted — thanks for the update" });
+      reset();
+      onOpenChange(false);
+    } catch (e) {
+      toast({
+        title: "Couldn't submit",
+        description: e instanceof ApiError ? e.message : (e as Error)?.message || "Unknown error",
+        variant: "destructive",
+      });
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => (submitting ? null : onOpenChange(v))}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="font-display tracking-tight">·WHAT'S NEXT, MILESTONE 3?</DialogTitle>
+          <DialogDescription className="text-body">
+            Now that M2 is done — where is the project today, and what's the next step we should
+            know about? Submissions go to the WebZero ops team.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="cont-status" className="label-hw-dim">·CURRENT STATUS *</Label>
+            <Textarea
+              id="cont-status"
+              rows={4}
+              maxLength={STATUS_MAX + 100}
+              placeholder="Shipped to mainnet last week. Onboarding ~10 builders/day."
+              value={currentStatus}
+              onChange={(e) => setCurrentStatus(e.target.value)}
+              className="font-mono text-sm"
+            />
+            <div className="flex justify-end label-hw-dim">
+              {currentStatus.trim().length} / {STATUS_MAX}
+            </div>
+          </div>
+
+          <div className="lcd p-3 flex items-center justify-between gap-3">
+            <div>
+              <Label htmlFor="cont-want" className="label-hw text-display">
+                ·WANT CONTINUED SUPPORT?
+              </Label>
+              <p className="label-hw-dim mt-0.5">
+                MENTORSHIP, GRANT INTROS, FOLLOW-ON PROGRAMS, ETC.
+              </p>
+            </div>
+            <Switch
+              id="cont-want"
+              checked={wantSupport}
+              onCheckedChange={setWantSupport}
+              aria-label="Toggle support requested"
+            />
+          </div>
+
+          {wantSupport && (
+            <div className="space-y-1.5">
+              <Label htmlFor="cont-supportfor" className="label-hw-dim">·WHAT WOULD HELP?</Label>
+              <Textarea
+                id="cont-supportfor"
+                rows={3}
+                maxLength={SUPPORT_MAX + 100}
+                placeholder="Intros to grants programs in Polkadot. Feedback on the multi-chain payout flow."
+                value={supportFor}
+                onChange={(e) => setSupportFor(e.target.value)}
+                className="font-mono text-sm"
+              />
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            <Label htmlFor="cont-url" className="label-hw-dim">·NEXT-STEP URL (OPTIONAL)</Label>
+            <Input
+              id="cont-url"
+              type="url"
+              placeholder="https://… (grant app, demo, blog post)"
+              value={nextStepUrl}
+              onChange={(e) => setNextStepUrl(e.target.value)}
+              className="font-mono text-sm"
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <button
+            type="button"
+            onClick={() => { if (!submitting) { reset(); onOpenChange(false); } }}
+            disabled={submitting}
+            className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep disabled:opacity-50 px-3 py-1.5"
+          >
+            CANCEL
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting || !currentStatus.trim()}
+            className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-4 py-1.5 inline-flex items-center gap-1.5"
+          >
+            {submitting ? (
+              <>
+                <Loader2 className="h-3 w-3 animate-spin" /> SUBMITTING…
+              </>
+            ) : (
+              "SUBMIT ▸"
+            )}
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -216,6 +216,19 @@ export type ApiInboxEntry = {
   walletChain: string | null;
 };
 
+/** Row in `project_continuations` ('What's next, milestone 3?' submissions). */
+export type ApiProjectContinuation = {
+  id: string;
+  projectId: string;
+  currentStatus: string;
+  wantSupport: boolean;
+  supportFor: string | null;
+  nextStepUrl: string | null;
+  submittedBy: string;
+  submittedByChain: "substrate" | "ethereum" | "solana";
+  createdAt: string;
+};
+
 /** Tier-0 / tier-1 admin record. Same shape for both tables. */
 export type ApiAdminTierEntry = {
   walletChain: "substrate" | "ethereum" | "solana";
@@ -1634,6 +1647,32 @@ export const api = {
       throw new ApiError(`Inbox export failed (HTTP ${res.status})`, res.status);
     }
     return res.blob();
+  },
+
+  // --- Project continuations ('What's next, milestone 3?') ---
+
+  listProjectContinuations: async (
+    projectId: string,
+    authHeader: AdminAuthArg,
+  ): Promise<{ status: string; data: ApiProjectContinuation[] }> => {
+    return request(`/m2-program/${encodeURIComponent(projectId)}/continuations`, {
+      headers: adminAuthHeaders(authHeader),
+    });
+  },
+
+  createProjectContinuation: async (
+    projectId: string,
+    payload: Pick<ApiProjectContinuation, "currentStatus" | "wantSupport"> & {
+      supportFor?: string | null;
+      nextStepUrl?: string | null;
+    },
+    authHeader: AdminAuthArg,
+  ): Promise<{ status: string; data: ApiProjectContinuation }> => {
+    return request(`/m2-program/${encodeURIComponent(projectId)}/continuations`, {
+      method: "POST",
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
   },
 };
 

--- a/client/src/lib/siwsUtils.ts
+++ b/client/src/lib/siwsUtils.ts
@@ -3,7 +3,7 @@
  */
 
 export interface SiwsContext {
-  action: 'update-team' | 'submit-deliverable' | 'update-project' | 'register-address' | 'admin-action' | 'create-project' | 'delete-project' | 'review-project' | 'approve-project' | 'reject-project' | 'post-update' | 'update-funding-signal' | 'apply-to-program' | 'create-program' | 'update-program' | 'review-application' | 'update-program-sponsors' | 'import-program-signups' | 'update-notifications';
+  action: 'update-team' | 'submit-deliverable' | 'update-project' | 'register-address' | 'admin-action' | 'create-project' | 'delete-project' | 'review-project' | 'approve-project' | 'reject-project' | 'post-update' | 'update-funding-signal' | 'apply-to-program' | 'create-program' | 'update-program' | 'review-application' | 'update-program-sponsors' | 'import-program-signups' | 'submit-continuation' | 'update-notifications';
   projectId?: string;
   projectTitle?: string;
   programTitle?: string;
@@ -70,6 +70,8 @@ export function generateSiwsStatement(context: SiwsContext): string {
       return `Update program sponsors on ${baseDomain}`;
     case 'import-program-signups':
       return `Import program signups on ${baseDomain}`;
+    case 'submit-continuation':
+      return `Submit project continuation on ${baseDomain}`;
 
     // Phase 2 revamp (#71): notification preferences
     case 'update-notifications':

--- a/client/src/pages/ProjectDetailsPage.tsx
+++ b/client/src/pages/ProjectDetailsPage.tsx
@@ -40,6 +40,7 @@ import { ShareProjectModal } from "@/components/ShareProjectModal";
 import { WalletConnectionBanner } from "@/components/WalletConnectionBanner";
 import { TeamPaymentSection } from "@/components/TeamPaymentSection";
 import { M2SubmissionTimeline } from "@/components/M2SubmissionTimeline";
+import { ProjectContinuationModal } from "@/components/project/ProjectContinuationModal";
 import { SubmitM2DeliverablesModal } from "@/components/SubmitM2DeliverablesModal";
 import { ProjectUpdatesTab } from "@/components/project/ProjectUpdatesTab";
 import { FundingSignalBadge } from "@/components/project/FundingSignalBadge";
@@ -173,6 +174,7 @@ const ProjectDetailsPage = () => {
   const [teamModalOpen, setTeamModalOpen] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
   const [isSubmitM2ModalOpen, setIsSubmitM2ModalOpen] = useState(false);
+  const [isContinuationModalOpen, setIsContinuationModalOpen] = useState(false);
   const [isEditProjectDetailsOpen, setIsEditProjectDetailsOpen] = useState(false);
   const [activeTab, setActiveTab] = useState("overview");
   // Phase 1 revamp (#42): funding signal
@@ -1125,6 +1127,27 @@ const ProjectDetailsPage = () => {
                       onSubmit={() => setIsSubmitM2ModalOpen(true)}
                     />
 
+                    {/* 'What's next, milestone 3?' CTA — only on completed
+                        projects, only for team members. Admin-only inboxes
+                        list submissions; the form posts a new one each time. */}
+                    {project.m2Status === 'completed' && isTeamMember && (
+                      <div className="panel p-4 flex items-center justify-between gap-3">
+                        <div>
+                          <div className="label-hw text-display">·WHAT'S NEXT, MILESTONE 3?</div>
+                          <p className="text-body text-sm mt-1">
+                            Tell us where the project stands now and what you want next.
+                          </p>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => setIsContinuationModalOpen(true)}
+                          className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim px-3 py-1.5 flex-shrink-0"
+                        >
+                          SHARE UPDATE ▸
+                        </button>
+                      </div>
+                    )}
+
                     {/* M2 Agreement Section - Only for building status */}
                     {project.m2Status === 'building' && (
                       <M2AgreementSection
@@ -1378,6 +1401,18 @@ const ProjectDetailsPage = () => {
             project={project}
             onSubmit={handleSubmitM2}
           />
+
+          {/* 'What's next, milestone 3?' continuation modal */}
+          {connectedAddress && (
+            <ProjectContinuationModal
+              open={isContinuationModalOpen}
+              onOpenChange={setIsContinuationModalOpen}
+              projectId={project.id}
+              projectTitle={project.projectName}
+              connectedAddress={connectedAddress}
+              onSubmitted={() => { /* no list rendered yet — admin inbox is a follow-up */ }}
+            />
+          )}
 
           {/* Edit Project Details Modal */}
           <EditProjectDetailsModal

--- a/server/api/auth/statements.js
+++ b/server/api/auth/statements.js
@@ -36,6 +36,7 @@ export const VALID_STATEMENTS = [
   'Review application on Stadium',
   'Update program sponsors on Stadium',
   'Import program signups on Stadium',
+  'Submit project continuation on Stadium',
   // Phase 2 revamp: wallet contacts (#67)
   'Update notification preferences for wallet on Stadium',
 ];

--- a/server/api/controllers/__tests__/project-continuation.test.js
+++ b/server/api/controllers/__tests__/project-continuation.test.js
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../services/project.service.js', () => ({
+  default: { getProjectById: vi.fn() },
+}));
+vi.mock('../../services/project-update.service.js', () => ({
+  default: { listByProject: vi.fn(), create: vi.fn() },
+}));
+vi.mock('../../services/funding-signal.service.js', () => ({
+  default: { get: vi.fn(), upsert: vi.fn() },
+}));
+vi.mock('../../services/payment.service.js', () => ({ default: {} }));
+vi.mock('../../services/notification.service.js', () => ({ default: { notifyProjectTeam: vi.fn() } }));
+vi.mock('../../repositories/project-continuation.repository.js', () => ({
+  default: { create: vi.fn(), listByProjectId: vi.fn() },
+}));
+
+const projectService = (await import('../../services/project.service.js')).default;
+const continuationRepo = (await import('../../repositories/project-continuation.repository.js')).default;
+const ctrl = (await import('../project.controller.js')).default;
+
+const mockRes = () => {
+  const r = {};
+  r.status = vi.fn(() => r);
+  r.json = vi.fn(() => r);
+  return r;
+};
+
+const PROJECT = { id: 'plata-mia', projectName: 'Plata Mia' };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('listContinuations', () => {
+  it('returns 404 when the project is unknown', async () => {
+    projectService.getProjectById.mockResolvedValue(null);
+    const res = mockRes();
+    await ctrl.listContinuations({ params: { projectId: 'nope' } }, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns the list newest-first via the repo', async () => {
+    projectService.getProjectById.mockResolvedValue(PROJECT);
+    continuationRepo.listByProjectId.mockResolvedValue([{ id: 'c1' }, { id: 'c2' }]);
+    const res = mockRes();
+    await ctrl.listContinuations({ params: { projectId: PROJECT.id } }, res);
+    expect(continuationRepo.listByProjectId).toHaveBeenCalledWith(PROJECT.id);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});
+
+describe('createContinuation', () => {
+  it('returns 404 when the project is unknown', async () => {
+    projectService.getProjectById.mockResolvedValue(null);
+    const res = mockRes();
+    await ctrl.createContinuation(
+      { params: { projectId: 'nope' }, body: { currentStatus: 'OK' } },
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns 422 when currentStatus is empty', async () => {
+    projectService.getProjectById.mockResolvedValue(PROJECT);
+    const res = mockRes();
+    await ctrl.createContinuation(
+      { params: { projectId: PROJECT.id }, body: { currentStatus: '' } },
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('returns 422 when nextStepUrl is malformed', async () => {
+    projectService.getProjectById.mockResolvedValue(PROJECT);
+    const res = mockRes();
+    await ctrl.createContinuation(
+      {
+        params: { projectId: PROJECT.id },
+        body: { currentStatus: 'shipping', nextStepUrl: 'ftp://nope' },
+      },
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('creates with the submitter wallet stamped from req.user', async () => {
+    projectService.getProjectById.mockResolvedValue(PROJECT);
+    continuationRepo.create.mockImplementation((p) => Promise.resolve({ id: 'c1', ...p }));
+    const res = mockRes();
+    await ctrl.createContinuation(
+      {
+        params: { projectId: PROJECT.id },
+        body: {
+          currentStatus: 'Shipping M2.5, looking at grants.',
+          wantSupport: true,
+          supportFor: 'Grant intros',
+          nextStepUrl: 'https://blog.platamia.io/m25',
+        },
+        user: { address: '5Alice', chain: 'substrate' },
+      },
+      res,
+    );
+    expect(continuationRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: PROJECT.id,
+        currentStatus: 'Shipping M2.5, looking at grants.',
+        wantSupport: true,
+        supportFor: 'Grant intros',
+        nextStepUrl: 'https://blog.platamia.io/m25',
+        submittedBy: '5Alice',
+        submittedByChain: 'substrate',
+      }),
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it('defaults wantSupport to false and trims free-text fields', async () => {
+    projectService.getProjectById.mockResolvedValue(PROJECT);
+    continuationRepo.create.mockImplementation((p) => Promise.resolve({ id: 'c2', ...p }));
+    const res = mockRes();
+    await ctrl.createContinuation(
+      {
+        params: { projectId: PROJECT.id },
+        body: { currentStatus: '  trimmed  ', supportFor: '   ' },
+        user: { address: '5Bob', chain: 'ethereum' },
+      },
+      res,
+    );
+    expect(continuationRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentStatus: 'trimmed',
+        wantSupport: false,
+        supportFor: null,
+        nextStepUrl: null,
+        submittedByChain: 'ethereum',
+      }),
+    );
+  });
+});

--- a/server/api/controllers/project.controller.js
+++ b/server/api/controllers/project.controller.js
@@ -3,8 +3,9 @@ import projectUpdateService from '../services/project-update.service.js';
 import fundingSignalService from '../services/funding-signal.service.js';
 import paymentService from '../services/payment.service.js';
 import notificationService from '../services/notification.service.js';
+import projectContinuationRepository from '../repositories/project-continuation.repository.js';
 import { ALLOWED_CATEGORIES } from '../constants/allowedTech.js';
-import { validateM2Submission, validateSimpleUrl, validateProjectUpdate, validateFundingSignal, validateProject, validateAddress, ALLOWED_WALLET_CHAINS } from '../utils/validation.js';
+import { validateM2Submission, validateSimpleUrl, validateProjectUpdate, validateFundingSignal, validateProject, validateAddress, validateContinuation, ALLOWED_WALLET_CHAINS } from '../utils/validation.js';
 import { canEditM2Agreement, isSubmissionWindowOpen } from '../utils/dateHelpers.js';
 import logger from '../utils/logger.js';
 import { getAuthorizedAddresses } from '../../config/polkadot-config.js';
@@ -704,6 +705,52 @@ class ProjectController {
         } catch (error) {
             console.error('❌ Error updating funding signal:', error);
             res.status(500).json({ status: 'error', message: 'Failed to update funding signal' });
+        }
+    }
+
+    // --- Project continuations ('What's next, milestone 3?') ---
+
+    async listContinuations(req, res) {
+        try {
+            const { projectId } = req.params;
+            const project = await projectService.getProjectById(projectId);
+            if (!project) {
+                return res.status(404).json({ status: 'error', message: 'Project not found' });
+            }
+            const entries = await projectContinuationRepository.listByProjectId(projectId);
+            res.status(200).json({ status: 'success', data: entries });
+        } catch (error) {
+            console.error('❌ Error listing continuations:', error);
+            res.status(500).json({ status: 'error', message: 'Failed to list continuations' });
+        }
+    }
+
+    async createContinuation(req, res) {
+        try {
+            const { projectId } = req.params;
+            const project = await projectService.getProjectById(projectId);
+            if (!project) {
+                return res.status(404).json({ status: 'error', message: 'Project not found' });
+            }
+            const { valid, error } = validateContinuation(req.body);
+            if (!valid) {
+                return res.status(422).json({ status: 'error', message: error });
+            }
+            const submittedBy = req.user?.address || req.auth?.address || 'unknown';
+            const submittedByChain = req.user?.chain || req.auth?.chain || 'substrate';
+            const created = await projectContinuationRepository.create({
+                projectId,
+                currentStatus: req.body.currentStatus.trim(),
+                wantSupport: !!req.body.wantSupport,
+                supportFor: req.body.supportFor?.trim() || null,
+                nextStepUrl: req.body.nextStepUrl?.trim() || null,
+                submittedBy,
+                submittedByChain,
+            });
+            res.status(201).json({ status: 'success', data: created });
+        } catch (error) {
+            console.error('❌ Error creating continuation:', error);
+            res.status(500).json({ status: 'error', message: 'Failed to create continuation' });
         }
     }
 }

--- a/server/api/repositories/project-continuation.repository.js
+++ b/server/api/repositories/project-continuation.repository.js
@@ -1,0 +1,50 @@
+import { supabase } from '../../db.js';
+
+const transform = (row) => {
+  if (!row) return null;
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    currentStatus: row.current_status,
+    wantSupport: row.want_support,
+    supportFor: row.support_for,
+    nextStepUrl: row.next_step_url,
+    submittedBy: row.submitted_by,
+    submittedByChain: row.submitted_by_chain,
+    createdAt: row.created_at,
+  };
+};
+
+class ProjectContinuationRepository {
+  async listByProjectId(projectId) {
+    const { data, error } = await supabase
+      .from('project_continuations')
+      .select('*')
+      .eq('project_id', projectId)
+      .order('created_at', { ascending: false });
+    if (error) throw error;
+    return (data || []).map(transform);
+  }
+
+  async create({
+    projectId, currentStatus, wantSupport, supportFor, nextStepUrl, submittedBy, submittedByChain,
+  }) {
+    const { data, error } = await supabase
+      .from('project_continuations')
+      .insert({
+        project_id: projectId,
+        current_status: currentStatus,
+        want_support: !!wantSupport,
+        support_for: supportFor ?? null,
+        next_step_url: nextStepUrl ?? null,
+        submitted_by: submittedBy,
+        submitted_by_chain: submittedByChain,
+      })
+      .select('*')
+      .single();
+    if (error) throw error;
+    return transform(data);
+  }
+}
+
+export default new ProjectContinuationRepository();

--- a/server/api/routes/m2-program.routes.js
+++ b/server/api/routes/m2-program.routes.js
@@ -32,6 +32,10 @@ router.post('/:projectId/updates', requireTeamMemberOrAdmin, projectController.p
 router.get('/:projectId/funding-signal', projectController.getFundingSignal);
 router.patch('/:projectId/funding-signal', requireTeamMemberOrAdmin, projectController.updateFundingSignal);
 
+// --- 'What's next, milestone 3?' continuations (#15) ---
+router.get('/:projectId/continuations', requireTeamMemberOrAdmin, projectController.listContinuations);
+router.post('/:projectId/continuations', requireTeamMemberOrAdmin, projectController.createContinuation);
+
 // --- Phase 1 revamp: per-project application list (#43) ---
 router.get('/:projectId/applications', programController.listApplicationsForProject);
 

--- a/server/api/utils/validation.js
+++ b/server/api/utils/validation.js
@@ -546,3 +546,31 @@ export const validateSponsor = (data, { partial = false } = {}) => {
   }
   return { valid: true };
 };
+
+// --- Project continuations ('What's next, milestone 3?' form) ---
+
+export const validateContinuation = (data) => {
+  if (!data || typeof data !== 'object') {
+    return { valid: false, error: 'Continuation payload must be an object' };
+  }
+  if (typeof data.currentStatus !== 'string' || !validateLength(data.currentStatus, 1, 4000)) {
+    return { valid: false, error: 'currentStatus is required (1–4000 characters)' };
+  }
+  if (data.wantSupport !== undefined && typeof data.wantSupport !== 'boolean') {
+    return { valid: false, error: 'wantSupport must be a boolean' };
+  }
+  if (data.supportFor !== undefined && data.supportFor !== null) {
+    if (typeof data.supportFor !== 'string' || data.supportFor.length > 4000) {
+      return { valid: false, error: 'supportFor must be a string (max 4000 characters)' };
+    }
+  }
+  if (data.nextStepUrl !== undefined && data.nextStepUrl !== null && data.nextStepUrl !== '') {
+    if (typeof data.nextStepUrl !== 'string' || data.nextStepUrl.length > 500) {
+      return { valid: false, error: 'nextStepUrl must be a string (max 500 characters)' };
+    }
+    if (!/^https?:\/\//i.test(data.nextStepUrl)) {
+      return { valid: false, error: 'nextStepUrl must start with http:// or https://' };
+    }
+  }
+  return { valid: true };
+};

--- a/supabase/migrations/20260521200000_project_continuations.sql
+++ b/supabase/migrations/20260521200000_project_continuations.sql
@@ -1,0 +1,24 @@
+-- Project continuations — 'What's next, milestone 3?' submissions.
+--
+-- Triggered by the team after they finish M2: a small form that captures
+-- (a) the current status of the project, (b) whether they want continued
+-- support and what for, and (c) an optional URL pointing at the next thing
+-- (Grant application, new repo branch, demo deployment, etc.). Helps the
+-- ops team keep a finger on the pulse post-M2.
+--
+-- Additive and idempotent.
+
+CREATE TABLE IF NOT EXISTS project_continuations (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id         TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  current_status     TEXT NOT NULL,
+  want_support       BOOLEAN NOT NULL DEFAULT FALSE,
+  support_for        TEXT,
+  next_step_url      TEXT,
+  submitted_by       TEXT NOT NULL,
+  submitted_by_chain TEXT NOT NULL CHECK (submitted_by_chain IN ('substrate', 'ethereum', 'solana')),
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_continuations_project_recent
+  ON project_continuations(project_id, created_at DESC);


### PR DESCRIPTION
Closes the post-M2 feedback loop from #15. Team members on a completed project can share where it stands today, whether they want continued support, and what for. Last of the four pre-rehearsal feature PRs — will be batched into one develop→main release PR with #111, #112, #113.

## Schema (`20260521200000_project_continuations.sql`)

`project_continuations` (id, project_id FK cascade, current_status, want_support, support_for, next_step_url, submitted_by, submitted_by_chain CHECK, created_at) + idx on `(project_id, created_at DESC)`.

## Server

- `repositories/project-continuation.repository.js` — list + create
- `project.controller`:
  - `listContinuations` (gated `requireTeamMemberOrAdmin`)
  - `createContinuation`: validates payload, stamps submitter wallet + chain from `req.user`, persists
- `m2-program.routes`: `GET /:projectId/continuations` + `POST /:projectId/continuations`, both gated `requireTeamMemberOrAdmin`
- `validation.validateContinuation`:
  - `currentStatus` 1–4000 chars, required
  - `wantSupport` boolean (defaults false)
  - `supportFor` 0–4000 chars
  - `nextStepUrl` http(s):// when present
- `auth/statements`: `Submit project continuation on Stadium` added so SIWS messages pass `validateStatement`

## Server tests (+7)

`project-continuation.test.js`:
- listContinuations 404 on unknown project
- listContinuations happy path
- createContinuation 404 on unknown project
- createContinuation 422 on empty `currentStatus`
- createContinuation 422 on malformed `nextStepUrl`
- createContinuation stamps submitter wallet + chain from req.user
- defaults wantSupport=false and trims free-text fields

**Full server suite: 230 / 230** (this branch's baseline was 223; +7).

## Client

- `ApiProjectContinuation` type
- `api.listProjectContinuations` + `api.createProjectContinuation`
- `siwsUtils`: `submit-continuation` action → matching server statement
- `ProjectContinuationModal` — 3 fields (currentStatus textarea with counter, wantSupport switch with conditional supportFor textarea, nextStepUrl input). Signs one-shot SIWS.
- `ProjectDetailsPage` — 'WHAT'S NEXT, MILESTONE 3? · SHARE UPDATE ▸' panel appears immediately under `M2SubmissionTimeline` when `m2Status === 'completed'` AND the viewer is a team member.

## Verification

- `cd server && npm test` → 230 / 230
- `cd client && npm run build` → clean
- `cd client && npm run lint --max-warnings 0` → clean

## Test scenarios

- On a completed M2 project page as a team member, the new panel renders. Click SHARE UPDATE ▸ → modal opens. Fill currentStatus + toggle wantSupport on → supportFor textarea appears. Submit → SIWS popup → success toast → modal closes.
- Empty currentStatus → CANCEL/SUBMIT button disabled.
- Malformed nextStepUrl (e.g. `ftp://`) → toast 'must start with http:// or https://'.
- Non-team viewer on a completed project → no SHARE UPDATE panel.
- Non-completed project → no panel regardless of viewer.

## Out of scope (intentional)

- **Admin inbox for continuation submissions** — left as a focused follow-up. Submissions are queryable via `GET /m2-program/:id/continuations` for now; admin UI can be added in a small later PR.
- **Notification trigger** when a continuation is submitted — left to the existing notification stack to grow into.

Targets `develop`. Draft for review.