### PR TITLE
release: onboarding + inbox + audit log + continuations + pokemon card + global search

### DIFF
--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -1,6 +1,9 @@
+import { useState } from "react";
 import { Link, useLocation } from "react-router-dom";
+import { Search } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { BrightnessRack } from "./brightness-rack";
+import { SearchPalette } from "./SearchPalette";
 
 const TABS = [
   { href: "/", label: "HOME" },
@@ -12,21 +15,28 @@ const TABS = [
 export function Navigation() {
   const location = useLocation();
   const pathname = location.pathname;
+  const [searchOpen, setSearchOpen] = useState(false);
 
   return (
     <nav className="sticky top-0 z-50 panel border-b">
-      <div className="container mx-auto px-4">
-        {/* Top strip — brand + tabs + online status */}
-        <div className="flex items-center justify-between h-12 gap-4">
-          <Link to="/" className="flex items-center gap-2 group">
+      <div className="container mx-auto px-3 sm:px-4">
+        {/* Top strip — brand + tabs + search + online status.
+            Layout is responsive: tabs are scrollable on narrow screens; the
+            online label collapses to just the LED dot on small screens. */}
+        <div className="flex items-center justify-between h-12 gap-2 sm:gap-4">
+          <Link to="/" className="flex items-center gap-2 group flex-shrink-0">
             <span className="led" aria-hidden="true" />
-            <span className="font-mono font-bold text-[15px] text-display tracking-wide">
-              STADIUM <span className="text-label-dim font-normal text-[11px]">|||</span>
+            <span className="font-mono font-bold text-[13px] sm:text-[15px] text-display tracking-wide">
+              STADIUM <span className="text-label-dim font-normal text-[10px] sm:text-[11px]">|||</span>
             </span>
           </Link>
 
-          {/* Hardware tab strip — flush buttons, no gaps */}
-          <div className="flex" role="tablist">
+          {/* Hardware tab strip — scrolls horizontally on narrow screens
+              rather than overflowing. -mx- so the scrollbar sits flush. */}
+          <div
+            className="flex overflow-x-auto no-scrollbar -mx-1 px-1 flex-shrink min-w-0"
+            role="tablist"
+          >
             {TABS.map((tab, i) => {
               const active =
                 pathname === tab.href ||
@@ -39,11 +49,11 @@ export function Navigation() {
                   aria-selected={active}
                   aria-current={active ? "page" : undefined}
                   className={cn(
-                    "px-3 py-1 font-mono text-[10px] tracking-[0.14em] border border-hairline transition-colors duration-150",
+                    "px-2.5 sm:px-3 py-1 font-mono text-[10px] tracking-[0.14em] border border-hairline transition-colors duration-150 whitespace-nowrap",
                     i > 0 && "border-l-0",
                     active
                       ? "bg-display text-shell font-bold"
-                      : "bg-shell text-label-dim hover:text-display"
+                      : "bg-shell text-label-dim hover:text-display",
                   )}
                 >
                   {tab.label}
@@ -52,17 +62,36 @@ export function Navigation() {
             })}
           </div>
 
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-1.5 sm:gap-2 flex-shrink-0">
+            {/* Global search — visible everywhere, full keyboard shortcut. */}
+            <button
+              type="button"
+              onClick={() => setSearchOpen(true)}
+              aria-label="Open search (Cmd+K)"
+              title="Search projects and programs (⌘K)"
+              className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep h-7 px-2"
+            >
+              <Search className="h-3 w-3" />
+              <span className="hidden sm:inline">SEARCH</span>
+              <kbd className="hidden md:inline label-hw-dim border border-hairline px-1 py-0 leading-none">
+                ⌘K
+              </kbd>
+            </button>
+
+            {/* Status dot — label hidden on small screens. */}
             <span className="led" aria-hidden="true" />
-            <span className="label-hw">ONLINE</span>
+            <span className="label-hw hidden sm:inline">ONLINE</span>
           </div>
         </div>
 
-        {/* Second row — brightness rack, always visible */}
+        {/* Brightness rack — second row. On mobile it defaults to its
+            collapsed strip so it doesn't dominate the viewport. */}
         <div className="pb-2">
           <BrightnessRack />
         </div>
       </div>
+
+      <SearchPalette open={searchOpen} onOpenChange={setSearchOpen} />
     </nav>
   );
 }

--- a/client/src/components/SearchPalette.tsx
+++ b/client/src/components/SearchPalette.tsx
@@ -1,0 +1,177 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Loader2, Search } from "lucide-react";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { api, type ApiProject, type ApiProgram } from "@/lib/api";
+
+/**
+ * Global search palette. Triggered by:
+ *   - Cmd/Ctrl + K anywhere in the app
+ *   - The SEARCH button in Navigation
+ *   - Any caller passing `open` + `onOpenChange` (e.g. a future mobile FAB)
+ *
+ * Search hits both `projects` and `programs` lists in parallel. On select,
+ * navigates to the canonical detail page and closes the palette. Cmdk does
+ * fuzzy filtering client-side; we don't round-trip the query.
+ */
+export function SearchPalette({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+}) {
+  const navigate = useNavigate();
+  const [query, setQuery] = useState("");
+  const [projects, setProjects] = useState<ApiProject[]>([]);
+  const [programs, setPrograms] = useState<ApiProgram[]>([]);
+  const [loading, setLoading] = useState(false);
+  const loadedRef = useRef(false);
+
+  // Lazy-load the search corpus once on first open. Loading both lists
+  // costs one extra request beyond what the home page already does, and
+  // cmdk filters client-side from there. Refresh-on-mount happens because
+  // the dialog unmounts between sessions when the parent re-renders.
+  useEffect(() => {
+    if (!open || loadedRef.current) return;
+    loadedRef.current = true;
+    setLoading(true);
+    Promise.all([
+      api.getProjects({ limit: 1000, sortBy: "updatedAt", sortOrder: "desc" }).catch(() => null),
+      api.listPrograms().catch(() => null),
+    ])
+      .then(([projectResp, programResp]) => {
+        if (projectResp?.data) setProjects(projectResp.data);
+        if (programResp?.data) setPrograms(programResp.data);
+      })
+      .finally(() => setLoading(false));
+  }, [open]);
+
+  // Cmd/Ctrl + K toggles the palette from anywhere on the app.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        onOpenChange(!open);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onOpenChange]);
+
+  const selectProject = useCallback(
+    (id: string) => {
+      onOpenChange(false);
+      setQuery("");
+      navigate(`/m2-program/${id}`);
+    },
+    [navigate, onOpenChange],
+  );
+
+  const selectProgram = useCallback(
+    (slug: string) => {
+      onOpenChange(false);
+      setQuery("");
+      navigate(`/programs/${slug}`);
+    },
+    [navigate, onOpenChange],
+  );
+
+  // Pre-compute searchable hints so cmdk's matcher catches them even when
+  // they're hidden from the rendered row (author name, project id, etc.).
+  const projectItems = useMemo(
+    () =>
+      projects.map((p) => ({
+        id: p.id,
+        title: p.projectName,
+        meta: p.teamMembers?.[0]?.name || "Unknown team",
+        keywords: [
+          p.projectName,
+          p.teamMembers?.[0]?.name || "",
+          p.hackathon?.name || "",
+          ...(p.categories || []),
+          ...(p.techStack || []),
+        ]
+          .filter(Boolean)
+          .join(" "),
+      })),
+    [projects],
+  );
+
+  return (
+    <CommandDialog open={open} onOpenChange={onOpenChange}>
+      <CommandInput
+        placeholder="Search projects, programs, teams…"
+        value={query}
+        onValueChange={setQuery}
+      />
+      <CommandList className="max-h-[60vh]">
+        {loading ? (
+          <div className="flex items-center gap-2 label-hw-dim py-4 px-4">
+            <Loader2 className="h-3 w-3 animate-spin" /> LOADING SEARCH INDEX…
+          </div>
+        ) : (
+          <>
+            <CommandEmpty>
+              <span className="label-hw-dim">·NO MATCHES</span>
+            </CommandEmpty>
+
+            {programs.length > 0 && (
+              <CommandGroup heading="PROGRAMS">
+                {programs.map((p) => (
+                  <CommandItem
+                    key={`prog-${p.id}`}
+                    value={`program ${p.name} ${p.slug} ${p.programType}`}
+                    onSelect={() => selectProgram(p.slug)}
+                    className="flex items-center justify-between gap-3"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="font-mono text-[12px] text-display truncate">
+                        {p.name}
+                      </div>
+                      <div className="label-hw-dim truncate">
+                        {p.programType.toUpperCase()}
+                        {p.location ? ` · ${p.location.toUpperCase()}` : ""}
+                      </div>
+                    </div>
+                    <span className="label-hw-dim flex-shrink-0">
+                      {p.status.toUpperCase()}
+                    </span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+
+            {projectItems.length > 0 && (
+              <CommandGroup heading="PROJECTS">
+                {projectItems.map((p) => (
+                  <CommandItem
+                    key={`proj-${p.id}`}
+                    value={`project ${p.title} ${p.keywords}`}
+                    onSelect={() => selectProject(p.id)}
+                    className="flex items-center justify-between gap-3"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="font-mono text-[12px] text-display truncate">
+                        {p.title}
+                      </div>
+                      <div className="label-hw-dim truncate">BY {p.meta.toUpperCase()}</div>
+                    </div>
+                    <Search className="h-3 w-3 text-label-dim flex-shrink-0" aria-hidden="true" />
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+          </>
+        )}
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/client/src/components/admin/AdminTierSection.tsx
+++ b/client/src/components/admin/AdminTierSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
-import { Trash2, Loader2 } from "lucide-react";
+import { Trash2, Loader2, Copy, Check } from "lucide-react";
 import { api, type ApiAdminTierEntry, type AdminAuthArg, ApiError } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
 
@@ -34,6 +34,7 @@ export function AdminTierSection({
   const [loading, setLoading] = useState(false);
   const [adding, setAdding] = useState(false);
   const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
   const [wallet, setWallet] = useState("");
   const [label, setLabel] = useState("");
   const [chain, setChain] = useState<ChainOption>("substrate");
@@ -88,6 +89,32 @@ export function AdminTierSection({
     }
   };
 
+  const handleCopyInvite = async (entry: ApiAdminTierEntry) => {
+    const key = `${entry.walletChain}:${entry.wallet}`;
+    const origin = typeof window !== "undefined" ? window.location.origin : "https://stadium.joinwebzero.com";
+    const tierLabel = title.toLowerCase();
+    const message =
+      `You're an admin on Stadium 🛰️\n\n` +
+      `Tier: ${tierLabel}\n` +
+      `Chain: ${entry.walletChain}\n` +
+      `Wallet: ${entry.wallet}\n` +
+      `Sign in: ${origin}/admin\n\n` +
+      `If you haven't already, install the wallet extension for your chain (Polkadot-JS, MetaMask, or Phantom) ` +
+      `and connect on the admin page. From there you can manage programs, sponsors, and signups.`;
+    try {
+      await navigator.clipboard.writeText(message);
+      setCopiedKey(key);
+      toast({ title: "Invite copied to clipboard" });
+      setTimeout(() => setCopiedKey((k) => (k === key ? null : k)), 2000);
+    } catch {
+      toast({
+        title: "Couldn't copy",
+        description: "Clipboard access denied — copy the wallet manually.",
+        variant: "destructive",
+      });
+    }
+  };
+
   const handleRemove = async (entry: ApiAdminTierEntry) => {
     const key = `${entry.walletChain}:${entry.wallet}`;
     if (!confirm(`Remove ${entry.label || entry.wallet}?`)) return;
@@ -138,16 +165,28 @@ export function AdminTierSection({
                     {a.addedBy ? ` · ADDED BY ${a.addedBy.toUpperCase()}` : ""}
                   </p>
                 </div>
-                <button
-                  type="button"
-                  onClick={() => handleRemove(a)}
-                  disabled={busyKey === key}
-                  aria-label={`Remove ${a.wallet}`}
-                  className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-destructive hover:bg-destructive/10 disabled:opacity-50 px-2 py-1 inline-flex items-center gap-1"
-                >
-                  {busyKey === key ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
-                  REMOVE
-                </button>
+                <div className="flex items-center gap-1.5 flex-shrink-0">
+                  <button
+                    type="button"
+                    onClick={() => handleCopyInvite(a)}
+                    aria-label={`Copy invite for ${a.wallet}`}
+                    title="Copy a pre-formatted invite message"
+                    className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep px-2 py-1 inline-flex items-center gap-1"
+                  >
+                    {copiedKey === key ? <Check className="h-3 w-3 text-led" /> : <Copy className="h-3 w-3" />}
+                    {copiedKey === key ? "COPIED" : "COPY INVITE"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(a)}
+                    disabled={busyKey === key}
+                    aria-label={`Remove ${a.wallet}`}
+                    className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-destructive hover:bg-destructive/10 disabled:opacity-50 px-2 py-1 inline-flex items-center gap-1"
+                  >
+                    {busyKey === key ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
+                    REMOVE
+                  </button>
+                </div>
               </li>
             );
           })}

--- a/client/src/components/admin/ProgramAuditLogSection.tsx
+++ b/client/src/components/admin/ProgramAuditLogSection.tsx
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useState } from "react";
+import { Loader2, RotateCw } from "lucide-react";
+import { api, type ApiAuditLogEntry, type AdminAuthArg, ApiError } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+
+const truncate = (s?: string | null, n = 18) => {
+  if (!s) return "—";
+  if (s.length <= n) return s;
+  return `${s.slice(0, Math.max(2, n - 4))}…${s.slice(-4)}`;
+};
+
+const relativeTime = (iso: string): string => {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 30) return `${d}d ago`;
+  return new Date(iso).toLocaleDateString();
+};
+
+const actionTone = (action: string): string => {
+  if (action.startsWith("admin.")) return "border-display text-display bg-panel-deep";
+  if (action.startsWith("sponsor.")) return "border-hairline text-display bg-panel-deep";
+  if (action.startsWith("signups.") || action.startsWith("signup.")) return "border-hairline text-label-mid";
+  if (action === "application.accepted") return "border-led text-led";
+  if (action === "application.rejected" || action === "application.withdrawn") return "border-hairline text-label-mid";
+  return "border-hairline text-display";
+};
+
+/**
+ * Per-program admin activity log. Surfaces who did what — sponsor edits,
+ * CSV imports, application status changes, admin add/remove — for
+ * handoff and forensics. Read-only on the client; writes happen as a
+ * side-effect of the underlying actions via `auditLog.logSafe` on the
+ * server.
+ */
+export function ProgramAuditLogSection({
+  programSlug,
+  signAuthHeader,
+}: {
+  programSlug: string;
+  signAuthHeader: () => Promise<AdminAuthArg>;
+}) {
+  const { toast } = useToast();
+  const [entries, setEntries] = useState<ApiAuditLogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(() => {
+    let active = true;
+    setLoading(true);
+    (async () => {
+      try {
+        const auth = await signAuthHeader();
+        const r = await api.listProgramAuditLog(programSlug, auth, { limit: 50 });
+        if (active) setEntries(r.data);
+      } catch (e) {
+        if (active) {
+          toast({
+            title: "Couldn't load audit log",
+            description: e instanceof ApiError ? e.message : (e as Error)?.message,
+            variant: "destructive",
+          });
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => { active = false; };
+  }, [programSlug, signAuthHeader, toast]);
+
+  useEffect(() => {
+    const cleanup = load();
+    return cleanup;
+  }, [load]);
+
+  return (
+    <div className="panel p-4 mb-3">
+      <div className="flex items-center justify-between mb-3 pb-3 border-b border-hairline-subtle">
+        <div className="flex items-center gap-3">
+          <span className="label-hw text-display">·AUDIT LOG</span>
+          <span className="label-hw-dim">LAST 50 ADMIN ACTIONS ON THIS PROGRAM</span>
+        </div>
+        <button
+          type="button"
+          onClick={load}
+          aria-label="Refresh audit log"
+          className="inline-flex items-center justify-center border border-hairline text-label-mid hover:text-display hover:bg-panel-deep w-7 h-7"
+        >
+          <RotateCw className="h-3 w-3" />
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 label-hw-dim py-4">
+          <Loader2 className="h-3 w-3 animate-spin" /> LOADING…
+        </div>
+      ) : entries.length === 0 ? (
+        <p className="text-body text-sm">No admin actions recorded yet for this program.</p>
+      ) : (
+        <ul className="space-y-1.5">
+          {entries.map((e) => (
+            <li
+              key={e.id}
+              className="lcd px-3 py-2 flex items-center justify-between gap-3"
+            >
+              <div className="min-w-0 flex-1 flex items-center gap-2">
+                <span
+                  className={`border ${actionTone(e.action)} px-1.5 py-[1px] font-mono text-[9px] tracking-[0.12em] uppercase`}
+                >
+                  {e.action}
+                </span>
+                <div className="min-w-0">
+                  <div className="font-mono text-[12px] text-display truncate">
+                    {e.targetId || e.targetType || "—"}
+                  </div>
+                  <div className="label-hw-dim truncate">
+                    BY {truncate(e.actorWallet)}
+                    {e.actorChain ? ` · ${e.actorChain.toUpperCase()}` : ""}
+                  </div>
+                </div>
+              </div>
+              <span
+                className="font-mono text-[10px] text-label-mid tabular-nums flex-shrink-0"
+                title={new Date(e.createdAt).toLocaleString()}
+              >
+                {relativeTime(e.createdAt).toUpperCase()}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/admin/ProgramInboxSection.tsx
+++ b/client/src/components/admin/ProgramInboxSection.tsx
@@ -1,0 +1,201 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Loader2, Download } from "lucide-react";
+import { api, type ApiInboxEntry, type AdminAuthArg, ApiError } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+
+type Filter = "all" | "signup" | "application";
+
+const formatDate = (iso?: string | null) => {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+};
+
+const truncate = (s?: string | null, n = 22) => {
+  if (!s) return "—";
+  if (s.length <= n) return s;
+  return `${s.slice(0, Math.max(2, n - 4))}…${s.slice(-4)}`;
+};
+
+/**
+ * Unified per-program inbox — merges signups (Luma CSV imports) and
+ * applications (project teams that applied in-app) into one table. Lets
+ * admins triage both streams in one place and export to CSV for sharing
+ * with sponsors.
+ */
+export function ProgramInboxSection({
+  programSlug,
+  signAuthHeader,
+}: {
+  programSlug: string;
+  signAuthHeader: () => Promise<AdminAuthArg>;
+}) {
+  const { toast } = useToast();
+  const [entries, setEntries] = useState<ApiInboxEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [exporting, setExporting] = useState(false);
+  const [filter, setFilter] = useState<Filter>("all");
+  const [meta, setMeta] = useState({ total: 0, signups: 0, applications: 0 });
+
+  const load = useCallback(() => {
+    let active = true;
+    setLoading(true);
+    (async () => {
+      try {
+        const auth = await signAuthHeader();
+        const r = await api.listProgramInbox(programSlug, auth);
+        if (!active) return;
+        setEntries(r.data);
+        setMeta(r.meta);
+      } catch (e) {
+        if (!active) return;
+        toast({
+          title: "Couldn't load inbox",
+          description: e instanceof ApiError ? e.message : (e as Error)?.message,
+          variant: "destructive",
+        });
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => { active = false; };
+  }, [programSlug, signAuthHeader, toast]);
+
+  useEffect(() => {
+    const cleanup = load();
+    return cleanup;
+  }, [load]);
+
+  const filtered = useMemo(
+    () => (filter === "all" ? entries : entries.filter((e) => e.source === filter)),
+    [entries, filter],
+  );
+
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      const auth = await signAuthHeader();
+      const blob = await api.exportProgramInboxCsv(programSlug, auth);
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `${programSlug}-inbox-${new Date().toISOString().slice(0, 10)}.csv`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+      toast({ title: "Inbox CSV downloaded" });
+    } catch (e) {
+      toast({
+        title: "Couldn't export inbox",
+        description: e instanceof ApiError ? e.message : (e as Error)?.message,
+        variant: "destructive",
+      });
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  return (
+    <div className="panel p-4 mb-3">
+      <div className="flex items-center justify-between mb-3 pb-3 border-b border-hairline-subtle flex-wrap gap-2">
+        <div className="flex items-center gap-3 flex-wrap">
+          <span className="label-hw text-display">·INBOX</span>
+          <span className="lcd px-2 py-[1px] font-mono text-[10px] text-display tabular-nums">
+            {meta.total}
+          </span>
+          <span className="label-hw-dim">
+            ·{meta.signups} SIGNUP{meta.signups === 1 ? "" : "S"} · {meta.applications} APPLICATION
+            {meta.applications === 1 ? "" : "S"}
+          </span>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="inline-flex border border-hairline divide-x divide-hairline">
+            {(["all", "signup", "application"] as Filter[]).map((f) => (
+              <button
+                key={f}
+                type="button"
+                onClick={() => setFilter(f)}
+                className={
+                  filter === f
+                    ? "font-mono text-[10px] tracking-[0.14em] bg-display text-shell px-2 py-1"
+                    : "font-mono text-[10px] tracking-[0.14em] text-display hover:bg-panel-deep px-2 py-1"
+                }
+              >
+                {f.toUpperCase()}
+              </button>
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={handleExport}
+            disabled={exporting || meta.total === 0}
+            className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-3 py-1"
+          >
+            {exporting ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <Download className="h-3 w-3" />
+            )}
+            EXPORT CSV
+          </button>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 label-hw-dim py-4">
+          <Loader2 className="h-3 w-3 animate-spin" /> LOADING INBOX…
+        </div>
+      ) : filtered.length === 0 ? (
+        <p className="text-body text-sm py-2">
+          {meta.total === 0
+            ? "Empty inbox. Import a Luma CSV or wait for project applications."
+            : `No ${filter} entries match.`}
+        </p>
+      ) : (
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between label-hw-dim px-1">
+            <span>·SOURCE · NAME · IDENTIFIER</span>
+            <span>STATUS · WHEN</span>
+          </div>
+          {filtered.map((e) => (
+            <div
+              key={`${e.source}-${e.id}`}
+              className="lcd px-3 py-2 flex items-center justify-between gap-3"
+            >
+              <div className="min-w-0 flex-1 flex items-center gap-2">
+                <span
+                  className={
+                    e.source === "signup"
+                      ? "border border-hairline text-label-mid px-1.5 py-[1px] font-mono text-[9px] tracking-[0.12em] uppercase"
+                      : "border border-display text-display bg-panel-deep px-1.5 py-[1px] font-mono text-[9px] tracking-[0.12em] uppercase"
+                  }
+                >
+                  {e.source}
+                </span>
+                <div className="min-w-0">
+                  <div className="font-mono text-[12px] text-display truncate">
+                    {e.name || "—"}
+                  </div>
+                  <div className="label-hw-dim truncate">
+                    {e.identifier}
+                    {e.wallet ? ` · ${truncate(e.wallet)}` : ""}
+                  </div>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 flex-shrink-0 text-right">
+                {e.status && (
+                  <span className="label-hw text-display">{e.status.toUpperCase()}</span>
+                )}
+                <span className="font-mono text-[10px] text-label-mid tabular-nums">
+                  {formatDate(e.when).toUpperCase()}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/project/ProjectContinuationModal.tsx
+++ b/client/src/components/project/ProjectContinuationModal.tsx
@@ -1,0 +1,215 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Loader2 } from "lucide-react";
+import { web3Enable, web3Accounts, web3FromSource } from "@polkadot/extension-dapp";
+import { SiwsMessage } from "@talismn/siws";
+import { generateSiwsStatement } from "@/lib/siwsUtils";
+import { api, type ApiProjectContinuation, ApiError } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+
+const STATUS_MAX = 4000;
+const SUPPORT_MAX = 4000;
+
+export function ProjectContinuationModal({
+  open,
+  onOpenChange,
+  projectId,
+  projectTitle,
+  connectedAddress,
+  onSubmitted,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  projectId: string;
+  projectTitle: string;
+  connectedAddress: string;
+  onSubmitted: (entry: ApiProjectContinuation) => void;
+}) {
+  const { toast } = useToast();
+  const [currentStatus, setCurrentStatus] = useState("");
+  const [wantSupport, setWantSupport] = useState(false);
+  const [supportFor, setSupportFor] = useState("");
+  const [nextStepUrl, setNextStepUrl] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const reset = () => {
+    setCurrentStatus("");
+    setWantSupport(false);
+    setSupportFor("");
+    setNextStepUrl("");
+    setSubmitting(false);
+  };
+
+  const validate = (): string | null => {
+    const status = currentStatus.trim();
+    if (!status) return "Tell us where the project stands today.";
+    if (status.length > STATUS_MAX) return `Current status must be ${STATUS_MAX} chars or fewer.`;
+    if (supportFor.length > SUPPORT_MAX) return `Support details must be ${SUPPORT_MAX} chars or fewer.`;
+    if (nextStepUrl.trim() && !/^https?:\/\//i.test(nextStepUrl.trim())) {
+      return "Next-step URL must start with http:// or https://.";
+    }
+    return null;
+  };
+
+  const handleSubmit = async () => {
+    const error = validate();
+    if (error) {
+      toast({ title: "Check the form", description: error, variant: "destructive" });
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await web3Enable("Stadium");
+      const accounts = await web3Accounts();
+      const account = accounts.find((a) => a.address === connectedAddress) || accounts[0];
+      if (!account) throw new Error("No wallet account found");
+      const siws = new SiwsMessage({
+        domain: window.location.hostname,
+        uri: window.location.origin,
+        address: account.address,
+        nonce: Math.random().toString(36).slice(2),
+        statement: generateSiwsStatement({ action: "submit-continuation", projectTitle }),
+      });
+      const injector = await web3FromSource(account.meta.source);
+      const signed = (await siws.sign(injector)) as unknown as { signature: string; message?: string };
+      const messageStr =
+        typeof signed.message === "string" && signed.message
+          ? signed.message
+          : (siws as unknown as { toString: () => string }).toString();
+      const authHeader = btoa(
+        JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address }),
+      );
+      const res = await api.createProjectContinuation(
+        projectId,
+        {
+          currentStatus: currentStatus.trim(),
+          wantSupport,
+          supportFor: supportFor.trim() || null,
+          nextStepUrl: nextStepUrl.trim() || null,
+        },
+        authHeader,
+      );
+      onSubmitted(res.data);
+      toast({ title: "Submitted — thanks for the update" });
+      reset();
+      onOpenChange(false);
+    } catch (e) {
+      toast({
+        title: "Couldn't submit",
+        description: e instanceof ApiError ? e.message : (e as Error)?.message || "Unknown error",
+        variant: "destructive",
+      });
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => (submitting ? null : onOpenChange(v))}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="font-display tracking-tight">·WHAT'S NEXT, MILESTONE 3?</DialogTitle>
+          <DialogDescription className="text-body">
+            Now that M2 is done — where is the project today, and what's the next step we should
+            know about? Submissions go to the WebZero ops team.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="cont-status" className="label-hw-dim">·CURRENT STATUS *</Label>
+            <Textarea
+              id="cont-status"
+              rows={4}
+              maxLength={STATUS_MAX + 100}
+              placeholder="Shipped to mainnet last week. Onboarding ~10 builders/day."
+              value={currentStatus}
+              onChange={(e) => setCurrentStatus(e.target.value)}
+              className="font-mono text-sm"
+            />
+            <div className="flex justify-end label-hw-dim">
+              {currentStatus.trim().length} / {STATUS_MAX}
+            </div>
+          </div>
+
+          <div className="lcd p-3 flex items-center justify-between gap-3">
+            <div>
+              <Label htmlFor="cont-want" className="label-hw text-display">
+                ·WANT CONTINUED SUPPORT?
+              </Label>
+              <p className="label-hw-dim mt-0.5">
+                MENTORSHIP, GRANT INTROS, FOLLOW-ON PROGRAMS, ETC.
+              </p>
+            </div>
+            <Switch
+              id="cont-want"
+              checked={wantSupport}
+              onCheckedChange={setWantSupport}
+              aria-label="Toggle support requested"
+            />
+          </div>
+
+          {wantSupport && (
+            <div className="space-y-1.5">
+              <Label htmlFor="cont-supportfor" className="label-hw-dim">·WHAT WOULD HELP?</Label>
+              <Textarea
+                id="cont-supportfor"
+                rows={3}
+                maxLength={SUPPORT_MAX + 100}
+                placeholder="Intros to grants programs in Polkadot. Feedback on the multi-chain payout flow."
+                value={supportFor}
+                onChange={(e) => setSupportFor(e.target.value)}
+                className="font-mono text-sm"
+              />
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            <Label htmlFor="cont-url" className="label-hw-dim">·NEXT-STEP URL (OPTIONAL)</Label>
+            <Input
+              id="cont-url"
+              type="url"
+              placeholder="https://… (grant app, demo, blog post)"
+              value={nextStepUrl}
+              onChange={(e) => setNextStepUrl(e.target.value)}
+              className="font-mono text-sm"
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <button
+            type="button"
+            onClick={() => { if (!submitting) { reset(); onOpenChange(false); } }}
+            disabled={submitting}
+            className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep disabled:opacity-50 px-3 py-1.5"
+          >
+            CANCEL
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting || !currentStatus.trim()}
+            className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-4 py-1.5 inline-flex items-center gap-1.5"
+          >
+            {submitting ? (
+              <>
+                <Loader2 className="h-3 w-3 animate-spin" /> SUBMITTING…
+              </>
+            ) : (
+              "SUBMIT ▸"
+            )}
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/unit-detail-modal.tsx
+++ b/client/src/components/unit-detail-modal.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -5,15 +6,14 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Separator } from "@/components/ui/separator";
-import { ExternalLink, Github } from "lucide-react";
+import { ExternalLink, Github, ChevronDown } from "lucide-react";
 
 interface Unit {
   unitNumber: string;
   title: string;
   author: string;
+  /** Long-form copy. Trimmed to a TL;DR by default; the full text is
+   *  revealed by the READ MORE toggle. */
   description: string;
   longDescription?: string;
   track: string;
@@ -24,6 +24,12 @@ interface Unit {
   demoUrl?: string;
   githubUrl?: string;
   projectUrl?: string;
+  /** Tech stack chips. Optional — falls through cleanly when absent. */
+  techStack?: string[];
+  /** Category chips (Gaming, DeFi, etc.). Optional. */
+  categories?: string[];
+  /** Team size; rendered as a stat chip when ≥ 1. */
+  teamSize?: number;
 }
 
 interface UnitDetailModalProps {
@@ -32,95 +38,181 @@ interface UnitDetailModalProps {
   unit: Unit;
 }
 
+/**
+ * First sentence (up to `max` chars) of `text`. Pokemon-card-style TL;DR:
+ * fast scan, the rest hides behind READ MORE.
+ */
+const tldr = (text: string | undefined, max = 160): string => {
+  if (!text) return "";
+  const sentenceMatch = text.match(/^[\s\S]+?[.!?](\s|$)/);
+  const first = sentenceMatch ? sentenceMatch[0].trim() : text.trim();
+  if (first.length <= max) return first;
+  return `${first.slice(0, max - 1).trimEnd()}…`;
+};
+
+/** Reusable stat tile — label on top, value bold below. */
+function StatTile({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="lcd px-3 py-2 min-w-0 flex-1">
+      <div className="label-hw-dim mb-1 truncate">{label}</div>
+      <div className="font-mono text-[14px] text-display tabular-nums truncate">{value}</div>
+    </div>
+  );
+}
+
 export function UnitDetailModal({ open, onOpenChange, unit }: UnitDetailModalProps) {
+  const [expanded, setExpanded] = useState(false);
+  const fullDescription = unit.longDescription || unit.description;
+  const summary = tldr(fullDescription);
+  const hasMore = fullDescription && fullDescription.length > summary.length;
+
+  const techChips = (unit.techStack || []).slice(0, 8);
+  const categoryChips = (unit.categories || []).slice(0, 4);
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="lcd max-w-3xl max-h-[90vh] overflow-y-auto">
-        <DialogHeader>
-          <div className="label-hw-dim mb-2">
-            UNIT {unit.unitNumber}{unit.date && ` · ${unit.date}`}
-          </div>
-          <div className="flex items-start justify-between gap-4">
-            <div className="flex-1">
-              <DialogTitle className="font-display text-4xl uppercase tracking-tight text-display">
-                {unit.title}
-              </DialogTitle>
-              <DialogDescription className="label-hw-dim mt-2">
-                BY {unit.author.toUpperCase()}
-              </DialogDescription>
+      <DialogContent className="lcd max-w-xl max-h-[88vh] overflow-y-auto p-0">
+        {/* Card header — number + date pinned top-left, badges top-right */}
+        <DialogHeader className="px-5 pt-5 pb-3">
+          <div className="flex items-start justify-between gap-3 mb-1">
+            <div className="label-hw-dim">
+              UNIT {unit.unitNumber}{unit.date && ` · ${unit.date}`}
             </div>
-            <div className="flex gap-1">
+            <div className="flex gap-1 flex-shrink-0">
               {unit.isWinner && (
-                <span className="bg-display text-shell px-2 py-1 font-mono text-[10px] font-bold tracking-[0.12em]">
+                <span className="bg-display text-shell px-2 py-[2px] font-mono text-[10px] font-bold tracking-[0.12em]">
                   WINNER
                 </span>
               )}
               {unit.isM2 && (
-                <span className="border border-display text-display px-2 py-1 font-mono text-[10px] font-bold tracking-[0.12em]">
+                <span className="border border-display text-display px-2 py-[2px] font-mono text-[10px] font-bold tracking-[0.12em]">
                   M2
                 </span>
               )}
             </div>
           </div>
+          <DialogTitle className="font-display text-3xl md:text-4xl uppercase tracking-tight text-display leading-[0.95]">
+            {unit.title}
+          </DialogTitle>
+          <DialogDescription className="label-hw-dim mt-1">
+            BY {unit.author.toUpperCase()}
+          </DialogDescription>
         </DialogHeader>
 
-        <Separator className="my-4 bg-hairline-subtle" />
-
-        <div className="space-y-4">
-          <div>
-            <div className="label-hw mb-2">TRACK</div>
-            <Badge
-              variant="outline"
-              className="font-mono text-[10px] tracking-[0.14em] border-hairline text-label-mid bg-transparent"
-            >
-              {unit.track.toUpperCase()}
-            </Badge>
-          </div>
-
-          {unit.prize && (
-            <div>
-              <div className="label-hw mb-2">PRIZE</div>
-              <div className="font-mono text-display font-bold">{unit.prize}</div>
-            </div>
+        {/* Stat strip — pokemon-card style: 3-4 tiles at a glance */}
+        <div className="px-5 pb-3 flex gap-2">
+          <StatTile
+            label="TRACK"
+            value={<span className="text-[12px]">{unit.track.toUpperCase()}</span>}
+          />
+          {unit.prize && <StatTile label="PRIZE" value={unit.prize} />}
+          {typeof unit.teamSize === "number" && unit.teamSize > 0 && (
+            <StatTile label="TEAM" value={unit.teamSize} />
           )}
+          {techChips.length > 0 && (
+            <StatTile label="STACK" value={techChips.length} />
+          )}
+        </div>
 
-          <div>
-            <div className="label-hw mb-2">DESCRIPTION</div>
-            <p className="text-body leading-relaxed">
-              {unit.longDescription || unit.description}
+        {/* TL;DR — first sentence, mono caps for the lead-in arrow */}
+        {summary && (
+          <div className="px-5 pb-3">
+            <p className="text-body leading-relaxed text-sm">
+              <span className="label-hw-dim mr-1">▸</span>
+              {summary}
             </p>
           </div>
+        )}
 
-          <Separator className="bg-hairline-subtle" />
+        {/* Tech chips */}
+        {techChips.length > 0 && (
+          <div className="px-5 pb-3">
+            <div className="label-hw-dim mb-1.5">·STACK</div>
+            <div className="flex flex-wrap gap-1">
+              {techChips.map((t) => (
+                <span
+                  key={t}
+                  className="border border-hairline text-label-mid bg-panel-deep px-2 py-[1px] font-mono text-[10px] tracking-[0.12em] uppercase"
+                >
+                  {t}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
 
-          <div className="flex gap-2">
-            {unit.demoUrl && (
-              <Button className="flex-1" onClick={() => window.open(unit.demoUrl, "_blank")}>
-                <ExternalLink className="w-4 h-4 mr-2" />
-                VIEW DEMO
-              </Button>
-            )}
-            {unit.projectUrl && (
-              <Button
-                variant="secondary"
-                className="flex-1"
-                onClick={() => window.open(unit.projectUrl, "_blank")}
-              >
-                PROJECT PAGE
-              </Button>
-            )}
-            {unit.githubUrl && (
-              <Button
-                variant="outline"
-                size="icon"
-                className="text-label-mid hover:text-display"
-                onClick={() => window.open(unit.githubUrl, "_blank")}
-                aria-label="View on GitHub"
-              >
-                <Github className="w-5 h-5" />
-              </Button>
+        {/* Category chips — distinct tone (display border) so they don't
+            blur into the tech stack row */}
+        {categoryChips.length > 0 && (
+          <div className="px-5 pb-3">
+            <div className="label-hw-dim mb-1.5">·CATEGORIES</div>
+            <div className="flex flex-wrap gap-1">
+              {categoryChips.map((c) => (
+                <span
+                  key={c}
+                  className="border border-display text-display px-2 py-[1px] font-mono text-[10px] tracking-[0.12em] uppercase"
+                >
+                  {c}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* READ MORE — preserves the full long-form description for
+            anyone who wants it without forcing it on every viewer */}
+        {hasMore && (
+          <div className="px-5 pb-3">
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              className="label-hw-dim hover:text-display transition-colors duration-150 inline-flex items-center gap-1"
+              aria-expanded={expanded}
+            >
+              {expanded ? "▴ READ LESS" : "▾ READ MORE"}
+              <ChevronDown
+                className={`h-3 w-3 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
+                aria-hidden="true"
+              />
+            </button>
+            {expanded && (
+              <p className="text-body leading-relaxed text-sm mt-3 whitespace-pre-line">
+                {fullDescription}
+              </p>
             )}
           </div>
+        )}
+
+        {/* Action bar */}
+        <div className="border-t border-hairline-subtle px-5 py-3 flex flex-wrap gap-2">
+          {unit.demoUrl && (
+            <button
+              type="button"
+              onClick={() => window.open(unit.demoUrl, "_blank", "noopener,noreferrer")}
+              className="flex-1 min-w-[140px] inline-flex items-center justify-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim px-3 py-2"
+            >
+              <ExternalLink className="w-3 h-3" />
+              VIEW DEMO
+            </button>
+          )}
+          {unit.projectUrl && (
+            <a
+              href={unit.projectUrl}
+              className="flex-1 min-w-[140px] inline-flex items-center justify-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep px-3 py-2"
+            >
+              PROJECT PAGE
+            </a>
+          )}
+          {unit.githubUrl && (
+            <button
+              type="button"
+              onClick={() => window.open(unit.githubUrl, "_blank", "noopener,noreferrer")}
+              aria-label="View on GitHub"
+              className="inline-flex items-center justify-center border border-hairline text-label-mid hover:text-display hover:bg-panel-deep w-9 h-9 flex-shrink-0"
+            >
+              <Github className="w-4 h-4" />
+            </button>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/client/src/hooks/use-brightness.ts
+++ b/client/src/hooks/use-brightness.ts
@@ -14,12 +14,23 @@ interface StoredState {
   collapsed: boolean;
 }
 
+// Below this viewport width we treat the device as "mobile-ish" and default
+// the brightness rack to its compact strip — otherwise the full panel eats
+// ~170px of vertical space on every page load, which felt invasive.
+const MOBILE_BREAKPOINT_PX = 640;
+
+function isMobileViewport(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.innerWidth < MOBILE_BREAKPOINT_PX;
+}
+
 function readStored(): StoredState {
   const defaults: StoredState = {
     mode: 'auto',
     manualValue: null,
     paletteKey: DEFAULT_PALETTE_KEY,
-    collapsed: false,
+    // Default to collapsed on mobile viewports; users can expand explicitly.
+    collapsed: isMobileViewport(),
   };
   if (typeof window === 'undefined') return defaults;
   try {
@@ -31,7 +42,11 @@ function readStored(): StoredState {
       mode: parsed.mode,
       manualValue: typeof parsed.manualValue === 'number' ? parsed.manualValue : null,
       paletteKey: typeof parsed.paletteKey === 'string' ? parsed.paletteKey : DEFAULT_PALETTE_KEY,
-      collapsed: typeof parsed.collapsed === 'boolean' ? parsed.collapsed : false,
+      // Honor a stored collapsed=true; if the user never set one, fall back
+      // to the mobile-viewport default so first-time mobile loads aren't
+      // dominated by the brightness panel.
+      collapsed:
+        typeof parsed.collapsed === 'boolean' ? parsed.collapsed : isMobileViewport(),
     };
   } catch {
     return defaults;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -162,3 +162,13 @@ code, pre { @apply font-mono; }
 @media (prefers-reduced-motion: reduce) {
   .led-pulse { animation: none; }
 }
+
+/* Hide scrollbar on horizontally-scrollable strips (nav tabs on mobile)
+   while keeping the content scrollable. Cross-browser shorthand. */
+.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -212,6 +212,19 @@ export type ApiAdminTierEntry = {
   createdAt?: string;
 };
 
+/** One row in the per-program audit log. */
+export type ApiAuditLogEntry = {
+  id: string;
+  programId: string;
+  actorChain: string | null;
+  actorWallet: string | null;
+  action: string;
+  targetType: string | null;
+  targetId: string | null;
+  metadata: Record<string, unknown> | null;
+  createdAt: string;
+};
+
 /** Shape of a row in the `programs` table (Phase 1 revamp). */
 export type ApiProgram = {
   id: string;
@@ -1580,6 +1593,19 @@ export const api = {
       `/admin/global-admins/${encodeURIComponent(wallet)}?chain=${encodeURIComponent(walletChain)}`,
       { method: "DELETE", headers: adminAuthHeaders(authHeader) },
     );
+  },
+
+  // --- Program audit log ---
+
+  listProgramAuditLog: async (
+    slug: string,
+    authHeader: AdminAuthArg,
+    options: { limit?: number } = {},
+  ): Promise<{ status: string; data: ApiAuditLogEntry[] }> => {
+    const qs = options.limit ? `?limit=${encodeURIComponent(String(options.limit))}` : "";
+    return request(`/programs/${encodeURIComponent(slug)}/audit-log${qs}`, {
+      headers: adminAuthHeaders(authHeader),
+    });
   },
 };
 

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -203,6 +203,19 @@ export type ApiProgramAdmin = {
   createdAt: string;
 };
 
+/** One row in the unified program inbox (signups + applications merged). */
+export type ApiInboxEntry = {
+  source: "signup" | "application";
+  id: string;
+  when: string | null;
+  name: string | null;
+  email: string | null;
+  identifier: string;
+  status: string | null;
+  wallet: string | null;
+  walletChain: string | null;
+};
+
 /** Tier-0 / tier-1 admin record. Same shape for both tables. */
 export type ApiAdminTierEntry = {
   walletChain: "substrate" | "ethereum" | "solana";
@@ -1580,6 +1593,47 @@ export const api = {
       `/admin/global-admins/${encodeURIComponent(wallet)}?chain=${encodeURIComponent(walletChain)}`,
       { method: "DELETE", headers: adminAuthHeaders(authHeader) },
     );
+  },
+
+  // --- Program inbox (merged signups + applications) ---
+
+  listProgramInbox: async (
+    slug: string,
+    authHeader: AdminAuthArg,
+  ): Promise<{
+    status: string;
+    data: ApiInboxEntry[];
+    meta: { total: number; signups: number; applications: number };
+  }> => {
+    if (USE_MOCK_DATA) {
+      // Mock mode returns an empty inbox — the underlying tables are
+      // mock-mode-only and unrelated. Real exercise happens on dev/prod.
+      return {
+        status: "success",
+        data: [],
+        meta: { total: 0, signups: 0, applications: 0 },
+      };
+    }
+    return request(`/programs/${encodeURIComponent(slug)}/inbox`, {
+      headers: adminAuthHeaders(authHeader),
+    });
+  },
+
+  /**
+   * Returns the same data as `listProgramInbox` serialised as CSV. Caller
+   * is expected to trigger a download via blob URL — see
+   * `ProgramInboxSection.handleExport` for the canonical flow.
+   */
+  exportProgramInboxCsv: async (slug: string, authHeader: AdminAuthArg): Promise<Blob> => {
+    if (USE_MOCK_DATA) {
+      return new Blob(["source,when,identifier,name,email,status,wallet\n"], { type: "text/csv" });
+    }
+    const url = `${API_BASE_URL}/programs/${encodeURIComponent(slug)}/inbox.csv`;
+    const res = await fetch(url, { headers: adminAuthHeaders(authHeader) });
+    if (!res.ok) {
+      throw new ApiError(`Inbox export failed (HTTP ${res.status})`, res.status);
+    }
+    return res.blob();
   },
 };
 

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -216,6 +216,19 @@ export type ApiInboxEntry = {
   walletChain: string | null;
 };
 
+/** Row in `project_continuations` ('What's next, milestone 3?' submissions). */
+export type ApiProjectContinuation = {
+  id: string;
+  projectId: string;
+  currentStatus: string;
+  wantSupport: boolean;
+  supportFor: string | null;
+  nextStepUrl: string | null;
+  submittedBy: string;
+  submittedByChain: "substrate" | "ethereum" | "solana";
+  createdAt: string;
+};
+
 /** Tier-0 / tier-1 admin record. Same shape for both tables. */
 export type ApiAdminTierEntry = {
   walletChain: "substrate" | "ethereum" | "solana";
@@ -1634,6 +1647,32 @@ export const api = {
       throw new ApiError(`Inbox export failed (HTTP ${res.status})`, res.status);
     }
     return res.blob();
+  },
+
+  // --- Project continuations ('What's next, milestone 3?') ---
+
+  listProjectContinuations: async (
+    projectId: string,
+    authHeader: AdminAuthArg,
+  ): Promise<{ status: string; data: ApiProjectContinuation[] }> => {
+    return request(`/m2-program/${encodeURIComponent(projectId)}/continuations`, {
+      headers: adminAuthHeaders(authHeader),
+    });
+  },
+
+  createProjectContinuation: async (
+    projectId: string,
+    payload: Pick<ApiProjectContinuation, "currentStatus" | "wantSupport"> & {
+      supportFor?: string | null;
+      nextStepUrl?: string | null;
+    },
+    authHeader: AdminAuthArg,
+  ): Promise<{ status: string; data: ApiProjectContinuation }> => {
+    return request(`/m2-program/${encodeURIComponent(projectId)}/continuations`, {
+      method: "POST",
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
   },
 };
 

--- a/client/src/lib/siwsUtils.ts
+++ b/client/src/lib/siwsUtils.ts
@@ -3,7 +3,7 @@
  */
 
 export interface SiwsContext {
-  action: 'update-team' | 'submit-deliverable' | 'update-project' | 'register-address' | 'admin-action' | 'create-project' | 'delete-project' | 'review-project' | 'approve-project' | 'reject-project' | 'post-update' | 'update-funding-signal' | 'apply-to-program' | 'create-program' | 'update-program' | 'review-application' | 'update-program-sponsors' | 'import-program-signups' | 'update-notifications';
+  action: 'update-team' | 'submit-deliverable' | 'update-project' | 'register-address' | 'admin-action' | 'create-project' | 'delete-project' | 'review-project' | 'approve-project' | 'reject-project' | 'post-update' | 'update-funding-signal' | 'apply-to-program' | 'create-program' | 'update-program' | 'review-application' | 'update-program-sponsors' | 'import-program-signups' | 'submit-continuation' | 'update-notifications';
   projectId?: string;
   projectTitle?: string;
   programTitle?: string;
@@ -70,6 +70,8 @@ export function generateSiwsStatement(context: SiwsContext): string {
       return `Update program sponsors on ${baseDomain}`;
     case 'import-program-signups':
       return `Import program signups on ${baseDomain}`;
+    case 'submit-continuation':
+      return `Submit project continuation on ${baseDomain}`;
 
     // Phase 2 revamp (#71): notification preferences
     case 'update-notifications':

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -393,6 +393,37 @@ const AdminPage = () => {
           <LCDStat value={fmtUSD(totalPaidUsd)} label="Paid Out" size="sm" showLED />
         </div>
 
+        {/* Empty-state CTA — only shown when there are no projects yet. Gives
+            a fresh admin (or a first-time event organiser) a single obvious
+            place to start instead of an empty PROGRAMS table. */}
+        {!loading && projects.length === 0 && (
+          <section className="panel p-6 mb-4 text-center">
+            <div className="label-hw-dim mb-3">·WELCOME, ADMIN</div>
+            <h2 className="font-display text-2xl md:text-3xl uppercase tracking-tight text-display mb-3">
+              Create your first event
+            </h2>
+            <p className="text-body text-sm max-w-md mx-auto mb-5">
+              Stadium tracks events end-to-end: applications, sponsors, signups, payouts.
+              Spin up your program now and start onboarding builders.
+            </p>
+            <div className="flex flex-wrap gap-2 justify-center">
+              <button
+                type="button"
+                onClick={() => setShowCreateProjectModal(true)}
+                className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim px-4 py-2"
+              >
+                <Plus className="h-3 w-3" /> CREATE PROJECT
+              </button>
+              <Link
+                to="/admin/app-admins"
+                className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep px-4 py-2"
+              >
+                ADMIN TIERS ▸
+              </Link>
+            </div>
+          </section>
+        )}
+
         {/* Pending Review */}
         <section className="panel p-4 mb-4">
           <div className="flex items-center gap-2 mb-3 pb-3 border-b border-hairline-subtle">

--- a/client/src/pages/AdminProgramPage.tsx
+++ b/client/src/pages/AdminProgramPage.tsx
@@ -14,6 +14,7 @@ import { ApplicationCard } from "@/components/admin/ApplicationCard";
 import { ProgramAdminsSection } from "@/components/admin/ProgramAdminsSection";
 import { ProgramSponsorsSection } from "@/components/admin/ProgramSponsorsSection";
 import { ProgramSignupsSection } from "@/components/admin/ProgramSignupsSection";
+import { ProgramInboxSection } from "@/components/admin/ProgramInboxSection";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 
@@ -240,6 +241,11 @@ const AdminProgramPage = () => {
                 />
 
                 <ProgramSignupsSection
+                  programSlug={program.slug}
+                  signAuthHeader={getAdminAuth}
+                />
+
+                <ProgramInboxSection
                   programSlug={program.slug}
                   signAuthHeader={getAdminAuth}
                 />

--- a/client/src/pages/AdminProgramPage.tsx
+++ b/client/src/pages/AdminProgramPage.tsx
@@ -14,6 +14,7 @@ import { ApplicationCard } from "@/components/admin/ApplicationCard";
 import { ProgramAdminsSection } from "@/components/admin/ProgramAdminsSection";
 import { ProgramSponsorsSection } from "@/components/admin/ProgramSponsorsSection";
 import { ProgramSignupsSection } from "@/components/admin/ProgramSignupsSection";
+import { ProgramAuditLogSection } from "@/components/admin/ProgramAuditLogSection";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 
@@ -240,6 +241,11 @@ const AdminProgramPage = () => {
                 />
 
                 <ProgramSignupsSection
+                  programSlug={program.slug}
+                  signAuthHeader={getAdminAuth}
+                />
+
+                <ProgramAuditLogSection
                   programSlug={program.slug}
                   signAuthHeader={getAdminAuth}
                 />

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -181,7 +181,10 @@ const HomePage = () => {
       );
     }
 
-    if (showWinnersOnly) {
+    // When a search query is active, ignore the winners-only filter so
+    // non-winning matches still surface — the user clearly wants a
+    // specific project, regardless of category default.
+    if (showWinnersOnly && !searchQuery) {
       filtered = filtered.filter((p) => Array.isArray(p.bountyPrize) && p.bountyPrize.length > 0);
     }
 
@@ -306,7 +309,6 @@ const HomePage = () => {
             value={searchQuery}
             onChange={setSearchQuery}
             placeholder="search units..."
-            kbdHint="⌘K"
             className="flex-1 min-w-[200px]"
           />
           {hackathons.length > 0 && (

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -33,6 +33,9 @@ type UnitForCard = {
   demoUrl?: string;
   githubUrl?: string;
   projectUrl?: string;
+  techStack?: string[];
+  categories?: string[];
+  teamSize?: number;
 };
 
 const FILTER_TO_CATEGORY: Record<string, string> = {
@@ -161,6 +164,9 @@ const HomePage = () => {
       demoUrl: p.demoUrl,
       githubUrl: p.projectRepo,
       projectUrl: p.id ? `/m2-program/${p.id}` : undefined,
+      techStack: Array.isArray(p.techStack) ? p.techStack : undefined,
+      categories: p.categories,
+      teamSize: p.teamMembers?.length,
     };
   }, []);
 

--- a/client/src/pages/ProjectDetailsPage.tsx
+++ b/client/src/pages/ProjectDetailsPage.tsx
@@ -40,6 +40,7 @@ import { ShareProjectModal } from "@/components/ShareProjectModal";
 import { WalletConnectionBanner } from "@/components/WalletConnectionBanner";
 import { TeamPaymentSection } from "@/components/TeamPaymentSection";
 import { M2SubmissionTimeline } from "@/components/M2SubmissionTimeline";
+import { ProjectContinuationModal } from "@/components/project/ProjectContinuationModal";
 import { SubmitM2DeliverablesModal } from "@/components/SubmitM2DeliverablesModal";
 import { ProjectUpdatesTab } from "@/components/project/ProjectUpdatesTab";
 import { FundingSignalBadge } from "@/components/project/FundingSignalBadge";
@@ -173,6 +174,7 @@ const ProjectDetailsPage = () => {
   const [teamModalOpen, setTeamModalOpen] = useState(false);
   const [showShareModal, setShowShareModal] = useState(false);
   const [isSubmitM2ModalOpen, setIsSubmitM2ModalOpen] = useState(false);
+  const [isContinuationModalOpen, setIsContinuationModalOpen] = useState(false);
   const [isEditProjectDetailsOpen, setIsEditProjectDetailsOpen] = useState(false);
   const [activeTab, setActiveTab] = useState("overview");
   // Phase 1 revamp (#42): funding signal
@@ -1125,6 +1127,27 @@ const ProjectDetailsPage = () => {
                       onSubmit={() => setIsSubmitM2ModalOpen(true)}
                     />
 
+                    {/* 'What's next, milestone 3?' CTA — only on completed
+                        projects, only for team members. Admin-only inboxes
+                        list submissions; the form posts a new one each time. */}
+                    {project.m2Status === 'completed' && isTeamMember && (
+                      <div className="panel p-4 flex items-center justify-between gap-3">
+                        <div>
+                          <div className="label-hw text-display">·WHAT'S NEXT, MILESTONE 3?</div>
+                          <p className="text-body text-sm mt-1">
+                            Tell us where the project stands now and what you want next.
+                          </p>
+                        </div>
+                        <button
+                          type="button"
+                          onClick={() => setIsContinuationModalOpen(true)}
+                          className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim px-3 py-1.5 flex-shrink-0"
+                        >
+                          SHARE UPDATE ▸
+                        </button>
+                      </div>
+                    )}
+
                     {/* M2 Agreement Section - Only for building status */}
                     {project.m2Status === 'building' && (
                       <M2AgreementSection
@@ -1378,6 +1401,18 @@ const ProjectDetailsPage = () => {
             project={project}
             onSubmit={handleSubmitM2}
           />
+
+          {/* 'What's next, milestone 3?' continuation modal */}
+          {connectedAddress && (
+            <ProjectContinuationModal
+              open={isContinuationModalOpen}
+              onOpenChange={setIsContinuationModalOpen}
+              projectId={project.id}
+              projectTitle={project.projectName}
+              connectedAddress={connectedAddress}
+              onSubmitted={() => { /* no list rendered yet — admin inbox is a follow-up */ }}
+            />
+          )}
 
           {/* Edit Project Details Modal */}
           <EditProjectDetailsModal

--- a/client/src/pages/WinnersPage.tsx
+++ b/client/src/pages/WinnersPage.tsx
@@ -21,6 +21,7 @@ type ApiProject = {
   demoUrl?: string;
   liveUrl?: string;
   bountyPrize?: { name: string; amount: number; hackathonWonAtId: string }[];
+  techStack?: string[];
   categories?: string[];
   m2Status?: "building" | "under_review" | "completed";
   hackathon?: { id: string; name: string; endDate: string };
@@ -40,6 +41,9 @@ type Unit = {
   demoUrl?: string;
   githubUrl?: string;
   projectUrl?: string;
+  techStack?: string[];
+  categories?: string[];
+  teamSize?: number;
 };
 
 const WinnersPage = () => {
@@ -99,6 +103,9 @@ const WinnersPage = () => {
               demoUrl: p.demoUrl,
               githubUrl: p.projectRepo,
               projectUrl: p.id ? `/m2-program/${p.id}` : undefined,
+              techStack: Array.isArray(p.techStack) ? p.techStack : undefined,
+              categories: p.categories,
+              teamSize: p.teamMembers?.length,
             };
           }),
         );

--- a/server/api/auth/statements.js
+++ b/server/api/auth/statements.js
@@ -36,6 +36,7 @@ export const VALID_STATEMENTS = [
   'Review application on Stadium',
   'Update program sponsors on Stadium',
   'Import program signups on Stadium',
+  'Submit project continuation on Stadium',
   // Phase 2 revamp: wallet contacts (#67)
   'Update notification preferences for wallet on Stadium',
 ];

--- a/server/api/controllers/__tests__/project-continuation.test.js
+++ b/server/api/controllers/__tests__/project-continuation.test.js
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../services/project.service.js', () => ({
+  default: { getProjectById: vi.fn() },
+}));
+vi.mock('../../services/project-update.service.js', () => ({
+  default: { listByProject: vi.fn(), create: vi.fn() },
+}));
+vi.mock('../../services/funding-signal.service.js', () => ({
+  default: { get: vi.fn(), upsert: vi.fn() },
+}));
+vi.mock('../../services/payment.service.js', () => ({ default: {} }));
+vi.mock('../../services/notification.service.js', () => ({ default: { notifyProjectTeam: vi.fn() } }));
+vi.mock('../../repositories/project-continuation.repository.js', () => ({
+  default: { create: vi.fn(), listByProjectId: vi.fn() },
+}));
+
+const projectService = (await import('../../services/project.service.js')).default;
+const continuationRepo = (await import('../../repositories/project-continuation.repository.js')).default;
+const ctrl = (await import('../project.controller.js')).default;
+
+const mockRes = () => {
+  const r = {};
+  r.status = vi.fn(() => r);
+  r.json = vi.fn(() => r);
+  return r;
+};
+
+const PROJECT = { id: 'plata-mia', projectName: 'Plata Mia' };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('listContinuations', () => {
+  it('returns 404 when the project is unknown', async () => {
+    projectService.getProjectById.mockResolvedValue(null);
+    const res = mockRes();
+    await ctrl.listContinuations({ params: { projectId: 'nope' } }, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns the list newest-first via the repo', async () => {
+    projectService.getProjectById.mockResolvedValue(PROJECT);
+    continuationRepo.listByProjectId.mockResolvedValue([{ id: 'c1' }, { id: 'c2' }]);
+    const res = mockRes();
+    await ctrl.listContinuations({ params: { projectId: PROJECT.id } }, res);
+    expect(continuationRepo.listByProjectId).toHaveBeenCalledWith(PROJECT.id);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});
+
+describe('createContinuation', () => {
+  it('returns 404 when the project is unknown', async () => {
+    projectService.getProjectById.mockResolvedValue(null);
+    const res = mockRes();
+    await ctrl.createContinuation(
+      { params: { projectId: 'nope' }, body: { currentStatus: 'OK' } },
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(404);
+  });
+
+  it('returns 422 when currentStatus is empty', async () => {
+    projectService.getProjectById.mockResolvedValue(PROJECT);
+    const res = mockRes();
+    await ctrl.createContinuation(
+      { params: { projectId: PROJECT.id }, body: { currentStatus: '' } },
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('returns 422 when nextStepUrl is malformed', async () => {
+    projectService.getProjectById.mockResolvedValue(PROJECT);
+    const res = mockRes();
+    await ctrl.createContinuation(
+      {
+        params: { projectId: PROJECT.id },
+        body: { currentStatus: 'shipping', nextStepUrl: 'ftp://nope' },
+      },
+      res,
+    );
+    expect(res.status).toHaveBeenCalledWith(422);
+  });
+
+  it('creates with the submitter wallet stamped from req.user', async () => {
+    projectService.getProjectById.mockResolvedValue(PROJECT);
+    continuationRepo.create.mockImplementation((p) => Promise.resolve({ id: 'c1', ...p }));
+    const res = mockRes();
+    await ctrl.createContinuation(
+      {
+        params: { projectId: PROJECT.id },
+        body: {
+          currentStatus: 'Shipping M2.5, looking at grants.',
+          wantSupport: true,
+          supportFor: 'Grant intros',
+          nextStepUrl: 'https://blog.platamia.io/m25',
+        },
+        user: { address: '5Alice', chain: 'substrate' },
+      },
+      res,
+    );
+    expect(continuationRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        projectId: PROJECT.id,
+        currentStatus: 'Shipping M2.5, looking at grants.',
+        wantSupport: true,
+        supportFor: 'Grant intros',
+        nextStepUrl: 'https://blog.platamia.io/m25',
+        submittedBy: '5Alice',
+        submittedByChain: 'substrate',
+      }),
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it('defaults wantSupport to false and trims free-text fields', async () => {
+    projectService.getProjectById.mockResolvedValue(PROJECT);
+    continuationRepo.create.mockImplementation((p) => Promise.resolve({ id: 'c2', ...p }));
+    const res = mockRes();
+    await ctrl.createContinuation(
+      {
+        params: { projectId: PROJECT.id },
+        body: { currentStatus: '  trimmed  ', supportFor: '   ' },
+        user: { address: '5Bob', chain: 'ethereum' },
+      },
+      res,
+    );
+    expect(continuationRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        currentStatus: 'trimmed',
+        wantSupport: false,
+        supportFor: null,
+        nextStepUrl: null,
+        submittedByChain: 'ethereum',
+      }),
+    );
+  });
+});

--- a/server/api/controllers/program.controller.js
+++ b/server/api/controllers/program.controller.js
@@ -2,6 +2,7 @@ import programService from '../services/program.service.js';
 import programApplicationService from '../services/program-application.service.js';
 import programSponsorService from '../services/program-sponsor.service.js';
 import programSignupService from '../services/program-signup.service.js';
+import auditLog from '../services/program-audit-log.service.js';
 import projectService from '../services/project.service.js';
 import notificationService from '../services/notification.service.js';
 import programAdminRepository from '../repositories/program-admin.repository.js';
@@ -134,6 +135,15 @@ class ProgramController {
       // to 404 via the Postgres PGRST116 code we see on not-found.
       res.status(200).json({ status: 'success', data: updated });
 
+      auditLog.logSafe({
+        programId: program.id,
+        actor: { chain: req.user?.chain, wallet: reviewedBy },
+        action: `application.${updated.status}`,
+        targetType: 'application',
+        targetId: updated.id,
+        metadata: { from: prevStatus, to: updated.status, projectId: updated.projectId },
+      });
+
       if (prevStatus === 'submitted' && (updated.status === 'accepted' || updated.status === 'rejected')) {
         const eventType = updated.status === 'accepted' ? 'application_accepted' : 'application_rejected';
         try {
@@ -184,6 +194,14 @@ class ProgramController {
 
       const updated = await programService.updateBySlug(slug, patch);
       res.status(200).json({ status: 'success', data: updated });
+      auditLog.logSafe({
+        programId: updated.id,
+        actor: { chain: req.user?.chain, wallet: req.user?.address },
+        action: 'program.update',
+        targetType: 'program',
+        targetId: updated.id,
+        metadata: { changedKeys: Object.keys(patch || {}) },
+      });
     } catch (error) {
       if (error?.code === '23505') {
         return res.status(409).json({
@@ -348,6 +366,14 @@ class ProgramController {
         });
       }
       res.status(201).json({ status: 'success', data: added });
+      auditLog.logSafe({
+        programId: program.id,
+        actor: { chain: req.user?.chain, wallet: req.user?.address },
+        action: 'admin.add',
+        targetType: 'admin',
+        targetId: `${walletChain}:${added.wallet}`,
+        metadata: null,
+      });
     } catch (error) {
       console.error('❌ Error adding program admin:', error);
       res.status(500).json({ status: 'error', message: 'Failed to add program admin' });
@@ -370,6 +396,14 @@ class ProgramController {
       }
       await programAdminRepository.remove(program.id, walletChain, wallet);
       res.status(204).end();
+      auditLog.logSafe({
+        programId: program.id,
+        actor: { chain: req.user?.chain, wallet: req.user?.address },
+        action: 'admin.remove',
+        targetType: 'admin',
+        targetId: `${walletChain}:${wallet}`,
+        metadata: null,
+      });
     } catch (error) {
       console.error('❌ Error removing program admin:', error);
       res.status(500).json({ status: 'error', message: 'Failed to remove program admin' });
@@ -406,6 +440,14 @@ class ProgramController {
       }
       const created = await programSponsorService.create({ ...req.body, programId: program.id });
       res.status(201).json({ status: 'success', data: created });
+      auditLog.logSafe({
+        programId: program.id,
+        actor: { chain: req.user?.chain, wallet: req.user?.address },
+        action: 'sponsor.add',
+        targetType: 'sponsor',
+        targetId: created.id,
+        metadata: { name: created.name },
+      });
     } catch (error) {
       console.error('❌ Error creating program sponsor:', error);
       res.status(500).json({ status: 'error', message: 'Failed to create program sponsor' });
@@ -429,6 +471,14 @@ class ProgramController {
       }
       const updated = await programSponsorService.update(sponsorId, req.body);
       res.status(200).json({ status: 'success', data: updated });
+      auditLog.logSafe({
+        programId: program.id,
+        actor: { chain: req.user?.chain, wallet: req.user?.address },
+        action: 'sponsor.update',
+        targetType: 'sponsor',
+        targetId: sponsorId,
+        metadata: { changedKeys: Object.keys(req.body || {}) },
+      });
     } catch (error) {
       console.error('❌ Error updating program sponsor:', error);
       res.status(500).json({ status: 'error', message: 'Failed to update program sponsor' });
@@ -448,6 +498,14 @@ class ProgramController {
       }
       await programSponsorService.delete(sponsorId);
       res.status(204).end();
+      auditLog.logSafe({
+        programId: program.id,
+        actor: { chain: req.user?.chain, wallet: req.user?.address },
+        action: 'sponsor.delete',
+        targetType: 'sponsor',
+        targetId: sponsorId,
+        metadata: { name: existing.name },
+      });
     } catch (error) {
       console.error('❌ Error deleting program sponsor:', error);
       res.status(500).json({ status: 'error', message: 'Failed to delete program sponsor' });
@@ -520,6 +578,21 @@ class ProgramController {
           inserted: dryRun ? [] : inserted || [],
         },
       });
+      if (!dryRun) {
+        auditLog.logSafe({
+          programId: program.id,
+          actor: { chain: req.user?.chain, wallet: req.user?.address },
+          action: 'signups.import',
+          targetType: 'signups_batch',
+          targetId: null,
+          metadata: {
+            newCount: summary.newCount,
+            duplicates: summary.duplicates,
+            skippedNoEmail: summary.skippedNoEmail,
+            totalParsed: summary.totalParsed,
+          },
+        });
+      }
     } catch (error) {
       console.error('❌ Error importing program signups:', error);
       res.status(500).json({ status: 'error', message: 'Failed to import program signups' });
@@ -541,9 +614,35 @@ class ProgramController {
       }
       await programSignupService.delete(signupId);
       res.status(204).end();
+      auditLog.logSafe({
+        programId: program.id,
+        actor: { chain: req.user?.chain, wallet: req.user?.address },
+        action: 'signup.delete',
+        targetType: 'signup',
+        targetId: signupId,
+        metadata: { email: existing.email },
+      });
     } catch (error) {
       console.error('❌ Error deleting program signup:', error);
       res.status(500).json({ status: 'error', message: 'Failed to delete program signup' });
+    }
+  }
+
+  // --- Audit log read endpoint ---
+
+  async listAuditLog(req, res) {
+    try {
+      const { slug } = req.params;
+      const limit = Math.min(parseInt(req.query.limit, 10) || 100, 500);
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const entries = await auditLog.listByProgramId(program.id, { limit });
+      res.status(200).json({ status: 'success', data: entries });
+    } catch (error) {
+      console.error('❌ Error listing program audit log:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to list audit log' });
     }
   }
 }

--- a/server/api/controllers/program.controller.js
+++ b/server/api/controllers/program.controller.js
@@ -2,6 +2,7 @@ import programService from '../services/program.service.js';
 import programApplicationService from '../services/program-application.service.js';
 import programSponsorService from '../services/program-sponsor.service.js';
 import programSignupService from '../services/program-signup.service.js';
+import programInboxService, { inboxToCsv } from '../services/program-inbox.service.js';
 import projectService from '../services/project.service.js';
 import notificationService from '../services/notification.service.js';
 import programAdminRepository from '../repositories/program-admin.repository.js';
@@ -544,6 +545,48 @@ class ProgramController {
     } catch (error) {
       console.error('❌ Error deleting program signup:', error);
       res.status(500).json({ status: 'error', message: 'Failed to delete program signup' });
+    }
+  }
+
+  // --- Inbox (merged signups + applications) ---
+
+  async listInbox(req, res) {
+    try {
+      const { slug } = req.params;
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const entries = await programInboxService.listInbox(program.id);
+      const signupCount = entries.filter((e) => e.source === 'signup').length;
+      const applicationCount = entries.length - signupCount;
+      res.status(200).json({
+        status: 'success',
+        data: entries,
+        meta: { total: entries.length, signups: signupCount, applications: applicationCount },
+      });
+    } catch (error) {
+      console.error('❌ Error listing program inbox:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to list program inbox' });
+    }
+  }
+
+  async exportInboxCsv(req, res) {
+    try {
+      const { slug } = req.params;
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const entries = await programInboxService.listInbox(program.id);
+      const csv = inboxToCsv(entries, { programSlug: slug });
+      const filename = `${slug}-inbox-${new Date().toISOString().slice(0, 10)}.csv`;
+      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+      res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+      res.status(200).send(csv);
+    } catch (error) {
+      console.error('❌ Error exporting program inbox CSV:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to export program inbox' });
     }
   }
 }

--- a/server/api/controllers/project.controller.js
+++ b/server/api/controllers/project.controller.js
@@ -3,8 +3,9 @@ import projectUpdateService from '../services/project-update.service.js';
 import fundingSignalService from '../services/funding-signal.service.js';
 import paymentService from '../services/payment.service.js';
 import notificationService from '../services/notification.service.js';
+import projectContinuationRepository from '../repositories/project-continuation.repository.js';
 import { ALLOWED_CATEGORIES } from '../constants/allowedTech.js';
-import { validateM2Submission, validateSimpleUrl, validateProjectUpdate, validateFundingSignal, validateProject, validateAddress, ALLOWED_WALLET_CHAINS } from '../utils/validation.js';
+import { validateM2Submission, validateSimpleUrl, validateProjectUpdate, validateFundingSignal, validateProject, validateAddress, validateContinuation, ALLOWED_WALLET_CHAINS } from '../utils/validation.js';
 import { canEditM2Agreement, isSubmissionWindowOpen } from '../utils/dateHelpers.js';
 import logger from '../utils/logger.js';
 import { getAuthorizedAddresses } from '../../config/polkadot-config.js';
@@ -704,6 +705,52 @@ class ProjectController {
         } catch (error) {
             console.error('❌ Error updating funding signal:', error);
             res.status(500).json({ status: 'error', message: 'Failed to update funding signal' });
+        }
+    }
+
+    // --- Project continuations ('What's next, milestone 3?') ---
+
+    async listContinuations(req, res) {
+        try {
+            const { projectId } = req.params;
+            const project = await projectService.getProjectById(projectId);
+            if (!project) {
+                return res.status(404).json({ status: 'error', message: 'Project not found' });
+            }
+            const entries = await projectContinuationRepository.listByProjectId(projectId);
+            res.status(200).json({ status: 'success', data: entries });
+        } catch (error) {
+            console.error('❌ Error listing continuations:', error);
+            res.status(500).json({ status: 'error', message: 'Failed to list continuations' });
+        }
+    }
+
+    async createContinuation(req, res) {
+        try {
+            const { projectId } = req.params;
+            const project = await projectService.getProjectById(projectId);
+            if (!project) {
+                return res.status(404).json({ status: 'error', message: 'Project not found' });
+            }
+            const { valid, error } = validateContinuation(req.body);
+            if (!valid) {
+                return res.status(422).json({ status: 'error', message: error });
+            }
+            const submittedBy = req.user?.address || req.auth?.address || 'unknown';
+            const submittedByChain = req.user?.chain || req.auth?.chain || 'substrate';
+            const created = await projectContinuationRepository.create({
+                projectId,
+                currentStatus: req.body.currentStatus.trim(),
+                wantSupport: !!req.body.wantSupport,
+                supportFor: req.body.supportFor?.trim() || null,
+                nextStepUrl: req.body.nextStepUrl?.trim() || null,
+                submittedBy,
+                submittedByChain,
+            });
+            res.status(201).json({ status: 'success', data: created });
+        } catch (error) {
+            console.error('❌ Error creating continuation:', error);
+            res.status(500).json({ status: 'error', message: 'Failed to create continuation' });
         }
     }
 }

--- a/server/api/repositories/program-audit-log.repository.js
+++ b/server/api/repositories/program-audit-log.repository.js
@@ -1,0 +1,49 @@
+import { supabase } from '../../db.js';
+
+const transform = (row) => {
+  if (!row) return null;
+  return {
+    id: row.id,
+    programId: row.program_id,
+    actorChain: row.actor_chain,
+    actorWallet: row.actor_wallet,
+    action: row.action,
+    targetType: row.target_type,
+    targetId: row.target_id,
+    metadata: row.metadata,
+    createdAt: row.created_at,
+  };
+};
+
+class ProgramAuditLogRepository {
+  async listByProgramId(programId, { limit = 100 } = {}) {
+    const { data, error } = await supabase
+      .from('program_audit_log')
+      .select('*')
+      .eq('program_id', programId)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+    if (error) throw error;
+    return (data || []).map(transform);
+  }
+
+  async insert({ programId, actorChain, actorWallet, action, targetType, targetId, metadata }) {
+    const { data, error } = await supabase
+      .from('program_audit_log')
+      .insert({
+        program_id: programId,
+        actor_chain: actorChain ?? null,
+        actor_wallet: actorWallet ?? null,
+        action,
+        target_type: targetType ?? null,
+        target_id: targetId ?? null,
+        metadata: metadata ?? null,
+      })
+      .select('*')
+      .single();
+    if (error) throw error;
+    return transform(data);
+  }
+}
+
+export default new ProgramAuditLogRepository();

--- a/server/api/repositories/project-continuation.repository.js
+++ b/server/api/repositories/project-continuation.repository.js
@@ -1,0 +1,50 @@
+import { supabase } from '../../db.js';
+
+const transform = (row) => {
+  if (!row) return null;
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    currentStatus: row.current_status,
+    wantSupport: row.want_support,
+    supportFor: row.support_for,
+    nextStepUrl: row.next_step_url,
+    submittedBy: row.submitted_by,
+    submittedByChain: row.submitted_by_chain,
+    createdAt: row.created_at,
+  };
+};
+
+class ProjectContinuationRepository {
+  async listByProjectId(projectId) {
+    const { data, error } = await supabase
+      .from('project_continuations')
+      .select('*')
+      .eq('project_id', projectId)
+      .order('created_at', { ascending: false });
+    if (error) throw error;
+    return (data || []).map(transform);
+  }
+
+  async create({
+    projectId, currentStatus, wantSupport, supportFor, nextStepUrl, submittedBy, submittedByChain,
+  }) {
+    const { data, error } = await supabase
+      .from('project_continuations')
+      .insert({
+        project_id: projectId,
+        current_status: currentStatus,
+        want_support: !!wantSupport,
+        support_for: supportFor ?? null,
+        next_step_url: nextStepUrl ?? null,
+        submitted_by: submittedBy,
+        submitted_by_chain: submittedByChain,
+      })
+      .select('*')
+      .single();
+    if (error) throw error;
+    return transform(data);
+  }
+}
+
+export default new ProjectContinuationRepository();

--- a/server/api/routes/m2-program.routes.js
+++ b/server/api/routes/m2-program.routes.js
@@ -32,6 +32,10 @@ router.post('/:projectId/updates', requireTeamMemberOrAdmin, projectController.p
 router.get('/:projectId/funding-signal', projectController.getFundingSignal);
 router.patch('/:projectId/funding-signal', requireTeamMemberOrAdmin, projectController.updateFundingSignal);
 
+// --- 'What's next, milestone 3?' continuations (#15) ---
+router.get('/:projectId/continuations', requireTeamMemberOrAdmin, projectController.listContinuations);
+router.post('/:projectId/continuations', requireTeamMemberOrAdmin, projectController.createContinuation);
+
 // --- Phase 1 revamp: per-project application list (#43) ---
 router.get('/:projectId/applications', programController.listApplicationsForProject);
 

--- a/server/api/routes/program.routes.js
+++ b/server/api/routes/program.routes.js
@@ -78,4 +78,9 @@ router.delete(
   programController.deleteSignup,
 );
 
+// --- Inbox (merged signups + applications) ---
+// Admin-only — both source rows are gated; the merge inherits that.
+router.get('/:slug/inbox', requireProgramAdmin('slug'), programController.listInbox);
+router.get('/:slug/inbox.csv', requireProgramAdmin('slug'), programController.exportInboxCsv);
+
 export default router;

--- a/server/api/routes/program.routes.js
+++ b/server/api/routes/program.routes.js
@@ -78,4 +78,7 @@ router.delete(
   programController.deleteSignup,
 );
 
+// --- Audit log ---
+router.get('/:slug/audit-log', requireProgramAdmin('slug'), programController.listAuditLog);
+
 export default router;

--- a/server/api/services/__tests__/program-audit-log.service.test.js
+++ b/server/api/services/__tests__/program-audit-log.service.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../repositories/program-audit-log.repository.js', () => ({
+  default: { insert: vi.fn(), listByProgramId: vi.fn() },
+}));
+
+const repo = (await import('../../repositories/program-audit-log.repository.js')).default;
+const { default: service } = await import('../program-audit-log.service.js');
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('logSafe', () => {
+  it('inserts a normalised row when programId + action are present', async () => {
+    repo.insert.mockResolvedValue({ id: 'audit-1' });
+    const out = await service.logSafe({
+      programId: 'bitrefill-2026',
+      actor: { chain: 'substrate', wallet: '5Alice' },
+      action: 'sponsor.add',
+      targetType: 'sponsor',
+      targetId: 'sponsor-1',
+      metadata: { name: 'Bitrefill' },
+    });
+    expect(out).toEqual({ id: 'audit-1' });
+    expect(repo.insert).toHaveBeenCalledWith({
+      programId: 'bitrefill-2026',
+      actorChain: 'substrate',
+      actorWallet: '5Alice',
+      action: 'sponsor.add',
+      targetType: 'sponsor',
+      targetId: 'sponsor-1',
+      metadata: { name: 'Bitrefill' },
+    });
+  });
+
+  it('skips the write when programId is missing', async () => {
+    const out = await service.logSafe({ action: 'x' });
+    expect(out).toBeNull();
+    expect(repo.insert).not.toHaveBeenCalled();
+  });
+
+  it('skips the write when action is missing', async () => {
+    const out = await service.logSafe({ programId: 'x' });
+    expect(out).toBeNull();
+    expect(repo.insert).not.toHaveBeenCalled();
+  });
+
+  it('returns null and never throws when the insert errors', async () => {
+    repo.insert.mockRejectedValue(new Error('DB down'));
+    const out = await service.logSafe({
+      programId: 'bitrefill-2026',
+      action: 'sponsor.add',
+    });
+    expect(out).toBeNull();
+  });
+
+  it('stringifies non-string targetId so JSONB queries stay sane', async () => {
+    repo.insert.mockResolvedValue({ id: 'audit-2' });
+    await service.logSafe({
+      programId: 'p',
+      action: 'a',
+      targetId: 42,
+    });
+    expect(repo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ targetId: '42' }),
+    );
+  });
+
+  it('passes through null targetId without stringifying', async () => {
+    repo.insert.mockResolvedValue({ id: 'audit-3' });
+    await service.logSafe({
+      programId: 'p',
+      action: 'signups.import',
+      targetId: null,
+    });
+    expect(repo.insert).toHaveBeenCalledWith(
+      expect.objectContaining({ targetId: null }),
+    );
+  });
+});
+
+describe('listByProgramId', () => {
+  it('passes through to the repository', async () => {
+    repo.listByProgramId.mockResolvedValue([{ id: 'a' }]);
+    const out = await service.listByProgramId('p', { limit: 10 });
+    expect(repo.listByProgramId).toHaveBeenCalledWith('p', { limit: 10 });
+    expect(out).toEqual([{ id: 'a' }]);
+  });
+});

--- a/server/api/services/__tests__/program-inbox.service.test.js
+++ b/server/api/services/__tests__/program-inbox.service.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../program-application.service.js', () => ({
+  default: { listByProgram: vi.fn() },
+}));
+vi.mock('../program-signup.service.js', () => ({
+  default: { listByProgramId: vi.fn() },
+}));
+vi.mock('../project.service.js', () => ({
+  default: { getProjectById: vi.fn() },
+}));
+
+const applicationService = (await import('../program-application.service.js')).default;
+const signupService = (await import('../program-signup.service.js')).default;
+const projectService = (await import('../project.service.js')).default;
+const { default: inboxService, inboxToCsv } = await import('../program-inbox.service.js');
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('listInbox', () => {
+  it('returns an empty array when there are no signups or applications', async () => {
+    signupService.listByProgramId.mockResolvedValue([]);
+    applicationService.listByProgram.mockResolvedValue([]);
+    const out = await inboxService.listInbox('bitrefill-2026');
+    expect(out).toEqual([]);
+  });
+
+  it('merges both sources and sorts newest first by `when`', async () => {
+    signupService.listByProgramId.mockResolvedValue([
+      { id: 's1', email: 'alice@x.com', name: 'Alice', registeredAt: '2026-05-10T00:00:00Z', wallet: '5A' },
+      { id: 's2', email: 'bob@x.com', name: 'Bob', registeredAt: '2026-05-15T00:00:00Z' },
+    ]);
+    applicationService.listByProgram.mockResolvedValue([
+      { id: 'a1', projectId: 'plata-mia', submittedAt: '2026-05-12T00:00:00Z', submittedBy: '5C', status: 'submitted' },
+    ]);
+    projectService.getProjectById.mockResolvedValue({ projectName: 'Plata Mia' });
+
+    const out = await inboxService.listInbox('bitrefill-2026');
+    expect(out).toHaveLength(3);
+    expect(out[0]).toMatchObject({ source: 'signup', identifier: 'bob@x.com' });          // 2026-05-15
+    expect(out[1]).toMatchObject({ source: 'application', identifier: 'plata-mia' });     // 2026-05-12
+    expect(out[2]).toMatchObject({ source: 'signup', identifier: 'alice@x.com' });        // 2026-05-10
+  });
+
+  it('enriches application rows with the project name (one fetch per unique projectId)', async () => {
+    signupService.listByProgramId.mockResolvedValue([]);
+    applicationService.listByProgram.mockResolvedValue([
+      { id: 'a1', projectId: 'plata-mia', submittedAt: '2026-05-12T00:00:00Z', submittedBy: '5C', status: 'submitted' },
+      { id: 'a2', projectId: 'plata-mia', submittedAt: '2026-05-13T00:00:00Z', submittedBy: '5C', status: 'submitted' },
+    ]);
+    projectService.getProjectById.mockResolvedValue({ projectName: 'Plata Mia' });
+
+    const out = await inboxService.listInbox('bitrefill-2026');
+    expect(out.every((e) => e.name === 'Plata Mia')).toBe(true);
+    // Both entries share the projectId — service should only round-trip once.
+    expect(projectService.getProjectById).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to projectId when project lookup fails', async () => {
+    signupService.listByProgramId.mockResolvedValue([]);
+    applicationService.listByProgram.mockResolvedValue([
+      { id: 'a1', projectId: 'missing-project', submittedAt: '2026-05-12T00:00:00Z', status: 'submitted' },
+    ]);
+    projectService.getProjectById.mockRejectedValue(new Error('not found'));
+
+    const out = await inboxService.listInbox('bitrefill-2026');
+    expect(out[0].name).toBe('missing-project');
+  });
+});
+
+describe('inboxToCsv', () => {
+  it('emits the header + each row + a slug stamp', () => {
+    const csv = inboxToCsv(
+      [
+        {
+          source: 'signup',
+          when: '2026-05-10T00:00:00Z',
+          identifier: 'alice@x.com',
+          name: 'Alice',
+          email: 'alice@x.com',
+          status: null,
+          wallet: '5A',
+        },
+      ],
+      { programSlug: 'bitrefill-2026' },
+    );
+    const lines = csv.trim().split('\n');
+    expect(lines[0]).toBe('source,when,identifier,name,email,status,wallet');
+    expect(lines[1]).toContain('alice@x.com');
+    expect(lines.at(-1)).toMatch(/^# program=bitrefill-2026/);
+  });
+
+  it('quotes values containing commas, quotes, or newlines', () => {
+    const csv = inboxToCsv([
+      { source: 'application', when: '', identifier: 'p', name: 'Smith, Jr.', email: null, status: null, wallet: null },
+      { source: 'application', when: '', identifier: 'q', name: 'has "quote"', email: null, status: null, wallet: null },
+      { source: 'application', when: '', identifier: 'r', name: 'line\nbreak', email: null, status: null, wallet: null },
+    ]);
+    expect(csv).toContain('"Smith, Jr."');
+    expect(csv).toContain('"has ""quote"""');
+    expect(csv).toContain('"line\nbreak"');
+  });
+});

--- a/server/api/services/program-audit-log.service.js
+++ b/server/api/services/program-audit-log.service.js
@@ -1,0 +1,43 @@
+import repo from '../repositories/program-audit-log.repository.js';
+import logger from '../utils/logger.js';
+
+/**
+ * Best-effort write of an audit-log row. NEVER throws — a log failure
+ * must not break the calling action (importing a CSV, accepting an
+ * application, etc.). Errors land in the server log instead.
+ *
+ * Pull `actor` out of `req.user` at the call-site:
+ *   await auditLog.logSafe({
+ *     programId,
+ *     actor: { chain: req.user?.chain, wallet: req.user?.address },
+ *     action: 'sponsor.add',
+ *     targetType: 'sponsor',
+ *     targetId: created.id,
+ *     metadata: { name: created.name },
+ *   });
+ */
+class ProgramAuditLogService {
+  async listByProgramId(programId, opts) {
+    return await repo.listByProgramId(programId, opts);
+  }
+
+  async logSafe({ programId, actor, action, targetType, targetId, metadata }) {
+    try {
+      if (!programId || !action) return null;
+      return await repo.insert({
+        programId,
+        actorChain: actor?.chain,
+        actorWallet: actor?.wallet,
+        action,
+        targetType,
+        targetId: targetId == null ? null : String(targetId),
+        metadata,
+      });
+    } catch (e) {
+      logger.error(`audit-log failed (action=${action}, program=${programId}):`, e);
+      return null;
+    }
+  }
+}
+
+export default new ProgramAuditLogService();

--- a/server/api/services/program-inbox.service.js
+++ b/server/api/services/program-inbox.service.js
@@ -1,0 +1,125 @@
+import programApplicationService from './program-application.service.js';
+import programSignupService from './program-signup.service.js';
+import projectService from './project.service.js';
+
+/**
+ * Per-program inbox — one merged feed of `program_signups` (Luma CSV
+ * imports, individuals) plus `program_applications` (project teams that
+ * applied in-app). Two distinct concepts; the inbox unifies them for
+ * triage / export.
+ *
+ * Each entry carries a `source` discriminator + a stable `when` timestamp
+ * so the merged feed sorts cleanly.
+ */
+
+/** Unified shape returned by listInbox. */
+const baseEntry = (source, raw) => ({
+  source,
+  id: raw.id,
+  when: raw.when,
+  name: raw.name ?? null,
+  email: raw.email ?? null,
+  identifier: raw.identifier,
+  status: raw.status ?? null,
+  wallet: raw.wallet ?? null,
+  walletChain: raw.walletChain ?? null,
+});
+
+class ProgramInboxService {
+  /**
+   * Return merged signups + applications for a program, newest first.
+   * Application entries are enriched with the project name when known.
+   *
+   * @param {string} programId
+   * @returns {Promise<Array>}
+   */
+  async listInbox(programId) {
+    const [signups, applications] = await Promise.all([
+      programSignupService.listByProgramId(programId),
+      programApplicationService.listByProgram(programId),
+    ]);
+
+    // Best-effort enrich application rows with their project name. Dedup
+    // upfront (multiple applications can point at the same project) so we
+    // don't race the Promise.all on identical projectIds.
+    const uniqueProjectIds = [...new Set(applications.map((a) => a.projectId))];
+    const projectNameById = new Map();
+    await Promise.all(
+      uniqueProjectIds.map(async (projectId) => {
+        try {
+          const project = await projectService.getProjectById(projectId);
+          projectNameById.set(projectId, project?.projectName || null);
+        } catch {
+          projectNameById.set(projectId, null);
+        }
+      }),
+    );
+
+    const signupEntries = signups.map((s) =>
+      baseEntry('signup', {
+        id: s.id,
+        when: s.registeredAt || s.createdAt,
+        name: s.name,
+        email: s.email,
+        identifier: s.email,
+        status: null,
+        wallet: s.wallet,
+        walletChain: null,
+      }),
+    );
+
+    const applicationEntries = applications.map((a) =>
+      baseEntry('application', {
+        id: a.id,
+        when: a.submittedAt,
+        name: projectNameById.get(a.projectId) || a.projectId,
+        email: null,
+        identifier: a.projectId,
+        status: a.status,
+        wallet: a.submittedBy,
+        walletChain: null,
+      }),
+    );
+
+    return [...signupEntries, ...applicationEntries].sort((a, b) => {
+      const aMs = a.when ? new Date(a.when).getTime() : 0;
+      const bMs = b.when ? new Date(b.when).getTime() : 0;
+      return bMs - aMs;
+    });
+  }
+}
+
+export default new ProgramInboxService();
+
+// CSV serialisation lives here so the controller stays thin. Escapes
+// double-quotes per RFC 4180.
+const csvCell = (val) => {
+  if (val == null) return '';
+  const s = String(val);
+  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+};
+
+export function inboxToCsv(rows, { programSlug } = {}) {
+  const header = [
+    'source',
+    'when',
+    'identifier',
+    'name',
+    'email',
+    'status',
+    'wallet',
+  ];
+  const lines = [header.join(',')];
+  for (const r of rows) {
+    lines.push(
+      [r.source, r.when, r.identifier, r.name, r.email, r.status, r.wallet]
+        .map(csvCell)
+        .join(','),
+    );
+  }
+  // Stamp the slug in a trailing comment so the export is self-identifying
+  // when re-opened later. Not parsed by Excel/Numbers as a row.
+  if (programSlug) lines.push(`# program=${programSlug}, exported=${new Date().toISOString()}`);
+  return lines.join('\n') + '\n';
+}

--- a/server/api/utils/validation.js
+++ b/server/api/utils/validation.js
@@ -546,3 +546,31 @@ export const validateSponsor = (data, { partial = false } = {}) => {
   }
   return { valid: true };
 };
+
+// --- Project continuations ('What's next, milestone 3?' form) ---
+
+export const validateContinuation = (data) => {
+  if (!data || typeof data !== 'object') {
+    return { valid: false, error: 'Continuation payload must be an object' };
+  }
+  if (typeof data.currentStatus !== 'string' || !validateLength(data.currentStatus, 1, 4000)) {
+    return { valid: false, error: 'currentStatus is required (1–4000 characters)' };
+  }
+  if (data.wantSupport !== undefined && typeof data.wantSupport !== 'boolean') {
+    return { valid: false, error: 'wantSupport must be a boolean' };
+  }
+  if (data.supportFor !== undefined && data.supportFor !== null) {
+    if (typeof data.supportFor !== 'string' || data.supportFor.length > 4000) {
+      return { valid: false, error: 'supportFor must be a string (max 4000 characters)' };
+    }
+  }
+  if (data.nextStepUrl !== undefined && data.nextStepUrl !== null && data.nextStepUrl !== '') {
+    if (typeof data.nextStepUrl !== 'string' || data.nextStepUrl.length > 500) {
+      return { valid: false, error: 'nextStepUrl must be a string (max 500 characters)' };
+    }
+    if (!/^https?:\/\//i.test(data.nextStepUrl)) {
+      return { valid: false, error: 'nextStepUrl must start with http:// or https://' };
+    }
+  }
+  return { valid: true };
+};

--- a/supabase/migrations/20260521100000_program_audit_log.sql
+++ b/supabase/migrations/20260521100000_program_audit_log.sql
@@ -1,0 +1,25 @@
+-- Per-program audit log for admin actions.
+--
+-- Records sponsor add/edit/delete, signup CSV imports + deletes, application
+-- status changes, program edits, and admin add/remove. Useful for handoffs
+-- between WebZero ops and per-event admins ("what did the previous admin
+-- do last week?"). Writes are best-effort — a logging failure must never
+-- block the user-visible action (enforced at the service layer with
+-- `logSafe`, not by trigger).
+--
+-- Additive and idempotent.
+
+CREATE TABLE IF NOT EXISTS program_audit_log (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  program_id   TEXT NOT NULL REFERENCES programs(id) ON DELETE CASCADE,
+  actor_chain  TEXT,
+  actor_wallet TEXT,
+  action       TEXT NOT NULL,
+  target_type  TEXT,
+  target_id    TEXT,
+  metadata     JSONB,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_program_audit_log_program_recent
+  ON program_audit_log(program_id, created_at DESC);

--- a/supabase/migrations/20260521200000_project_continuations.sql
+++ b/supabase/migrations/20260521200000_project_continuations.sql
@@ -1,0 +1,24 @@
+-- Project continuations — 'What's next, milestone 3?' submissions.
+--
+-- Triggered by the team after they finish M2: a small form that captures
+-- (a) the current status of the project, (b) whether they want continued
+-- support and what for, and (c) an optional URL pointing at the next thing
+-- (Grant application, new repo branch, demo deployment, etc.). Helps the
+-- ops team keep a finger on the pulse post-M2.
+--
+-- Additive and idempotent.
+
+CREATE TABLE IF NOT EXISTS project_continuations (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  project_id         TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  current_status     TEXT NOT NULL,
+  want_support       BOOLEAN NOT NULL DEFAULT FALSE,
+  support_for        TEXT,
+  next_step_url      TEXT,
+  submitted_by       TEXT NOT NULL,
+  submitted_by_chain TEXT NOT NULL CHECK (submitted_by_chain IN ('substrate', 'ethereum', 'solana')),
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_project_continuations_project_recent
+  ON project_continuations(project_id, created_at DESC);


### PR DESCRIPTION
Promotes 6 feature PRs to prod. Single batch.

## What lands

| PR | Title | Migration? |
|---|---|---|
| **#111** | Onboarding empty-state + invite-copy button | — |
| **#112** | Unified inbox + CSV export per program | — |
| **#113** | Admin audit log | **`20260521100000_program_audit_log.sql`** |
| **#114** | 'What's next, milestone 3?' continuation form | **`20260521200000_project_continuations.sql`** |
| **#115** | Redesign unit detail modal — pokemon-card style | — |
| **#116** | Global ⌘K search + mobile-friendly nav + brightness collapse on small screens | — |

## Required pre-merge step — apply migrations to prod Supabase

From a terminal you've authorized:

```
cd /Users/salansky/Desktop/GithubRepos/stadium
supabase db push --linked
```

Two migrations pending:
- `supabase/migrations/20260521100000_program_audit_log.sql` (#113)
- `supabase/migrations/20260521200000_project_continuations.sql` (#114)

Both **additive + idempotent** (CREATE TABLE IF NOT EXISTS, DEFAULT values). Safe to apply at any time.

If you merge BEFORE applying: the audit log writes silently no-op (logSafe swallows DB errors) but the audit-log read endpoint will 500, and the continuations form will 500 on submit. Apply first to avoid the broken window.

## Env vars

None new. `ADMIN_SESSION_SECRET` is already set on Railway.

## Verification

- `cd server && npm test` on develop tip: **230 / 230** passing
- `cd client && npm run build` → clean
- `cd client && npm run lint --max-warnings 0` → clean

## Post-merge smoke test

```
# audit-log endpoint now mounted (expect 401 = exists, gated)
curl -s -o /dev/null -w 'audit: %{http_code}\n' \
  https://stadium-production-996a.up.railway.app/api/programs/bitrefill-2026/audit-log

# continuations endpoint mounted (expect 401)
curl -s -o /dev/null -w 'continuations: %{http_code}\n' \
  -X POST https://stadium-production-996a.up.railway.app/api/m2-program/plata-mia/continuations

# inbox + export already live; should still 401
curl -s -o /dev/null -w 'inbox: %{http_code}\n' \
  https://stadium-production-996a.up.railway.app/api/programs/bitrefill-2026/inbox
```

In the browser, hit `https://stadium.joinwebzero.com/`:
1. ⌘K opens the global search palette → typing 'plata' surfaces Plata Mia → click → navigates.
2. Click a unit card → new pokemon-card modal layout: stat strip + ▸ TL;DR + READ MORE expander.
3. Resize to 375px wide → nav tabs scroll horizontally without breaking, brightness rack is the compact 1-line strip.
4. On `/admin/programs/bitrefill-2026` as a global admin: the AUDIT LOG panel renders under SIGNUPS; the INBOX panel renders below it with export CSV.
5. On a completed M2 project page as a team member: 'WHAT'S NEXT, MILESTONE 3? · SHARE UPDATE ▸' panel appears.

## Risks

- **Schema migration ordering.** Already covered above — apply before merging.
- **Single big release, multiple surface areas touched.** No invasive auth changes; the only schema additions are two new tables. All existing flows backward-compatible.

Targets `main`. Draft for review. Mark ready once the migrations are applied.