### PR TITLE
copy + nav: refresh homepage hero, m2/dogfooding blurbs, drop m2 tab (#137, #138)

### DIFF
--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -7,7 +7,6 @@ import { SearchPalette } from "./SearchPalette";
 
 const TABS = [
   { href: "/", label: "HOME" },
-  { href: "/m2-program", label: "M2" },
   { href: "/programs", label: "PROGRAMS" },
   { href: "/admin", label: "ADMIN" },
 ];

--- a/client/src/lib/mockPrograms.ts
+++ b/client/src/lib/mockPrograms.ts
@@ -86,7 +86,7 @@ export const mockPrograms: ApiProgram[] = [
     slug: "m2-incubator",
     programType: "m2_incubator",
     description:
-      "Continuation track for event winners — focused build sprint with a mentor.",
+      "Projects who've continued hacking in our mentorship and milestone-focused incubation programs.",
     status: "open",
     owner: "webzero",
     applicationsOpenAt: null,
@@ -104,7 +104,7 @@ export const mockPrograms: ApiProgram[] = [
     slug: "dogfooding",
     programType: "dogfooding",
     description:
-      "Continuation track where past winners trade structured feedback by using each other's products.",
+      "Continuation track where past winners trade structured feedback by using each other's products. Apply on an ongoing basis to get what you're building featured at our upcoming events.",
     status: "open",
     owner: "webzero",
     applicationsOpenAt: null,

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -265,7 +265,7 @@ const HomePage = () => {
             Stadium
           </h1>
           <p className="text-body text-base md:text-lg max-w-xl leading-relaxed">
-            Builders showcase what they ship at WebZero events — and keep building between them.
+            Stuff people have built here.
           </p>
 
           <div className="pt-8">


### PR DESCRIPTION
## Summary

Bundled draft PR closing #137 (copy fixes) and #138 (drop M2 from primary nav). Diff is 4 changed lines across 3 files — no behaviour change beyond strings + one nav entry.

- Hero \`<p>\` on \`/\` → "Stuff people have built here."
- M2 Incubator description (mock fixture) → "Projects who've continued hacking in our mentorship and milestone-focused incubation programs."
- Generic Dogfooding description (mock fixture) → appends "Apply on an ongoing basis to get what you're building featured at our upcoming events."
- M2 tab removed from the primary nav strip. \`/m2-program\` route is preserved; users reach it via the existing PROGRAMS tab.

Closes #137. Closes #138.

## Files changed

- \`client/src/pages/HomePage.tsx\` — hero text on \`/\` (line 268).
- \`client/src/lib/mockPrograms.ts\` — M2 Incubator description (line 89), generic Dogfooding description (line 107).
- \`client/src/components/Navigation.tsx\` — removed M2 entry from \`TABS\`.

## Where the changes are visible

- Hero copy: \`/\`
- M2 + Dogfooding copy: **\`/programs\`** — the homepage filters program cards to \`programType === 'hackathon'\` (HomePage.tsx:81–82), so M2 / Dogfooding surface on the \`/programs\` index, not on \`/\`.
- Nav: every page.

## Manual rollout follow-up (not in this PR)

The mock-fixture changes ship visibly on the Vercel preview (mock mode). **Production reads M2 and the generic Dogfooding row from Supabase**, so the descriptions need to be updated manually via the Supabase dashboard:

- \`programs\` row \`slug = 'm2-incubator'\` → update \`description\`.
- \`programs\` row \`slug = 'dogfooding'\` (generic ongoing, NOT \`dogfooding-2026-berlin\`) → update \`description\`.

The Berlin 2026 dogfooding row and \`server/scripts/seed-dogfooding-program.js\` are intentionally untouched.

## Test plan

- [x] \`npm test\` in \`server/\` — 248 passed (31 files).
- [x] \`npm run build\` in \`client/\` — green; only pre-existing chunk-size warning.
- [x] \`npm run lint\` in \`client/\` — clean (\`--max-warnings 0\`).
- [x] \`stadium-tester\` against \`http://localhost:8080\` with \`VITE_USE_MOCK_DATA=true\` — 5/5 PASS, 0 console errors.
- [ ] Visual review on the Vercel preview by reviewer.
- [ ] Manual Supabase prod row updates after merge (above).

## stadium-tester report

\`\`\`
## Stadium UI verification — http://localhost:8080

**Scenarios**: 5 total, 5 pass, 0 fail, 0 skipped

| # | Scenario                                                                                              | Result | Notes                                                                       |
|---|-------------------------------------------------------------------------------------------------------|--------|-----------------------------------------------------------------------------|
| 1 | On /, hero <p> reads exactly "Stuff people have built here."                                          | PASS   | observed verbatim in hero <p>                                               |
| 2 | On /programs, M2 Incubator card description reads new mentorship/milestone copy                       | PASS   | route corrected from / → /programs; HomePage only renders 'hackathon' cards |
| 3 | On /programs, generic Dogfooding card description ends with ongoing-application CTA                   | PASS   | route corrected from / → /programs for the same reason                      |
| 4 | On /, top nav contains HOME / PROGRAMS / ADMIN, no M2                                                 | PASS   | M2 tab absent from [role=tablist]; required tabs present                    |
| 5 | On /m2-program, the page loads (route preserved)                                                      | PASS   | nav renders, no 404 string                                                  |

**Preview mode**: window.__STADIUM_MOCK__ = true (dev server started with VITE_USE_MOCK_DATA=true)
**Console errors during run**: 0
**Recommended next action**: continue to PR
\`\`\`

## Invariants respected

- No \`console.*\` added.
- No light-mode styles or hex-with-\`!important\` introduced.
- No Mongoose access in \`server/api/**\`; no Supabase access in \`server/scripts/\`.
- ESM untouched. No new files.
- \`BYPASS_ADMIN_CHECK\` untouched.

## Notes

- Per CLAUDE.md §6: opening as draft, never merging. CODEOWNER reviews + merges.