### PR TITLE
docs: log 8 backlog items from post-#121 security audit

### DIFF
--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -137,3 +137,51 @@ Do **not** manually edit `- **Promoted**` lines.
 - **File(s)**: `client/src/components/TeamPaymentSection.tsx:210`
 - **Observed during**: full user-journey test pass (team-member journeys, Team & Payments tab)
 - **Suggestion**: team-member cards render with `key={member.walletAddress || index}`. Wallet address is not guaranteed unique across a project's team members — in the mock dataset two Plata Mia members share the redacted address `5MockWalletAddressRedactedForPreviewPurposes00000`, so React logs "Encountered two children with the same key" (3× per Team & Payments render). The `|| index` fallback only triggers on a *falsy* address, so a non-empty-but-duplicate address still collides. Production addresses are normally distinct so it does not surface there, but keying on a non-unique field is fragile. Key by a stable unique member id, or always fold in the index (e.g. `` key={`${member.walletAddress}-${index}`} ``).
+
+## [2026-05-21] Add `express-rate-limit` to admin-session + auth endpoints
+- **Severity**: minor
+- **File(s)**: `server/server.js`, `server/api/routes/admin-session.routes.js`
+- **Observed during**: security audit after #121 (substrate verifier P0)
+- **Suggestion**: `POST /api/admin/session` does SIWS signature verification (~50–200ms per call) and is unauthenticated. A burst of a few hundred req/sec could noticeably load the server. Add `express-rate-limit` with tight per-IP limits on `/api/admin/session` (e.g. 10/min) and a looser app-wide default (e.g. 200/min/IP). No new env vars needed.
+
+## [2026-05-21] Add `helmet` security headers middleware
+- **Severity**: nit
+- **File(s)**: `server/server.js`
+- **Observed during**: security audit after #121
+- **Suggestion**: server doesn't set `X-Frame-Options`, `X-Content-Type-Options`, or CSP. Railway terminates TLS and may set some at the edge, but defense-in-depth at the app layer is cheap. Drop `app.use(helmet())` after the CORS middleware. No CSP customisation needed since the server only serves JSON, not HTML.
+
+## [2026-05-21] `ADMIN_SESSION_SECRET` validation is lazy (first-call), not at startup
+- **Severity**: nit
+- **File(s)**: `server/api/auth/sessionToken.js:30`, `server/server.js`
+- **Observed during**: security audit after #121
+- **Suggestion**: `getSecret()` throws on the first `issueSessionToken`/`verifySessionToken` call if the env var is missing or under 32 chars. The server still boots successfully with a misconfigured secret, and the first admin to try logging in sees a 500. Move the check into `server.js` startup so misconfiguration fails fast and visibly in the deploy logs.
+
+## [2026-05-21] `requireAdmin` and `requireTeamMemberOrAdmin` don't capture `req.user.chain`
+- **Severity**: nit
+- **File(s)**: `server/api/middleware/auth.middleware.js` (`requireAdmin`, `requireTeamMemberOrAdmin`)
+- **Observed during**: security audit after #121
+- **Suggestion**: `requireProgramAdmin` and `requireAppAdmin` both stamp `chain` onto `req.user`. The other two middlewares don't. Downstream `auditLog.logSafe({ actor: { chain: req.user?.chain, … } })` calls then record `actor_chain = null` for any admin or team-member action — a forensics gap, not a security flaw. Add `chain: auth.chain` to both `req.user` assignments.
+
+## [2026-05-21] Audit-log coverage gaps on payment / payout actions
+- **Severity**: minor
+- **File(s)**: `server/api/controllers/project.controller.js` (`approveM2`, `requestChanges`, `confirmPayment`, `createContinuation`)
+- **Observed during**: security audit after #121
+- **Suggestion**: program-level mutations (`program.update`, `sponsor.*`, `signups.*`, `admin.*`, `application.<status>`) already log via `auditLog.logSafe`. Project-level mutations don't — `confirmPayment` in particular is high-value because it records on-chain payout proof. Wire `auditLog.logSafe` AFTER `res.json` for each, with `programId = project.program_id || null`. Continuations also worth auditing (post-M2 follow-up trail).
+
+## [2026-05-21] Tighten `tsconfig.app.json` strict mode (phased)
+- **Severity**: minor
+- **File(s)**: `client/tsconfig.app.json`
+- **Observed during**: bug investigation in #120 — missing api methods typechecked as `any` because `noImplicitAny: false` and `strict: false`
+- **Suggestion**: turn on `strict: true` + `noImplicitAny: true` after a sweep cleanup. Wide blast radius — likely hundreds of errors. Phase: first ratchet just `noImplicitAny: true`, fix everything, then enable `strictNullChecks`, then `strict: true`. Each phase its own PR.
+
+## [2026-05-21] Add a server boot smoke test
+- **Severity**: nit
+- **File(s)**: `server/tests/` (new)
+- **Observed during**: investigating #117's bad merge that broke prod for ~10 min
+- **Suggestion**: vitest currently tests handlers, repositories, and verifiers in isolation. None of the 243+ tests imports `server.js` end-to-end, so a route mounting an undefined controller method passes CI but crashes Railway at boot. Add a 1-test file that does `await import('../server.js')` with a 2s timeout, asserts the server starts listening, then closes. Would have caught #117 before merge.
+
+## [2026-05-21] CSV import body parsers might need formula-injection defense on read path too
+- **Severity**: nit
+- **File(s)**: `server/api/services/program-signup.service.js` (Luma CSV importer)
+- **Observed during**: hardening CSV export (#122) for formula injection
+- **Suggestion**: #122 sanitises the inbox EXPORT. The Luma CSV IMPORT reads attacker-controllable rows from a third-party file and persists them. The values aren't re-emitted to a spreadsheet from a different surface (yet), so import-side sanitisation isn't urgent — but if any future feature exports a CSV that includes signup names/emails from this table, the same defense must run. Either: apply the prefix at import time (defense in depth, alters stored data), or factor `csvCell` from `program-inbox.service.js` into a shared `csv.util.js` and call it everywhere CSV is generated.


### PR DESCRIPTION
Documentation-only change. Appends 8 entries to `docs/improvement-backlog.md` from the security audit run after the substrate-verifier P0 (#121) and CSV formula-injection defense (#122) shipped.

None of the items is exploitable. They're defense-in-depth and process hardening — promote via `/promote-backlog` when there's a window.

Entries:
1. `express-rate-limit` on `/api/admin/session` + app-wide
2. `helmet` middleware (`X-Frame-Options` etc.)
3. `ADMIN_SESSION_SECRET` startup validation (currently lazy)
4. `req.user.chain` capture in `requireAdmin` + `requireTeamMemberOrAdmin` (audit-log forensics gap)
5. Audit-log coverage on payment / payout / continuation actions
6. `tsconfig.app.json` strict-mode tightening (phased)
7. Server boot smoke test (would have caught #117)
8. Shared `csvCell` utility for any future CSV exports

No code changes.