### PR TITLE
feat(ui): redesign unit detail modal — pokemon-card style

### DIFF
--- a/client/src/components/unit-detail-modal.tsx
+++ b/client/src/components/unit-detail-modal.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -5,15 +6,14 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Separator } from "@/components/ui/separator";
-import { ExternalLink, Github } from "lucide-react";
+import { ExternalLink, Github, ChevronDown } from "lucide-react";
 
 interface Unit {
   unitNumber: string;
   title: string;
   author: string;
+  /** Long-form copy. Trimmed to a TL;DR by default; the full text is
+   *  revealed by the READ MORE toggle. */
   description: string;
   longDescription?: string;
   track: string;
@@ -24,6 +24,12 @@ interface Unit {
   demoUrl?: string;
   githubUrl?: string;
   projectUrl?: string;
+  /** Tech stack chips. Optional — falls through cleanly when absent. */
+  techStack?: string[];
+  /** Category chips (Gaming, DeFi, etc.). Optional. */
+  categories?: string[];
+  /** Team size; rendered as a stat chip when ≥ 1. */
+  teamSize?: number;
 }
 
 interface UnitDetailModalProps {
@@ -32,95 +38,181 @@ interface UnitDetailModalProps {
   unit: Unit;
 }
 
+/**
+ * First sentence (up to `max` chars) of `text`. Pokemon-card-style TL;DR:
+ * fast scan, the rest hides behind READ MORE.
+ */
+const tldr = (text: string | undefined, max = 160): string => {
+  if (!text) return "";
+  const sentenceMatch = text.match(/^[\s\S]+?[.!?](\s|$)/);
+  const first = sentenceMatch ? sentenceMatch[0].trim() : text.trim();
+  if (first.length <= max) return first;
+  return `${first.slice(0, max - 1).trimEnd()}…`;
+};
+
+/** Reusable stat tile — label on top, value bold below. */
+function StatTile({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="lcd px-3 py-2 min-w-0 flex-1">
+      <div className="label-hw-dim mb-1 truncate">{label}</div>
+      <div className="font-mono text-[14px] text-display tabular-nums truncate">{value}</div>
+    </div>
+  );
+}
+
 export function UnitDetailModal({ open, onOpenChange, unit }: UnitDetailModalProps) {
+  const [expanded, setExpanded] = useState(false);
+  const fullDescription = unit.longDescription || unit.description;
+  const summary = tldr(fullDescription);
+  const hasMore = fullDescription && fullDescription.length > summary.length;
+
+  const techChips = (unit.techStack || []).slice(0, 8);
+  const categoryChips = (unit.categories || []).slice(0, 4);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="lcd max-w-3xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <div className="label-hw-dim mb-2">
-            UNIT {unit.unitNumber}{unit.date && ` · ${unit.date}`}
-          </div>
-          <div className="flex items-start justify-between gap-4">
-            <div className="flex-1">
-              <DialogTitle className="font-display text-4xl uppercase tracking-tight text-display">
-                {unit.title}
-              </DialogTitle>
-              <DialogDescription className="label-hw-dim mt-2">
-                BY {unit.author.toUpperCase()}
-              </DialogDescription>
+      <DialogContent className="lcd max-w-xl max-h-[88vh] overflow-y-auto p-0">
+        {/* Card header — number + date pinned top-left, badges top-right */}
+        <DialogHeader className="px-5 pt-5 pb-3">
+          <div className="flex items-start justify-between gap-3 mb-1">
+            <div className="label-hw-dim">
+              UNIT {unit.unitNumber}{unit.date && ` · ${unit.date}`}
             </div>
-            <div className="flex gap-1">
+            <div className="flex gap-1 flex-shrink-0">
               {unit.isWinner && (
-                <span className="bg-display text-shell px-2 py-1 font-mono text-[10px] font-bold tracking-[0.12em]">
+                <span className="bg-display text-shell px-2 py-[2px] font-mono text-[10px] font-bold tracking-[0.12em]">
                   WINNER
                 </span>
               )}
               {unit.isM2 && (
-                <span className="border border-display text-display px-2 py-1 font-mono text-[10px] font-bold tracking-[0.12em]">
+                <span className="border border-display text-display px-2 py-[2px] font-mono text-[10px] font-bold tracking-[0.12em]">
                   M2
                 </span>
               )}
             </div>
           </div>
+          <DialogTitle className="font-display text-3xl md:text-4xl uppercase tracking-tight text-display leading-[0.95]">
+            {unit.title}
+          </DialogTitle>
+          <DialogDescription className="label-hw-dim mt-1">
+            BY {unit.author.toUpperCase()}
+          </DialogDescription>
         </DialogHeader>
 
-        <Separator className="my-4 bg-hairline-subtle" />
-
-        <div className="space-y-4">
-          <div>
-            <div className="label-hw mb-2">TRACK</div>
-            <Badge
-              variant="outline"
-              className="font-mono text-[10px] tracking-[0.14em] border-hairline text-label-mid bg-transparent"
-            >
-              {unit.track.toUpperCase()}
-            </Badge>
-          </div>
-
-          {unit.prize && (
-            <div>
-              <div className="label-hw mb-2">PRIZE</div>
-              <div className="font-mono text-display font-bold">{unit.prize}</div>
-            </div>
+        {/* Stat strip — pokemon-card style: 3-4 tiles at a glance */}
+        <div className="px-5 pb-3 flex gap-2">
+          <StatTile
+            label="TRACK"
+            value={<span className="text-[12px]">{unit.track.toUpperCase()}</span>}
+          />
+          {unit.prize && <StatTile label="PRIZE" value={unit.prize} />}
+          {typeof unit.teamSize === "number" && unit.teamSize > 0 && (
+            <StatTile label="TEAM" value={unit.teamSize} />
           )}
+          {techChips.length > 0 && (
+            <StatTile label="STACK" value={techChips.length} />
+          )}
+        </div>
 
-          <div>
-            <div className="label-hw mb-2">DESCRIPTION</div>
-            <p className="text-body leading-relaxed">
-              {unit.longDescription || unit.description}
+        {/* TL;DR — first sentence, mono caps for the lead-in arrow */}
+        {summary && (
+          <div className="px-5 pb-3">
+            <p className="text-body leading-relaxed text-sm">
+              <span className="label-hw-dim mr-1">▸</span>
+              {summary}
             </p>
           </div>
+        )}
 
-          <Separator className="bg-hairline-subtle" />
+        {/* Tech chips */}
+        {techChips.length > 0 && (
+          <div className="px-5 pb-3">
+            <div className="label-hw-dim mb-1.5">·STACK</div>
+            <div className="flex flex-wrap gap-1">
+              {techChips.map((t) => (
+                <span
+                  key={t}
+                  className="border border-hairline text-label-mid bg-panel-deep px-2 py-[1px] font-mono text-[10px] tracking-[0.12em] uppercase"
+                >
+                  {t}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
 
-          <div className="flex gap-2">
-            {unit.demoUrl && (
-              <Button className="flex-1" onClick={() => window.open(unit.demoUrl, "_blank")}>
-                <ExternalLink className="w-4 h-4 mr-2" />
-                VIEW DEMO
-              </Button>
-            )}
-            {unit.projectUrl && (
-              <Button
-                variant="secondary"
-                className="flex-1"
-                onClick={() => window.open(unit.projectUrl, "_blank")}
-              >
-                PROJECT PAGE
-              </Button>
-            )}
-            {unit.githubUrl && (
-              <Button
-                variant="outline"
-                size="icon"
-                className="text-label-mid hover:text-display"
-                onClick={() => window.open(unit.githubUrl, "_blank")}
-                aria-label="View on GitHub"
-              >
-                <Github className="w-5 h-5" />
-              </Button>
+        {/* Category chips — distinct tone (display border) so they don't
+            blur into the tech stack row */}
+        {categoryChips.length > 0 && (
+          <div className="px-5 pb-3">
+            <div className="label-hw-dim mb-1.5">·CATEGORIES</div>
+            <div className="flex flex-wrap gap-1">
+              {categoryChips.map((c) => (
+                <span
+                  key={c}
+                  className="border border-display text-display px-2 py-[1px] font-mono text-[10px] tracking-[0.12em] uppercase"
+                >
+                  {c}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* READ MORE — preserves the full long-form description for
+            anyone who wants it without forcing it on every viewer */}
+        {hasMore && (
+          <div className="px-5 pb-3">
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              className="label-hw-dim hover:text-display transition-colors duration-150 inline-flex items-center gap-1"
+              aria-expanded={expanded}
+            >
+              {expanded ? "▴ READ LESS" : "▾ READ MORE"}
+              <ChevronDown
+                className={`h-3 w-3 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
+                aria-hidden="true"
+              />
+            </button>
+            {expanded && (
+              <p className="text-body leading-relaxed text-sm mt-3 whitespace-pre-line">
+                {fullDescription}
+              </p>
             )}
           </div>
+        )}
+
+        {/* Action bar */}
+        <div className="border-t border-hairline-subtle px-5 py-3 flex flex-wrap gap-2">
+          {unit.demoUrl && (
+            <button
+              type="button"
+              onClick={() => window.open(unit.demoUrl, "_blank", "noopener,noreferrer")}
+              className="flex-1 min-w-[140px] inline-flex items-center justify-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim px-3 py-2"
+            >
+              <ExternalLink className="w-3 h-3" />
+              VIEW DEMO
+            </button>
+          )}
+          {unit.projectUrl && (
+            <a
+              href={unit.projectUrl}
+              className="flex-1 min-w-[140px] inline-flex items-center justify-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep px-3 py-2"
+            >
+              PROJECT PAGE
+            </a>
+          )}
+          {unit.githubUrl && (
+            <button
+              type="button"
+              onClick={() => window.open(unit.githubUrl, "_blank", "noopener,noreferrer")}
+              aria-label="View on GitHub"
+              className="inline-flex items-center justify-center border border-hairline text-label-mid hover:text-display hover:bg-panel-deep w-9 h-9 flex-shrink-0"
+            >
+              <Github className="w-4 h-4" />
+            </button>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -33,6 +33,9 @@ type UnitForCard = {
   demoUrl?: string;
   githubUrl?: string;
   projectUrl?: string;
+  techStack?: string[];
+  categories?: string[];
+  teamSize?: number;
 };
 
 const FILTER_TO_CATEGORY: Record<string, string> = {
@@ -161,6 +164,9 @@ const HomePage = () => {
       demoUrl: p.demoUrl,
       githubUrl: p.projectRepo,
       projectUrl: p.id ? `/m2-program/${p.id}` : undefined,
+      techStack: Array.isArray(p.techStack) ? p.techStack : undefined,
+      categories: p.categories,
+      teamSize: p.teamMembers?.length,
     };
   }, []);
 

--- a/client/src/pages/WinnersPage.tsx
+++ b/client/src/pages/WinnersPage.tsx
@@ -21,6 +21,7 @@ type ApiProject = {
   demoUrl?: string;
   liveUrl?: string;
   bountyPrize?: { name: string; amount: number; hackathonWonAtId: string }[];
+  techStack?: string[];
   categories?: string[];
   m2Status?: "building" | "under_review" | "completed";
   hackathon?: { id: string; name: string; endDate: string };
@@ -40,6 +41,9 @@ type Unit = {
   demoUrl?: string;
   githubUrl?: string;
   projectUrl?: string;
+  techStack?: string[];
+  categories?: string[];
+  teamSize?: number;
 };
 
 const WinnersPage = () => {
@@ -99,6 +103,9 @@ const WinnersPage = () => {
               demoUrl: p.demoUrl,
               githubUrl: p.projectRepo,
               projectUrl: p.id ? `/m2-program/${p.id}` : undefined,
+              techStack: Array.isArray(p.techStack) ? p.techStack : undefined,
+              categories: p.categories,
+              teamSize: p.teamMembers?.length,
             };
           }),
         );


### PR DESCRIPTION
User-driven: the modal dumps the entire long-form description on open ([screenshot ref](.) from this session shows OpenArkiv's wall of text). This pass restructures to a fast-scan, pokemon-card-style hierarchy. **Will be batched into the next develop→main release PR with #111–#114.**

## Layout (top → bottom)

1. **Card header** — unit number + date pinned top-left, WINNER / M2 badges top-right. Title (font-display, all-caps) + BY <author>.
2. **Stat strip** — 2-to-4 LCD tiles inline: TRACK, PRIZE, TEAM size, STACK count. At-a-glance overview.
3. **TL;DR** — first sentence (or first 160 chars) of the description with a leading `▸`. Pokemon-card 'flavor text' equivalent.
4. **STACK chips** — tech stack as bordered mono chips (max 8).
5. **CATEGORIES chips** — display-toned border to differentiate from STACK.
6. **READ MORE toggle** — reveals the full long-form description in a collapsible block. Default collapsed — removes the wall of text from the initial view but doesn't lose the info.
7. **Action bar** — VIEW DEMO (display fill) + PROJECT PAGE (outline) + GH icon. Same affordances as before, tighter chrome.

## Data plumbed through

`Unit` (in `unit-detail-modal.tsx`) + `UnitForCard` (HomePage) + `Unit` (WinnersPage) all gain optional:
- `techStack?: string[]`
- `categories?: string[]`
- `teamSize?: number`

`HomePage.toUnit` and `WinnersPage`'s loader populate from the `ApiProject` shape. **Missing fields just render fewer tiles** — no breakage on legacy projects without tech/categories data.

## Why this design

- Pokemon cards lead with at-a-glance stats and a short flavor line, then hide depth in 'moves' and small text. Same structure here: stat strip on top, expandable depth below.
- The TL;DR (first sentence + ellipsis) is **auto-derived** — no schema change required. Projects whose description starts with a thesis-style first sentence get a clean summary for free.
- READ MORE preserves every word for anyone who cares; nothing dropped.

## Files

- `client/src/components/unit-detail-modal.tsx` — full rewrite (~+90 / -65)
- `client/src/pages/HomePage.tsx` — `UnitForCard` extended; `toUnit` populates new fields
- `client/src/pages/WinnersPage.tsx` — `Unit` extended; loader populates new fields

## Verification

- `npm run build` → clean (tsc + vite)
- `npm run lint --max-warnings 0` → 0 warnings / 0 errors

## Test scenarios

- Open any unit card on `/` (HomePage) or `/winners/:hackathon`. The modal shows the title big, stat tiles inline, TL;DR `▸` line, tech chips, READ MORE toggle.
- Click READ MORE → full description expands inline. Click again → collapses.
- A project with NO tech stack and NO categories renders only TRACK + PRIZE + TEAM stat tiles (no empty chip rows).
- A project with a single short description (≤ 160 chars) renders the full text inline; no READ MORE toggle appears.

Targets `develop`. Draft for review.