### PR TITLE
release: 2026-04-14 cleanup + 8 audit-derived backlog entries

### DIFF
--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -137,3 +137,51 @@ Do **not** manually edit `- **Promoted**` lines.
 - **File(s)**: `client/src/components/TeamPaymentSection.tsx:210`
 - **Observed during**: full user-journey test pass (team-member journeys, Team & Payments tab)
 - **Suggestion**: team-member cards render with `key={member.walletAddress || index}`. Wallet address is not guaranteed unique across a project's team members — in the mock dataset two Plata Mia members share the redacted address `5MockWalletAddressRedactedForPreviewPurposes00000`, so React logs "Encountered two children with the same key" (3× per Team & Payments render). The `|| index` fallback only triggers on a *falsy* address, so a non-empty-but-duplicate address still collides. Production addresses are normally distinct so it does not surface there, but keying on a non-unique field is fragile. Key by a stable unique member id, or always fold in the index (e.g. `` key={`${member.walletAddress}-${index}`} ``).
+
+## [2026-05-21] Add `express-rate-limit` to admin-session + auth endpoints
+- **Severity**: minor
+- **File(s)**: `server/server.js`, `server/api/routes/admin-session.routes.js`
+- **Observed during**: security audit after #121 (substrate verifier P0)
+- **Suggestion**: `POST /api/admin/session` does SIWS signature verification (~50–200ms per call) and is unauthenticated. A burst of a few hundred req/sec could noticeably load the server. Add `express-rate-limit` with tight per-IP limits on `/api/admin/session` (e.g. 10/min) and a looser app-wide default (e.g. 200/min/IP). No new env vars needed.
+
+## [2026-05-21] Add `helmet` security headers middleware
+- **Severity**: nit
+- **File(s)**: `server/server.js`
+- **Observed during**: security audit after #121
+- **Suggestion**: server doesn't set `X-Frame-Options`, `X-Content-Type-Options`, or CSP. Railway terminates TLS and may set some at the edge, but defense-in-depth at the app layer is cheap. Drop `app.use(helmet())` after the CORS middleware. No CSP customisation needed since the server only serves JSON, not HTML.
+
+## [2026-05-21] `ADMIN_SESSION_SECRET` validation is lazy (first-call), not at startup
+- **Severity**: nit
+- **File(s)**: `server/api/auth/sessionToken.js:30`, `server/server.js`
+- **Observed during**: security audit after #121
+- **Suggestion**: `getSecret()` throws on the first `issueSessionToken`/`verifySessionToken` call if the env var is missing or under 32 chars. The server still boots successfully with a misconfigured secret, and the first admin to try logging in sees a 500. Move the check into `server.js` startup so misconfiguration fails fast and visibly in the deploy logs.
+
+## [2026-05-21] `requireAdmin` and `requireTeamMemberOrAdmin` don't capture `req.user.chain`
+- **Severity**: nit
+- **File(s)**: `server/api/middleware/auth.middleware.js` (`requireAdmin`, `requireTeamMemberOrAdmin`)
+- **Observed during**: security audit after #121
+- **Suggestion**: `requireProgramAdmin` and `requireAppAdmin` both stamp `chain` onto `req.user`. The other two middlewares don't. Downstream `auditLog.logSafe({ actor: { chain: req.user?.chain, … } })` calls then record `actor_chain = null` for any admin or team-member action — a forensics gap, not a security flaw. Add `chain: auth.chain` to both `req.user` assignments.
+
+## [2026-05-21] Audit-log coverage gaps on payment / payout actions
+- **Severity**: minor
+- **File(s)**: `server/api/controllers/project.controller.js` (`approveM2`, `requestChanges`, `confirmPayment`, `createContinuation`)
+- **Observed during**: security audit after #121
+- **Suggestion**: program-level mutations (`program.update`, `sponsor.*`, `signups.*`, `admin.*`, `application.<status>`) already log via `auditLog.logSafe`. Project-level mutations don't — `confirmPayment` in particular is high-value because it records on-chain payout proof. Wire `auditLog.logSafe` AFTER `res.json` for each, with `programId = project.program_id || null`. Continuations also worth auditing (post-M2 follow-up trail).
+
+## [2026-05-21] Tighten `tsconfig.app.json` strict mode (phased)
+- **Severity**: minor
+- **File(s)**: `client/tsconfig.app.json`
+- **Observed during**: bug investigation in #120 — missing api methods typechecked as `any` because `noImplicitAny: false` and `strict: false`
+- **Suggestion**: turn on `strict: true` + `noImplicitAny: true` after a sweep cleanup. Wide blast radius — likely hundreds of errors. Phase: first ratchet just `noImplicitAny: true`, fix everything, then enable `strictNullChecks`, then `strict: true`. Each phase its own PR.
+
+## [2026-05-21] Add a server boot smoke test
+- **Severity**: nit
+- **File(s)**: `server/tests/` (new)
+- **Observed during**: investigating #117's bad merge that broke prod for ~10 min
+- **Suggestion**: vitest currently tests handlers, repositories, and verifiers in isolation. None of the 243+ tests imports `server.js` end-to-end, so a route mounting an undefined controller method passes CI but crashes Railway at boot. Add a 1-test file that does `await import('../server.js')` with a 2s timeout, asserts the server starts listening, then closes. Would have caught #117 before merge.
+
+## [2026-05-21] CSV import body parsers might need formula-injection defense on read path too
+- **Severity**: nit
+- **File(s)**: `server/api/services/program-signup.service.js` (Luma CSV importer)
+- **Observed during**: hardening CSV export (#122) for formula injection
+- **Suggestion**: #122 sanitises the inbox EXPORT. The Luma CSV IMPORT reads attacker-controllable rows from a third-party file and persists them. The values aren't re-emitted to a spreadsheet from a different surface (yet), so import-side sanitisation isn't urgent — but if any future feature exports a CSV that includes signup names/emails from this table, the same defense must run. Either: apply the prefix at import time (defense in depth, alters stored data), or factor `csvCell` from `program-inbox.service.js` into a shared `csv.util.js` and call it everywhere CSV is generated.


### PR DESCRIPTION
## Scope

Brings `main` into full sync with `develop`. Two distinct things:

### 1. Long-overdue back-port of the 2026-04-14 cleanup
On 2026-04-14 develop deleted 18 stale files that have stayed on `main` ever since. None of them is wired to a route or imported anywhere — they're one-shot Mongo scripts from the pre-Supabase era plus their accompanying runbook docs:

**Docs deleted** (5)
- `docs/FIND_SUPABASE_KEYS.md`
- `docs/MONGODB_THEN_SUPABASE_RUNBOOK.md`
- `docs/SUPABASE_DEBUG_AND_FRESH_START.md`
- `docs/SUPABASE_FIX_VIA_CLI.md`
- `docs/SUPABASE_VERIFY_MIGRATION.md`

**Scripts deleted** (13, all under `server/scripts/`)
- `apply-symbiosis-payouts-to-supabase.js`
- `fix-bounty-amounts-supabase.js`
- `fix-symbiosis-in-supabase.js`
- `remove-all-duplicates.js`
- `remove-symbiosis-duplicates.js`
- `seed-symbiosis-to-supabase.js`
- `set-symbiosis-completed.js`
- `set-symbiosis-m2-building.js`
- `sync-bounty-prizes-from-mongo.js`
- `sync-final-submissions-to-supabase.js`
- `test-api-db-read.js`
- `update-plata-mia-to-supabase.js`

**Note:** three of those filenames are mentioned in retained docs (`docs/improvement-backlog.md`, `docs/stadium-revamp-phase-1-spec.md`, `docs/SYMBIOSIS_M2_IN_PRODUCTION.md`, `server/migration-data/README.md`) as historical references — they don't invoke the scripts, they describe what those scripts did. Those stale references have already existed on `develop` for ~5 weeks; this PR doesn't introduce them, it just brings main into the same state.

### 2. New: `client/.eslintrc.cjs` + 8 audit-derived backlog entries (from #124)
- `client/.eslintrc.cjs` (+18 lines) — config addition that landed on develop
- `docs/improvement-backlog.md` (+48 lines) — the audit-derived hardening items I logged earlier today

## Stats
```
19 files changed, 66 insertions(+), 1971 deletions(-)
```
Net ~1900 lines deleted — pure cruft removal.

## Deploy effect
- No server code touched — Railway redeploy is a no-op.
- No client app code touched — Vercel rebuild is a no-op (eslint config doesn't ship to runtime).
- No migrations.
- No env-var changes.

## Verified
Prod is already in the post-#123 healthy state. Nothing in this PR alters runtime behavior.