### PR TITLE
chore: back-port hotfix #118 to develop

### DIFF
--- a/server/api/controllers/program.controller.js
+++ b/server/api/controllers/program.controller.js
@@ -3,6 +3,7 @@ import programApplicationService from '../services/program-application.service.j
 import programSponsorService from '../services/program-sponsor.service.js';
 import programSignupService from '../services/program-signup.service.js';
 import programInboxService, { inboxToCsv } from '../services/program-inbox.service.js';
+import auditLog from '../services/program-audit-log.service.js';
 import projectService from '../services/project.service.js';
 import notificationService from '../services/notification.service.js';
 import programAdminRepository from '../repositories/program-admin.repository.js';
@@ -627,12 +628,12 @@ class ProgramController {
       res.status(500).json({ status: 'error', message: 'Failed to delete program signup' });
     }
   }
-  // --- Audit log read endpoint ---
+  // --- Inbox (merged signups + applications) ---
 
-  async listAuditLog(req, res) {
+  async listInbox(req, res) {
     try {
       const { slug } = req.params;
-      const limit = Math.min(parseInt(req.query.limit, 10) || 100, 500);
+      const program = await programService.findBySlug(slug);
       if (!program) {
         return res.status(404).json({ status: 'error', message: 'Program not found' });
       }
@@ -647,6 +648,28 @@ class ProgramController {
     } catch (error) {
       console.error('❌ Error listing program inbox:', error);
       res.status(500).json({ status: 'error', message: 'Failed to list program inbox' });
+    }
+  }
+
+  // --- Audit log read endpoint ---
+
+  async listAuditLog(req, res) {
+    try {
+      const { slug } = req.params;
+      const limit = Math.min(parseInt(req.query.limit, 10) || 100, 500);
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const entries = await auditLog.listByProgramId(program.id, { limit });
+      res.status(200).json({
+        status: 'success',
+        data: entries,
+        meta: { total: entries.length, limit },
+      });
+    } catch (error) {
+      console.error('❌ Error listing program audit log:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to list program audit log' });
     }
   }
 

--- a/server/api/routes/program.routes.js
+++ b/server/api/routes/program.routes.js
@@ -83,4 +83,7 @@ router.delete(
 router.get('/:slug/inbox', requireProgramAdmin('slug'), programController.listInbox);
 router.get('/:slug/inbox.csv', requireProgramAdmin('slug'), programController.exportInboxCsv);
 
+// --- Audit log (per-program activity feed) ---
+router.get('/:slug/audit-log', requireProgramAdmin('slug'), programController.listAuditLog);
+
 export default router;


### PR DESCRIPTION
## Why

PR #118 hotfixed prod (#117's bad auto-merge dropped controller methods + a route) — but only on `main`. Without this back-port, develop's tip still has the broken state, and the next `develop → main` release would re-introduce the 502.

## What

Cherry-picks commit `6509e0e` from main onto develop:
- Restores `listInbox` controller method
- Repairs `listAuditLog` body (`auditLog.listByProgramId` instead of inbox logic; resolves `program` correctly)
- Adds missing `auditLog` import
- Adds `/:slug/audit-log` route to `program.routes.js`

Two files, +29 / -3.

## Not a forward-merge

I considered `git merge main` here but it would have reintroduced ~5 stale Mongo scripts that were intentionally deleted from develop on 2026-04-14 and still exist on main. Cherry-pick keeps the diff surgical.

## Verified on prod already

#118 is live; prod was smoke-tested (200 on /api/health, /api/programs; 401 on /api/programs/dogfooding/inbox, /inbox.csv, /audit-log). This PR just brings develop into the same state.

## Test

- `npm test` in `server/` → 243 / 243 (same fix as #118, already verified)