### PR TITLE
fix(admin): admin apply-on-behalf-of + wallet sign rate-limit dedupe

### DIFF
--- a/client/src/lib/auth/useWalletAuth.ts
+++ b/client/src/lib/auth/useWalletAuth.ts
@@ -6,7 +6,7 @@
  * gating) — this hook is identity-agnostic.
  */
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import type { Chain, WalletAccount } from './types'
 import { getProvider } from './registry'
 import { generateSiwsStatement, type SiwsContext } from '@/lib/siwsUtils'
@@ -134,6 +134,13 @@ export function useWalletAuth(): WalletAuth {
     [account]
   )
 
+  // De-dupes concurrent admin-bearer requests so multiple admin sections
+  // mounting in parallel only trigger ONE wallet sign popup. Without this,
+  // pages like AdminProgramPage (which renders 4 sections that each call
+  // getAdminBearerHeaders on mount) fire 4 simultaneous SIWS signs and the
+  // wallet extension rate-limits the burst with "rate limit exceeded".
+  const inflightSignRef = useRef<Promise<AdminAuthHeaders> | null>(null)
+
   const getAdminBearerHeaders = useCallback(async (): Promise<AdminAuthHeaders> => {
     if (!account) throw new Error('Wallet not connected')
 
@@ -142,43 +149,57 @@ export function useWalletAuth(): WalletAuth {
       return { Authorization: `Bearer ${cached}` }
     }
 
-    // No valid token — sign once with the existing admin-action statement,
-    // exchange via POST /api/admin/session for a short-lived bearer token,
-    // and cache it for the rest of this session.
-    const provider = getProvider(account.chain)
-    if (!provider) throw new Error(`Unsupported sign-in chain: ${account.chain}`)
-    const statement = generateSiwsStatement({ action: 'admin-action' })
-    const siwsHeader = await provider.signIn({ account, statement })
-
-    try {
-      const res = await fetch(`${API_BASE_URL}/admin/session`, {
-        method: 'POST',
-        headers: { 'x-siws-auth': siwsHeader, 'Content-Type': 'application/json' },
-        body: JSON.stringify({}),
-      })
-      if (!res.ok) {
-        // Session exchange failed — fall back to one-shot SIWS so the action
-        // still goes through. The caller passes the raw SIWS header instead.
-        return { 'x-siws-auth': siwsHeader }
-      }
-      const body = (await res.json()) as {
-        status: string
-        data: { token: string; expiresAt: string; chain: string; address: string }
-      }
-      if (!body?.data?.token) {
-        return { 'x-siws-auth': siwsHeader }
-      }
-      writeAdminToken({
-        chain: account.chain,
-        address: account.address,
-        token: body.data.token,
-        expiresAt: body.data.expiresAt,
-      })
-      return { Authorization: `Bearer ${body.data.token}` }
-    } catch {
-      // Network error — fall back to the SIWS one-shot so the caller still wins.
-      return { 'x-siws-auth': siwsHeader }
+    // A sign is already in flight — piggy-back on it instead of triggering
+    // a parallel popup.
+    if (inflightSignRef.current) {
+      return inflightSignRef.current
     }
+
+    // No valid token, no in-flight sign — start one. Cache the promise on the
+    // ref so any concurrent caller awaits it instead of starting a second.
+    const signFlow = (async (): Promise<AdminAuthHeaders> => {
+      try {
+        const provider = getProvider(account.chain)
+        if (!provider) throw new Error(`Unsupported sign-in chain: ${account.chain}`)
+        const statement = generateSiwsStatement({ action: 'admin-action' })
+        const siwsHeader = await provider.signIn({ account, statement })
+
+        try {
+          const res = await fetch(`${API_BASE_URL}/admin/session`, {
+            method: 'POST',
+            headers: { 'x-siws-auth': siwsHeader, 'Content-Type': 'application/json' },
+            body: JSON.stringify({}),
+          })
+          if (!res.ok) {
+            // Session exchange failed — fall back to one-shot SIWS so the action
+            // still goes through. The caller passes the raw SIWS header instead.
+            return { 'x-siws-auth': siwsHeader }
+          }
+          const body = (await res.json()) as {
+            status: string
+            data: { token: string; expiresAt: string; chain: string; address: string }
+          }
+          if (!body?.data?.token) {
+            return { 'x-siws-auth': siwsHeader }
+          }
+          writeAdminToken({
+            chain: account.chain,
+            address: account.address,
+            token: body.data.token,
+            expiresAt: body.data.expiresAt,
+          })
+          return { Authorization: `Bearer ${body.data.token}` }
+        } catch {
+          // Network error — fall back to the SIWS one-shot so the caller still wins.
+          return { 'x-siws-auth': siwsHeader }
+        }
+      } finally {
+        inflightSignRef.current = null
+      }
+    })()
+
+    inflightSignRef.current = signFlow
+    return signFlow
   }, [account])
 
   const disconnect = useCallback(() => {

--- a/client/src/pages/ProgramDetailPage.tsx
+++ b/client/src/pages/ProgramDetailPage.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
 import { useWalletAuth } from "@/lib/auth/useWalletAuth";
+import { isAdmin } from "@/lib/constants";
 import { ApplyToProgramModal } from "@/components/program/ApplyToProgramModal";
 
 const formatDateRange = (from?: string | null, to?: string | null) => {
@@ -46,6 +47,15 @@ const ProgramDetailPage = () => {
   const [sponsors, setSponsors] = useState<ApiProgramSponsor[]>([]);
   const [modalOpen, setModalOpen] = useState(false);
 
+  // Admins can apply on behalf of any project (server-side `requireTeamMemberOrAdminByBodyProject`
+  // accepts admins). Without this branch, the page would dead-end at "You need to be a team member"
+  // even though the server would have let them through.
+  const isUserAdmin = useMemo(
+    () => isAdmin(connectedAddress ?? undefined, auth.chain),
+    [connectedAddress, auth.chain],
+  );
+  const [allProjects, setAllProjects] = useState<ApiProject[]>([]);
+
   useEffect(() => {
     if (!slug) return;
     let active = true;
@@ -73,6 +83,28 @@ const ProgramDetailPage = () => {
       .catch(() => { if (active) setMyProjects([]); });
     return () => { active = false; };
   }, [connectedAddress]);
+
+  // Admins get the full project list so they can apply on behalf of any project.
+  // Limit is generous; we expect <500 projects historically. Response shape is
+  // `{ status, data: ApiProject[], meta }` per server/api/repositories/project.repository.js.
+  useEffect(() => {
+    if (!isUserAdmin) { setAllProjects([]); return; }
+    let active = true;
+    api
+      .getProjects({ limit: 500 })
+      .then((r: { data?: ApiProject[] }) => {
+        if (!active) return;
+        setAllProjects(Array.isArray(r?.data) ? r.data : []);
+      })
+      .catch(() => { if (active) setAllProjects([]); });
+    return () => { active = false; };
+  }, [isUserAdmin]);
+
+  // The list the apply modal renders: admin sees everything, normal user sees their team's projects.
+  const projectsForApply = useMemo(
+    () => (isUserAdmin && allProjects.length > 0 ? allProjects : myProjects),
+    [isUserAdmin, allProjects, myProjects],
+  );
 
   // Load sponsors once we know the program exists.
   useEffect(() => {
@@ -207,7 +239,17 @@ const ProgramDetailPage = () => {
       );
     }
 
-    if (myProjects.length === 0) {
+    if (projectsForApply.length === 0) {
+      if (isUserAdmin) {
+        // Admin signed in but the all-projects fetch is still pending or empty —
+        // surface a soft loading state instead of the gate copy.
+        return (
+          <div className="space-y-1">
+            <RackButton disabled>APPLY</RackButton>
+            <p className="label-hw-dim">LOADING PROJECTS…</p>
+          </div>
+        );
+      }
       return (
         <div className="space-y-1">
           <RackButton disabled>APPLY</RackButton>
@@ -216,7 +258,16 @@ const ProgramDetailPage = () => {
       );
     }
 
-    return <RackButton onClick={() => setModalOpen(true)}>APPLY WITH MY PROJECT</RackButton>;
+    return (
+      <div className="space-y-1">
+        <RackButton onClick={() => setModalOpen(true)}>
+          {isUserAdmin && myProjects.length === 0 ? "APPLY ON BEHALF OF…" : "APPLY WITH MY PROJECT"}
+        </RackButton>
+        {isUserAdmin && (
+          <p className="label-hw-dim">ADMIN MODE — APPLY ON BEHALF OF ANY PROJECT</p>
+        )}
+      </div>
+    );
   };
 
   return (
@@ -368,12 +419,12 @@ const ProgramDetailPage = () => {
               </div>
             </div>
 
-            {connectedAddress && myProjects.length > 0 && (
+            {connectedAddress && projectsForApply.length > 0 && (
               <ApplyToProgramModal
                 open={modalOpen}
                 onOpenChange={setModalOpen}
                 program={program}
-                projects={myProjects}
+                projects={projectsForApply}
                 connectedAddress={connectedAddress}
                 onApplied={handleApplied}
               />


### PR DESCRIPTION
Two related fixes the user surfaced from the same admin session:

## Bug 1 — admin can't apply to a program

Signing into `/programs/dogfooding` as an admin showed *'You need to be a team member on a Stadium project to apply'* — even though the server-side gate (`requireTeamMemberOrAdminByBodyProject`) already accepts admins.

**Cause:** `ProgramDetailPage.tsx` only loaded `myProjects` (the connected wallet's team-membership list) and gated the apply modal on `myProjects.length > 0`.

**Fix:** when the connected wallet is admin (`isAdmin(addr, chain)`), also fetch `api.getProjects({ limit: 500 })` and use that as the apply-modal project picker. Server posture unchanged.

## Bug 2 — 'rate limit exceeded' + 'Couldn't load admins' on AdminProgramPage

Opening `/admin/programs/bitrefill-2026` showed a destructive 'rate limit exceeded' toast and an empty admin section.

**Cause:** `AdminProgramPage` mounts 4 sections (`ProgramAdminsSection`, `ProgramSponsorsSection`, `ProgramSignupsSection`, `ProgramAuditLogSection`) and each section's mount effect calls `getAdminBearerHeaders()`. With an empty admin-session cache, all 4 cache-misses race and each launches a separate `provider.signIn(...)`. Talisman/Polkadot-JS sees 4 SIWS sign requests in a <50ms burst and rate-limits the wallet.

**Fix:** in `useWalletAuth.getAdminBearerHeaders`, store the in-flight sign promise on a `useRef` so concurrent callers await the same operation instead of starting parallel signs. After the first one resolves, the bearer is cached and later callers hit the cache path.

Effect: 1 popup per session (was up to 4 on AdminProgramPage). 'Rate limit exceeded' no longer fires from the burst. No behavior change for non-concurrent callers.

## Files

- `client/src/pages/ProgramDetailPage.tsx` — admin apply-on-behalf-of (Bug 1)
- `client/src/lib/auth/useWalletAuth.ts` — sign dedupe (Bug 2)

## Verified

| Check | Result |
|---|---|
| `cd client && npm run lint` | 0 warnings |
| `cd client && npm run build` (tsc + vite) | clean |
| Server posture | unchanged — server-side auth gates are correct already |