### PR TITLE
🚨 P0 SECURITY: substrate verifier — wallet impersonation fix

### DIFF
--- a/server/api/auth/verifiers/__tests__/substrate.verifier.test.js
+++ b/server/api/auth/verifiers/__tests__/substrate.verifier.test.js
@@ -26,14 +26,14 @@ describe('substrateVerifier.verify', () => {
     vi.clearAllMocks();
   });
 
-  it('returns valid:false for an invalid signature and does not parse the message', async () => {
+  it('returns valid:false for an invalid signature', async () => {
+    parseMessage.mockReturnValue({ statement: 'Sign in to Stadium', address: '5Abc', domain: 'localhost' });
     signatureVerify.mockReturnValue({ isValid: false });
 
     const result = await substrateVerifier.verify(INPUT);
 
     expect(result.valid).toBe(false);
     expect(result.error).toMatch(/Invalid signature/i);
-    expect(parseMessage).not.toHaveBeenCalled();
   });
 
   it('returns valid:true with parsed message and normalized address for a valid signature', async () => {
@@ -63,5 +63,65 @@ describe('substrateVerifier.verify', () => {
 
     expect(result.valid).toBe(true);
     expect(result.normalizedAddress).toBeNull();
+  });
+
+  // --- Regression tests: wallet-spoofing (see commit / PR description) ---
+
+  it('verifies the signature against parsed.address (from message body), NOT the header address', async () => {
+    // Attacker scenario: client says they are "5Attacker" but the signed SIWS
+    // body claims "5Victim". signatureVerify must be called against the body
+    // address, otherwise the attacker (who signed with their own key) would
+    // pass and the middleware would mint a session for the victim.
+    parseMessage.mockReturnValue({
+      statement: 'Sign in to Stadium',
+      address: '5Victim',
+      domain: 'localhost',
+    });
+    signatureVerify.mockReturnValue({ isValid: false }); // signature does NOT verify under 5Victim
+    decodeAddress.mockReturnValue(new Uint8Array([0xde, 0xad]));
+    u8aToHex.mockReturnValue('0xdead');
+
+    const result = await substrateVerifier.verify({
+      message: 'siws-message',
+      signature: '0xattackerSig',
+      address: '5Attacker', // header says attacker — must be ignored
+    });
+
+    expect(result.valid).toBe(false);
+    expect(signatureVerify).toHaveBeenCalledWith('siws-message', '0xattackerSig', '5Victim');
+  });
+
+  it('ignores the header address even when it differs from parsed.address (valid signature path)', async () => {
+    // Mirror of the previous test, with a passing signature. Confirms identity
+    // is taken from parsed.address regardless of what the header claims.
+    parseMessage.mockReturnValue({
+      statement: 'Sign in to Stadium',
+      address: '5Real',
+      domain: 'localhost',
+    });
+    signatureVerify.mockReturnValue({ isValid: true, crypto: 'sr25519' });
+    decodeAddress.mockReturnValue(new Uint8Array([0xbe, 0xef]));
+    u8aToHex.mockReturnValue('0xbeef');
+
+    const result = await substrateVerifier.verify({
+      message: 'siws-message',
+      signature: '0xsig',
+      address: '5Spoofed', // misleading header value
+    });
+
+    expect(result.valid).toBe(true);
+    expect(signatureVerify).toHaveBeenCalledWith('siws-message', '0xsig', '5Real');
+    expect(result.parsed.address).toBe('5Real');
+    expect(result.normalizedAddress).toBe('0xbeef');
+  });
+
+  it('rejects messages whose body has no address line', async () => {
+    parseMessage.mockReturnValue({ statement: 'Sign in to Stadium', domain: 'localhost' });
+
+    const result = await substrateVerifier.verify(INPUT);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/missing an address line/i);
+    expect(signatureVerify).not.toHaveBeenCalled();
   });
 });

--- a/server/api/auth/verifiers/substrate.verifier.js
+++ b/server/api/auth/verifiers/substrate.verifier.js
@@ -22,18 +22,42 @@ export const substrateVerifier = {
   chain: 'substrate',
 
   /**
-   * @param {{ message: string, signature: string, address: string }} input
+   * SECURITY: the signature must be verified against the address claimed INSIDE
+   * the SIWS message body (`parsed.address`), not against whatever address the
+   * client supplies in the request header. If we verified against the header
+   * address, an attacker could sign a message with their own key while putting
+   * a victim's address in the message body — the signature would still verify
+   * (against the attacker's address), and the middleware would then trust
+   * `parsed.address` (the victim) as the identity. The header `address` field
+   * is accepted for backwards compatibility with the request shape but is
+   * intentionally ignored here.
+   *
+   * Mirrors the ethereum verifier (ecrecover → compare to `fields.address`)
+   * and the solana verifier (derive pubkey from `parsed.address`). All three
+   * chains now share the invariant: the signing wallet is the wallet named in
+   * the signed message — there is no second, header-only source of identity.
+   *
+   * @param {{ message: string, signature: string, address?: string }} input
    * @returns {Promise<VerifyResult>}
    */
-  async verify({ message, signature, address }) {
+  async verify({ message, signature }) {
     await cryptoWaitReady();
 
-    const result = signatureVerify(message, signature, address);
+    const parsed = parseMessage(message);
+    if (!parsed?.address || typeof parsed.address !== 'string') {
+      return { valid: false, error: 'SIWS message is missing an address line' };
+    }
+
+    let result;
+    try {
+      result = signatureVerify(message, signature, parsed.address);
+    } catch (e) {
+      return { valid: false, error: `Signature verification threw: ${e.message}` };
+    }
     if (!result?.isValid) {
       return { valid: false, error: 'Invalid signature' };
     }
 
-    const parsed = parseMessage(message);
     return {
       valid: true,
       crypto: result.crypto,


### PR DESCRIPTION
## 🚨 P0 — Authentication bypass

The substrate SIWS verifier allowed any wallet holder to authenticate as any other substrate wallet on the platform, including all admin tiers (`app_admins`, `global_admins`, `AUTHORIZED_SIGNERS`, env-list admins).

## How the bypass worked

`server/api/auth/verifiers/substrate.verifier.js` called:
```js
const result = signatureVerify(message, signature, address); // ← address from request header
// ...
return { ..., normalizedAddress: normalizeAddress('substrate', parsed.address) }; // ← from message body
```

The two addresses were never cross-checked. So:

1. Attacker controls wallet `A`, knows victim's address `V` (public).
2. Attacker writes SIWS message text whose body claims `V` (`Address: V`).
3. Attacker signs that text with **their own** private key for `A` — gets `sig_A`.
4. Attacker sends `x-siws-auth: base64({ message, signature: sig_A, address: A })`.
5. Server calls `signatureVerify(message, sig_A, A)` → ✅ (A really did sign).
6. `parseMessage(message)` returns `parsed.address = V`.
7. Middleware records identity = `V` (the victim).
8. `requireAdmin` / `requireProgramAdmin` / `requireAppAdmin` all check the now-victim identity against the admin tables — full impersonation.

The bearer-token path inherits the spoof: a single spoofed SIWS exchange at `POST /api/admin/session` mints a 15-minute bearer bound to the victim's identity.

## Why the other two chains were safe

| Chain | Mechanism | Why safe |
|---|---|---|
| Ethereum | `ecrecover` recovers signer from sig+msg, then compares to `fields.address` (body) | recovered signer must equal body address |
| Solana | Decodes pubkey directly from `parsed.address` (body); the header address is destructured out of `verify({ message, signature })` | signature is verified against the body's pubkey |
| **Substrate (before)** | **Verified against header address, returned body address as identity** | **Two divergent sources → spoof** |

## Fix

`substrate.verifier.js` now parses the message first, then verifies the signature against `parsed.address` (from the body). The header `address` field is accepted in the request shape for backwards compatibility but is intentionally ignored. All three verifiers now share the invariant: "signing wallet is the wallet named in the signed message — no second header-only source."

## Regression tests

Two new tests in `substrate.verifier.test.js`:

1. **Mismatch rejected**: `parsed.address = '5Victim'`, header says `'5Attacker'`, `signatureVerify` mocked to return `{ isValid: false }` (the attacker's signature does not verify under the victim's address). Asserts `signatureVerify` was called with `'5Victim'` (body) and not `'5Attacker'` (header).
2. **Identity comes from parsed.address**: a valid signature is verified against `parsed.address` regardless of what the header claims. Asserts the final `normalizedAddress` equals the body, not the header.

Third test: messages with no address line are rejected with a clear error (instead of crashing on `undefined`).

## Verified

- `cd server && npm test` → 246 / 246 (was 243, three new regression tests)
- No changes outside the substrate verifier; eth/solana paths untouched

## Deploy urgency

This is exploitable in prod **right now**. Plata Mia rehearsal is in 2 days. Merge ASAP — Railway auto-deploys on merge to main, takes ~60s.

Will back-port to `develop` immediately after this merges.