### PR TITLE
copy: rename user-facing 'UNIT' label to 'ENTRY'

### DIFF
--- a/client/src/components/unit-card.tsx
+++ b/client/src/components/unit-card.tsx
@@ -62,7 +62,7 @@ export function UnitCard({
 
       <CardHeader className="pb-2">
         <div className="label-hw-dim mb-2">
-          UNIT {unitNumber}{date && ` · ${date}`}
+          ENTRY {unitNumber}{date && ` · ${date}`}
         </div>
         <h3 className="font-display text-2xl uppercase tracking-tight text-display line-clamp-1">
           {title}

--- a/client/src/components/unit-detail-modal.tsx
+++ b/client/src/components/unit-detail-modal.tsx
@@ -76,7 +76,7 @@ export function UnitDetailModal({ open, onOpenChange, unit }: UnitDetailModalPro
         <DialogHeader className="px-5 pt-5 pb-3">
           <div className="flex items-start justify-between gap-3 mb-1">
             <div className="label-hw-dim">
-              UNIT {unit.unitNumber}{unit.date && ` · ${unit.date}`}
+              ENTRY {unit.unitNumber}{unit.date && ` · ${unit.date}`}
             </div>
             <div className="flex gap-1 flex-shrink-0">
               {unit.isWinner && (

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -443,7 +443,7 @@ const AdminPage = () => {
               {projectsUnderReview.map((project) => (
                 <div key={project.id} className="lcd p-4">
                   <div className="mb-3">
-                    <div className="label-hw-dim mb-1">UNIT · SUBMITTED {formatDate(project.finalSubmission?.submittedDate || project.submittedDate)}</div>
+                    <div className="label-hw-dim mb-1">ENTRY · SUBMITTED {formatDate(project.finalSubmission?.submittedDate || project.submittedDate)}</div>
                     <h3 className="font-display text-2xl uppercase tracking-tight text-display leading-tight">
                       {project.projectName}
                     </h3>

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -284,7 +284,7 @@ const HomePage = () => {
           <div className="panel p-4">
             <div className="label-hw mb-3">·INDEX / LIVE</div>
             <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
-              <LCDStat value={statsLoading ? "—" : stats.totalProjects} label="Total Units" size="lg" />
+              <LCDStat value={statsLoading ? "—" : stats.totalProjects} label="Total Entries" size="lg" />
               <LCDStat value={statsLoading ? "—" : stats.winners} label="Winners" showLED pulse />
               <LCDStat value={statsLoading ? "—" : stats.m2Graduates} label="In M2" showLED />
               <LCDStat value={statsLoading ? "—" : fmtUSD(stats.totalPaid)} label="Paid" size="sm" showLED />
@@ -298,7 +298,7 @@ const HomePage = () => {
             <div className="flex items-center justify-between mb-3 pb-3 border-b border-hairline">
               <div className="label-hw text-display flex items-center gap-2">
                 <span className="led led-sm led-pulse" aria-hidden="true" />
-                ·NOW SHOWING / UNIT {featuredUnit.unitNumber}
+                ·NOW SHOWING / ENTRY {featuredUnit.unitNumber}
               </div>
               {featuredUnit.date && <div className="label-hw-dim">{featuredUnit.date}</div>}
             </div>
@@ -314,7 +314,7 @@ const HomePage = () => {
           <InputBus
             value={searchQuery}
             onChange={setSearchQuery}
-            placeholder="search units..."
+            placeholder="search entries..."
             className="flex-1 min-w-[200px]"
           />
           {hackathons.length > 0 && (
@@ -369,7 +369,7 @@ const HomePage = () => {
         <section className="mb-10">
           <div className="flex items-center justify-between mb-3 pb-3 border-b border-hairline">
             <div className="label-hw text-display">·DIRECTORY / GRID</div>
-            <div className="label-hw-dim">{filteredProjects.length} {filteredProjects.length === 1 ? "UNIT" : "UNITS"}</div>
+            <div className="label-hw-dim">{filteredProjects.length} {filteredProjects.length === 1 ? "ENTRY" : "ENTRIES"}</div>
           </div>
 
           {loading ? (

--- a/client/src/pages/M2ProgramPage.tsx
+++ b/client/src/pages/M2ProgramPage.tsx
@@ -189,7 +189,7 @@ const M2ProgramPage = () => {
           <InputBus
             value={search}
             onChange={setSearch}
-            placeholder="search teams or units..."
+            placeholder="search teams or entries..."
             kbdHint="⌘K"
             className="flex-1 min-w-[200px]"
           />
@@ -245,7 +245,7 @@ const M2ProgramPage = () => {
 
             {filtered.length === 0 && (
               <div className="panel px-4 py-10 text-center">
-                <div className="label-hw text-display mb-2">·NO UNITS MATCH</div>
+                <div className="label-hw text-display mb-2">·NO ENTRIES MATCH</div>
                 <p className="label-hw-dim">
                   {view === "mine" && !connectedAddress
                     ? "Connect a wallet to see your teams."
@@ -288,7 +288,7 @@ function M2Rack({
 
       <div className="hidden md:grid grid-cols-[32px_1fr_220px_90px_70px] gap-2 px-4 py-2 bg-shell border-b border-hairline-subtle">
         <div />
-        <div className="label-hw-dim">UNIT / TEAM</div>
+        <div className="label-hw-dim">ENTRY / TEAM</div>
         <div className="label-hw-dim">MILESTONES</div>
         <div className="label-hw-dim">PRIZE</div>
         <div />
@@ -316,7 +316,7 @@ function M2Row({ team, onClick }: { team: Team; onClick: () => void }) {
       </div>
 
       <div>
-        <div className="label-hw-dim mb-0.5">UNIT {team.unitNumber}</div>
+        <div className="label-hw-dim mb-0.5">ENTRY {team.unitNumber}</div>
         <div className="font-display text-base uppercase tracking-tight text-display leading-tight">
           {team.title}
         </div>

--- a/client/src/pages/NotFound.tsx
+++ b/client/src/pages/NotFound.tsx
@@ -10,7 +10,7 @@ const NotFound = () => {
         <h1 className="font-display text-7xl uppercase tracking-tight text-display leading-none mb-4">
           404
         </h1>
-        <p className="text-body text-base mb-2">No unit found at this address.</p>
+        <p className="text-body text-base mb-2">No entry found at this address.</p>
         <p className="label-hw-dim mb-6 break-all">{location.pathname}</p>
         <Link
           to="/"

--- a/client/src/pages/ProjectDetailsPage.tsx
+++ b/client/src/pages/ProjectDetailsPage.tsx
@@ -858,7 +858,7 @@ const ProjectDetailsPage = () => {
           <div className="max-w-4xl mx-auto space-y-6">
             {/* Header Section — rack chrome */}
             <div className="space-y-4">
-              <div className="label-hw-dim">·UNIT / {project.id?.toUpperCase()}</div>
+              <div className="label-hw-dim">·ENTRY / {project.id?.toUpperCase()}</div>
 
               <div className="flex flex-wrap items-center gap-2">
                 {project.m2Status === 'completed' && (

--- a/client/src/pages/WinnersPage.tsx
+++ b/client/src/pages/WinnersPage.tsx
@@ -158,7 +158,7 @@ const WinnersPage = () => {
               <span className="led led-sm" aria-hidden="true" /> ·GRID
             </div>
             <div className="label-hw-dim">
-              {loading ? "…" : `${winners.length} ${winners.length === 1 ? "UNIT" : "UNITS"}`}
+              {loading ? "…" : `${winners.length} ${winners.length === 1 ? "ENTRY" : "ENTRIES"}`}
             </div>
           </div>
 


### PR DESCRIPTION
## Summary

"Units" read oddly, so the user-facing label for a project/entry is now **ENTRY** / **ENTRIES**. **User-facing strings only** — internal identifiers are intentionally untouched (no import churn).

## Changes (8 files, copy only)
- Card label `ENTRY {n}` (`unit-card.tsx`) + detail modal header (`unit-detail-modal.tsx`).
- Home: hero stat **Total Entries**, directory count **N ENTRIES**, featured header **·NOW SHOWING / ENTRY NNN**, `search entries…` placeholder.
- M2 program: **ENTRY / TEAM** column, row labels **ENTRY NNN**, empty state **·NO ENTRIES MATCH**, `search teams or entries…` placeholder.
- Project detail breadcrumb **·ENTRY / <ID>**; admin card **ENTRY · SUBMITTED**; winners count **N ENTRIES**; 404 **No entry found at this address.**

> Note: the `Total Entries` stat label wasn't in the original scope list — caught by the grep guard during verification and included since it's user-facing.

## Not changed (internal — by design)
Filenames `unit-card.tsx` / `unit-detail-modal.tsx`; components `UnitCard` / `UnitDetailModal`; types `UnitForCard` / `Unit`; fn `toUnit`; field `unitNumber`; props `unit` / `featuredUnit` / `selectedUnit`. None render the word to users.

## Test plan
- [x] `npm run build` + `npm run lint` (client) — green.
- [x] Grep guard: `grep -rni unit client/src` → only internal identifiers + substring false-positives ("community", "Unity SDK") remain; no user-facing UNIT/UNITS text.
- [x] `stadium-tester` @ localhost (mock) — **7/7 PASS**.

## stadium-tester report
```
**Scenarios**: 7 total, 7 pass, 0 fail
| Scenario | Result |
| home: Total Entries, count, placeholder, ENTRY NNN cards, no UNIT leak | PASS |
| home: clicking a card opens modal headed ENTRY NNN                     | PASS |
| m2-program: ENTRY / TEAM header + placeholder, no UNIT leak            | PASS |
| project detail: breadcrumb reads ·ENTRY / <ID>                        | PASS |
| winners: count uses ENTRIES, no UNIT leak                             | PASS |
| 404: "No entry found at this address."                                | PASS |
| preview-mode sanity (window.__STADIUM_MOCK__ = true)                  | PASS |

console errors: 0
```

Pure copy change — no server, data, or new files. Per CLAUDE.md §6: draft, never merging.