### PR TITLE
fix(api): wire missing inbox + continuation methods on the API client

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1621,6 +1621,48 @@ export const api = {
     );
   },
 
+  // --- Program inbox (merged signups + applications, #112) ---
+
+  listProgramInbox: async (
+    slug: string,
+    authHeader: AdminAuthArg,
+  ): Promise<{
+    status: string;
+    data: ApiInboxEntry[];
+    meta: { total: number; signups: number; applications: number };
+  }> => {
+    if (USE_MOCK_DATA) {
+      return { status: "success", data: [], meta: { total: 0, signups: 0, applications: 0 } };
+    }
+    return request(`/programs/${encodeURIComponent(slug)}/inbox`, {
+      headers: adminAuthHeaders(authHeader),
+    });
+  },
+
+  exportProgramInboxCsv: async (
+    slug: string,
+    authHeader: AdminAuthArg,
+  ): Promise<Blob> => {
+    if (USE_MOCK_DATA) {
+      return new Blob(["source,when,name,email\n"], { type: "text/csv" });
+    }
+    const url = `${API_BASE_URL}/programs/${encodeURIComponent(slug)}/inbox.csv`;
+    const response = await fetch(url, { headers: adminAuthHeaders(authHeader) });
+    if (!response.ok) {
+      let message = mapStatusToMessage(response.status);
+      try {
+        const body = await response.json();
+        if (body && typeof body.message === "string" && body.message.trim()) {
+          message = body.error ? `${body.message}: ${body.error}` : body.message;
+        }
+      } catch {
+        // non-JSON error body — keep status-based message
+      }
+      throw new ApiError(message, response.status);
+    }
+    return response.blob();
+  },
+
   // --- Program audit log ---
 
   listProgramAuditLog: async (
@@ -1631,6 +1673,54 @@ export const api = {
     const qs = options.limit ? `?limit=${encodeURIComponent(String(options.limit))}` : "";
     return request(`/programs/${encodeURIComponent(slug)}/audit-log${qs}`, {
       headers: adminAuthHeaders(authHeader),
+    });
+  },
+
+  // --- Project continuations ('What's next, milestone 3?', #114) ---
+
+  listProjectContinuations: async (
+    projectId: string,
+    authHeader: AdminAuthArg,
+  ): Promise<{ status: string; data: ApiProjectContinuation[] }> => {
+    if (USE_MOCK_DATA) {
+      return { status: "success", data: [] };
+    }
+    return request(`/m2-program/${encodeURIComponent(projectId)}/continuations`, {
+      headers: adminAuthHeaders(authHeader),
+    });
+  },
+
+  createProjectContinuation: async (
+    projectId: string,
+    payload: {
+      currentStatus: string;
+      wantSupport: boolean;
+      supportFor: string | null;
+      nextStepUrl: string | null;
+    },
+    authHeader: AdminAuthArg,
+  ): Promise<{ status: string; data: ApiProjectContinuation }> => {
+    if (USE_MOCK_DATA) {
+      const now = new Date().toISOString();
+      return {
+        status: "success",
+        data: {
+          id: `mock-${Date.now()}`,
+          projectId,
+          currentStatus: payload.currentStatus,
+          wantSupport: payload.wantSupport,
+          supportFor: payload.supportFor,
+          nextStepUrl: payload.nextStepUrl,
+          submittedBy: "mock-wallet",
+          submittedByChain: "substrate",
+          createdAt: now,
+        },
+      };
+    }
+    return request(`/m2-program/${encodeURIComponent(projectId)}/continuations`, {
+      method: "POST",
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
     });
   },
 };


### PR DESCRIPTION
## Why

While auditing this session's commits for mistakes, I found three UI consumers calling api methods that were never added to the api object:

- `ProgramInboxSection.tsx:47` → `api.listProgramInbox(programSlug, auth)`
- `ProgramInboxSection.tsx:79` → `api.exportProgramInboxCsv(programSlug, auth)`
- `ProjectContinuationModal.tsx:93` → `api.createProjectContinuation(...)`

These were supposed to ship with PR #112 (inbox) and PR #114 (continuations). The summary mentioned a manual conflict resolution in `api.ts` during #114's rebase — that's where they were dropped.

## Why no build / lint signal

`client/tsconfig.app.json` has:
- `strict: false`
- `noImplicitAny: false`

…so `api.listProgramInbox` typechecks as `any`. The call only blows up at runtime as `TypeError: api.listProgramInbox is not a function` when the user clicks into the inbox or submits a continuation.

## Fix

Adds the four methods (`listProgramInbox`, `exportProgramInboxCsv`, `listProjectContinuations`, `createProjectContinuation`) following the existing api.ts conventions:
- JSON endpoints use the shared `request()` helper
- The CSV endpoint does a raw fetch (returns a Blob; `request()` always parses JSON)
- Each has a `USE_MOCK_DATA` short-circuit so Vercel preview deployments don't crash

## Verified

- `cd client && npm run lint` → 0 warnings
- `cd client && npm run build` → tsc + vite build clean
- `cd server && npm test` → 243 / 243 (unchanged; server-side was always correct)
- Manual cross-check: `ApiInboxEntry` and `ApiProjectContinuation` shapes match what the consumers expect

## Related observation (separate work)

The underlying foot-gun — `tsconfig.app.json` running with `strict: false` — is what let this ship undetected. Tightening that has wide blast radius (hundreds of latent issues likely). Worth a separate `/log-improvement` entry and a phased fix, not part of this PR.

## Trace

This is the third fix in a chain from PR #117's rough release:
- #118 (merged to main) — restored server-side `listInbox` + audit-log route after the bad auto-merge
- #119 (merged to develop) — back-ported #118 to develop
- This PR (develop) — restores the client-side methods #112 and #114 were supposed to ship