### PR TITLE
hotfix: restore listInbox + audit-log route (prod 502 fix)

### DIFF
--- a/server/api/controllers/program.controller.js
+++ b/server/api/controllers/program.controller.js
@@ -3,6 +3,7 @@ import programApplicationService from '../services/program-application.service.j
 import programSponsorService from '../services/program-sponsor.service.js';
 import programSignupService from '../services/program-signup.service.js';
 import programInboxService, { inboxToCsv } from '../services/program-inbox.service.js';
+import auditLog from '../services/program-audit-log.service.js';
 import projectService from '../services/project.service.js';
 import notificationService from '../services/notification.service.js';
 import programAdminRepository from '../repositories/program-admin.repository.js';
@@ -627,12 +628,12 @@ class ProgramController {
       res.status(500).json({ status: 'error', message: 'Failed to delete program signup' });
     }
   }
-  // --- Audit log read endpoint ---
+  // --- Inbox (merged signups + applications) ---
 
-  async listAuditLog(req, res) {
+  async listInbox(req, res) {
     try {
       const { slug } = req.params;
-      const limit = Math.min(parseInt(req.query.limit, 10) || 100, 500);
+      const program = await programService.findBySlug(slug);
       if (!program) {
         return res.status(404).json({ status: 'error', message: 'Program not found' });
       }
@@ -647,6 +648,28 @@ class ProgramController {
     } catch (error) {
       console.error('❌ Error listing program inbox:', error);
       res.status(500).json({ status: 'error', message: 'Failed to list program inbox' });
+    }
+  }
+
+  // --- Audit log read endpoint ---
+
+  async listAuditLog(req, res) {
+    try {
+      const { slug } = req.params;
+      const limit = Math.min(parseInt(req.query.limit, 10) || 100, 500);
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const entries = await auditLog.listByProgramId(program.id, { limit });
+      res.status(200).json({
+        status: 'success',
+        data: entries,
+        meta: { total: entries.length, limit },
+      });
+    } catch (error) {
+      console.error('❌ Error listing program audit log:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to list program audit log' });
     }
   }
 

--- a/server/api/routes/program.routes.js
+++ b/server/api/routes/program.routes.js
@@ -83,4 +83,7 @@ router.delete(
 router.get('/:slug/inbox', requireProgramAdmin('slug'), programController.listInbox);
 router.get('/:slug/inbox.csv', requireProgramAdmin('slug'), programController.exportInboxCsv);
 
+// --- Audit log (per-program activity feed) ---
+router.get('/:slug/audit-log', requireProgramAdmin('slug'), programController.listAuditLog);
+
 export default router;


### PR DESCRIPTION
## Why

PR #117 merged develop→main last night. Railway redeployed and crashed on startup:

```
TypeError: argument handler must be a function
    at file:///app/api/routes/program.routes.js:83:8
```

Three merge anomalies between #112 (inbox) and #113 (audit log) — both added new methods at the end of `program.controller.js` and new routes at the end of `program.routes.js`, and the auto-resolution silently mangled them.

## What was broken

1. **`programController.listInbox` was undefined** — the method got deleted entirely. The route at `program.routes.js:83` referenced it. **This is what crashed the boot.**
2. **`programController.listAuditLog` had the wrong body** — it called `programInboxService.listInbox` and referenced an undefined `program` variable.
3. **`/:slug/audit-log` route was missing** from `program.routes.js` (#113's route line was dropped in the resolution).
4. **`auditLog` import was missing** in `program.controller.js` — 7 call-sites (`auditLog.logSafe(...)`) would have crashed at runtime on every sponsor/application/admin mutation.

## Fix

- Re-added `auditLog` import at top of controller
- Restored proper `listInbox` controller method
- Repaired `listAuditLog` body to actually call `auditLog.listByProgramId`
- Added `/:slug/audit-log` route back to `program.routes.js`

## Test

- `npm test` in `server/` → 243 / 243 pass
- Manual route-file import smoke test: `node -e 'import("./api/routes/program.routes.js")'` resolves cleanly

## Deploy

Merge → Railway redeploys → API back online.

Targets `main` directly (hotfix) — will cherry-pick to `develop` after if needed, but the same fix is required on both branches.