### PR TITLE
feat(ui): global ⌘K search + mobile-friendly nav + brightness collapse on small screens

### DIFF
--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -1,6 +1,9 @@
+import { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
+import { Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { BrightnessRack } from "./brightness-rack";
+import { SearchPalette } from "./SearchPalette";
 
 const TABS = [
   { href: "/", label: "HOME" },
@@ -12,21 +15,28 @@ const TABS = [
 export function Navigation() {
   const location = useLocation();
   const pathname = location.pathname;
+  const [searchOpen, setSearchOpen] = useState(false);
 
   return (
     <nav className="sticky top-0 z-50 panel border-b">
-      <div className="container mx-auto px-4">
-        {/* Top strip — brand + tabs + online status */}
-        <div className="flex items-center justify-between h-12 gap-4">
-          <Link to="/" className="flex items-center gap-2 group">
+      <div className="container mx-auto px-3 sm:px-4">
+        {/* Top strip — brand + tabs + search + online status.
+            Layout is responsive: tabs are scrollable on narrow screens; the
+            online label collapses to just the LED dot on small screens. */}
+        <div className="flex items-center justify-between h-12 gap-2 sm:gap-4">
+          <Link to="/" className="flex items-center gap-2 group flex-shrink-0">
             <span className="led" aria-hidden="true" />
-            <span className="font-mono font-bold text-[15px] text-display tracking-wide">
-              STADIUM <span className="text-label-dim font-normal text-[11px]">|||</span>
+            <span className="font-mono font-bold text-[13px] sm:text-[15px] text-display tracking-wide">
+              STADIUM <span className="text-label-dim font-normal text-[10px] sm:text-[11px]">|||</span>
             </span>
           </Link>
 
-          {/* Hardware tab strip — flush buttons, no gaps */}
-          <div className="flex" role="tablist">
+          {/* Hardware tab strip — scrolls horizontally on narrow screens
+              rather than overflowing. -mx- so the scrollbar sits flush. */}
+          <div
+            className="flex overflow-x-auto no-scrollbar -mx-1 px-1 flex-shrink min-w-0"
+            role="tablist"
+          >
             {TABS.map((tab, i) => {
               const active =
                 pathname === tab.href ||
@@ -39,11 +49,11 @@ export function Navigation() {
                   aria-selected={active}
                   aria-current={active ? "page" : undefined}
                   className={cn(
-                    "px-3 py-1 font-mono text-[10px] tracking-[0.14em] border border-hairline transition-colors duration-150",
+                    "px-2.5 sm:px-3 py-1 font-mono text-[10px] tracking-[0.14em] border border-hairline transition-colors duration-150 whitespace-nowrap",
                     i > 0 && "border-l-0",
                     active
                       ? "bg-display text-shell font-bold"
-                      : "bg-shell text-label-dim hover:text-display"
+                      : "bg-shell text-label-dim hover:text-display",
                   )}
                 >
                   {tab.label}
@@ -52,17 +62,36 @@ export function Navigation() {
             })}
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5 sm:gap-2 flex-shrink-0">
+            {/* Global search — visible everywhere, full keyboard shortcut. */}
+            <button
+              type="button"
+              onClick={() => setSearchOpen(true)}
+              aria-label="Open search (Cmd+K)"
+              title="Search projects and programs (⌘K)"
+              className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep h-7 px-2"
+            >
+              <Search className="h-3 w-3" />
+              <span className="hidden sm:inline">SEARCH</span>
+              <kbd className="hidden md:inline label-hw-dim border border-hairline px-1 py-0 leading-none">
+                ⌘K
+              </kbd>
+            </button>
+
+            {/* Status dot — label hidden on small screens. */}
             <span className="led" aria-hidden="true" />
-            <span className="label-hw">ONLINE</span>
+            <span className="label-hw hidden sm:inline">ONLINE</span>
           </div>
         </div>
 
-        {/* Second row — brightness rack, always visible */}
+        {/* Brightness rack — second row. On mobile it defaults to its
+            collapsed strip so it doesn't dominate the viewport. */}
         <div className="pb-2">
           <BrightnessRack />
         </div>
       </div>
+
+      <SearchPalette open={searchOpen} onOpenChange={setSearchOpen} />
     </nav>
   );
 }

--- a/client/src/components/SearchPalette.tsx
+++ b/client/src/components/SearchPalette.tsx
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Loader2, Search } from "lucide-react";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { api, type ApiProject, type ApiProgram } from "@/lib/api";
+
+/**
+ * Global search palette. Triggered by:
+ *   - Cmd/Ctrl + K anywhere in the app
+ *   - The SEARCH button in Navigation
+ *   - Any caller passing `open` + `onOpenChange` (e.g. a future mobile FAB)
+ *
+ * Search hits both `projects` and `programs` lists in parallel. On select,
+ * navigates to the canonical detail page and closes the palette. Cmdk does
+ * fuzzy filtering client-side; we don't round-trip the query.
+ */
+export function SearchPalette({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+}) {
+  const navigate = useNavigate();
+  const [query, setQuery] = useState("");
+  const [projects, setProjects] = useState<ApiProject[]>([]);
+  const [programs, setPrograms] = useState<ApiProgram[]>([]);
+  const [loading, setLoading] = useState(false);
+  const loadedRef = useRef(false);
+
+  // Lazy-load the search corpus once on first open. Loading both lists
+  // costs one extra request beyond what the home page already does, and
+  // cmdk filters client-side from there. Refresh-on-mount happens because
+  // the dialog unmounts between sessions when the parent re-renders.
+  useEffect(() => {
+    if (!open || loadedRef.current) return;
+    loadedRef.current = true;
+    setLoading(true);
+    Promise.all([
+      api.getProjects({ limit: 1000, sortBy: "updatedAt", sortOrder: "desc" }).catch(() => null),
+      api.listPrograms().catch(() => null),
+    ])
+      .then(([projectResp, programResp]) => {
+        if (projectResp?.data) setProjects(projectResp.data);
+        if (programResp?.data) setPrograms(programResp.data);
+      })
+      .finally(() => setLoading(false));
+  }, [open]);
+
+  // Cmd/Ctrl + K toggles the palette from anywhere on the app.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        onOpenChange(!open);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onOpenChange]);
+
+  const selectProject = useCallback(
+    (id: string) => {
+      onOpenChange(false);
+      setQuery("");
+      navigate(`/m2-program/${id}`);
+    },
+    [navigate, onOpenChange],
+  );
+
+  const selectProgram = useCallback(
+    (slug: string) => {
+      onOpenChange(false);
+      setQuery("");
+      navigate(`/programs/${slug}`);
+    },
+    [navigate, onOpenChange],
+  );
+
+  // Pre-compute searchable hints so cmdk's matcher catches them even when
+  // they're hidden from the rendered row (author name, project id, etc.).
+  const projectItems = useMemo(
+    () =>
+      projects.map((p) => ({
+        id: p.id,
+        title: p.projectName,
+        meta: p.teamMembers?.[0]?.name || "Unknown team",
+        keywords: [
+          p.projectName,
+          p.teamMembers?.[0]?.name || "",
+          p.hackathon?.name || "",
+          ...(p.categories || []),
+          ...(p.techStack || []),
+        ]
+          .filter(Boolean)
+          .join(" "),
+      })),
+    [projects],
+  );
+
+  return (
+    <CommandDialog open={open} onOpenChange={onOpenChange}>
+      <CommandInput
+        placeholder="Search projects, programs, teams…"
+        value={query}
+        onValueChange={setQuery}
+      />
+      <CommandList className="max-h-[60vh]">
+        {loading ? (
+          <div className="flex items-center gap-2 label-hw-dim py-4 px-4">
+            <Loader2 className="h-3 w-3 animate-spin" /> LOADING SEARCH INDEX…
+          </div>
+        ) : (
+          <>
+            <CommandEmpty>
+              <span className="label-hw-dim">·NO MATCHES</span>
+            </CommandEmpty>
+
+            {programs.length > 0 && (
+              <CommandGroup heading="PROGRAMS">
+                {programs.map((p) => (
+                  <CommandItem
+                    key={`prog-${p.id}`}
+                    value={`program ${p.name} ${p.slug} ${p.programType}`}
+                    onSelect={() => selectProgram(p.slug)}
+                    className="flex items-center justify-between gap-3"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="font-mono text-[12px] text-display truncate">
+                        {p.name}
+                      </div>
+                      <div className="label-hw-dim truncate">
+                        {p.programType.toUpperCase()}
+                        {p.location ? ` · ${p.location.toUpperCase()}` : ""}
+                      </div>
+                    </div>
+                    <span className="label-hw-dim flex-shrink-0">
+                      {p.status.toUpperCase()}
+                    </span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+
+            {projectItems.length > 0 && (
+              <CommandGroup heading="PROJECTS">
+                {projectItems.map((p) => (
+                  <CommandItem
+                    key={`proj-${p.id}`}
+                    value={`project ${p.title} ${p.keywords}`}
+                    onSelect={() => selectProject(p.id)}
+                    className="flex items-center justify-between gap-3"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="font-mono text-[12px] text-display truncate">
+                        {p.title}
+                      </div>
+                      <div className="label-hw-dim truncate">BY {p.meta.toUpperCase()}</div>
+                    </div>
+                    <Search className="h-3 w-3 text-label-dim flex-shrink-0" aria-hidden="true" />
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+          </>
+        )}
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/client/src/hooks/use-brightness.ts
+++ b/client/src/hooks/use-brightness.ts
@@ -14,12 +14,23 @@ interface StoredState {
   collapsed: boolean;
 }
 
+// Below this viewport width we treat the device as "mobile-ish" and default
+// the brightness rack to its compact strip — otherwise the full panel eats
+// ~170px of vertical space on every page load, which felt invasive.
+const MOBILE_BREAKPOINT_PX = 640;
+
+function isMobileViewport(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.innerWidth < MOBILE_BREAKPOINT_PX;
+}
+
 function readStored(): StoredState {
   const defaults: StoredState = {
     mode: 'auto',
     manualValue: null,
     paletteKey: DEFAULT_PALETTE_KEY,
-    collapsed: false,
+    // Default to collapsed on mobile viewports; users can expand explicitly.
+    collapsed: isMobileViewport(),
   };
   if (typeof window === 'undefined') return defaults;
   try {
@@ -31,7 +42,11 @@ function readStored(): StoredState {
       mode: parsed.mode,
       manualValue: typeof parsed.manualValue === 'number' ? parsed.manualValue : null,
       paletteKey: typeof parsed.paletteKey === 'string' ? parsed.paletteKey : DEFAULT_PALETTE_KEY,
-      collapsed: typeof parsed.collapsed === 'boolean' ? parsed.collapsed : false,
+      // Honor a stored collapsed=true; if the user never set one, fall back
+      // to the mobile-viewport default so first-time mobile loads aren't
+      // dominated by the brightness panel.
+      collapsed:
+        typeof parsed.collapsed === 'boolean' ? parsed.collapsed : isMobileViewport(),
     };
   } catch {
     return defaults;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -162,3 +162,13 @@ code, pre { @apply font-mono; }
 @media (prefers-reduced-motion: reduce) {
   .led-pulse { animation: none; }
 }
+
+/* Hide scrollbar on horizontally-scrollable strips (nav tabs on mobile)
+   while keeping the content scrollable. Cross-browser shorthand. */
+.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -181,7 +181,10 @@ const HomePage = () => {
       );
     }
 
-    if (showWinnersOnly) {
+    // When a search query is active, ignore the winners-only filter so
+    // non-winning matches still surface — the user clearly wants a
+    // specific project, regardless of category default.
+    if (showWinnersOnly && !searchQuery) {
       filtered = filtered.filter((p) => Array.isArray(p.bountyPrize) && p.bountyPrize.length > 0);
     }
 
@@ -306,7 +309,6 @@ const HomePage = () => {
             value={searchQuery}
             onChange={setSearchQuery}
             placeholder="search units..."
-            kbdHint="⌘K"
             className="flex-1 min-w-[200px]"
           />
           {hackathons.length > 0 && (


### PR DESCRIPTION
User flagged three coupled UX bugs:
> 'its not iphone friendly and on mobile the scale brightness on mobile is too invasive… when i want to search a name or project its not possible. anywhere i am on the page i should be able to search.'

Three fixes in one PR, plus a related search-result regression caught along the way.

## 1. Brightness rack dominated mobile viewports

The expanded panel ate ~170px of vertical space on every page load. `useBrightness` now defaults `collapsed` to true when viewport < 640px AND no prior preference is stored. The strip still expands on tap. **Stored preferences still win** — a user who explicitly expanded once doesn't get re-collapsed on the next visit.

## 2. Search was only on /

Added `SearchPalette` (cmdk-based) bound to **⌘K globally** + a SEARCH button in `Navigation` visible on every page. Loads project + program lists lazily on first open, then cmdk filters client-side. Selecting a result navigates to the canonical detail page.

## 3. Nav top row overflowed on narrow screens

Tabs now sit in a horizontally-scrollable strip (`.no-scrollbar` class added to `index.css`). ONLINE label hidden < 640px (LED dot remains). Brand text scales down to 13px on mobile.

## Bonus regression fix

HomePage search query was AND'd with `showWinnersOnly` (default `true`), so searching for a non-winner returned zero results — a real bug. Search now overrides the winners-only filter when a query is active, so typing a name surfaces the project regardless of winner status.

Also removed `kbdHint="⌘K"` from HomePage's InputBus so the global palette owns ⌘K without a double-handler conflict.

## Files

- `client/src/components/SearchPalette.tsx` (new) — cmdk dialog with project + program groups
- `client/src/components/Navigation.tsx` — SEARCH button, mobile-friendly layout, mounts palette
- `client/src/hooks/use-brightness.ts` — default collapsed on < 640px viewports
- `client/src/index.css` — `.no-scrollbar` utility
- `client/src/pages/HomePage.tsx` — drop `kbdHint` to avoid conflict; override `showWinnersOnly` when searching

## Verification

- `npm run build` → clean (tsc + vite)
- `npm run lint --max-warnings 0` → 0 warnings / 0 errors

## Test scenarios

- On any page (Home, M2, Programs, Admin, a project detail), press ⌘K (or Ctrl+K) → search palette opens. Type 'plata' → Plata Mia row appears. Click it → navigates to the project page; palette closes.
- Click the SEARCH button in the nav → same palette.
- On `/` with default settings (winners-only ON), type 'openarkiv' → result appears even though the winners-only filter is on. Clear the search → list reverts to winners-only.
- Resize to ~375px wide. Brightness rack renders as the compact one-line strip, not the full panel. Nav tabs scroll horizontally without breaking layout. ONLINE label is gone but the LED dot remains.
- Click the brightness strip to expand → it expands. Reload — still expanded (preference stored). Clear localStorage and reload < 640px → collapsed again.

No schema, no env, no server changes. Pure client UX.

Targets `develop`. Draft for review.