### PR TITLE
feat(landing): program-type spaces entry point + per-program projects view

### DIFF
--- a/client/src/components/program-spaces.tsx
+++ b/client/src/components/program-spaces.tsx
@@ -1,0 +1,96 @@
+import { Link } from "react-router-dom";
+import { Zap, Lightbulb, Eye, Mic, type LucideIcon } from "lucide-react";
+import type { ApiProgram } from "@/lib/api";
+
+type Space = {
+  type: ApiProgram["programType"];
+  label: string;
+  blurb: string;
+  href: string;
+  Icon: LucideIcon;
+};
+
+// The four evergreen program types. M2 has its own dedicated page; the others
+// deep-link into the /programs directory filtered by type.
+const SPACES: Space[] = [
+  {
+    type: "hackathon",
+    label: "HACKATHONS",
+    blurb: "Weekend build sprints on Polkadot — ship something new, win bounties.",
+    href: "/programs?type=hackathon",
+    Icon: Zap,
+  },
+  {
+    type: "m2_incubator",
+    label: "M2 INCUBATOR",
+    blurb: "Keep building what you shipped, with a mentor and a defined Milestone 2.",
+    href: "/m2-program",
+    Icon: Lightbulb,
+  },
+  {
+    type: "dogfooding",
+    label: "DOGFOODING",
+    blurb: "Hands-on sessions where builders trade real, structured feedback.",
+    href: "/programs?type=dogfooding",
+    Icon: Eye,
+  },
+  {
+    type: "pitch_off",
+    label: "PITCHOFF",
+    blurb: "Builders pitch live to the room — the crowd picks what's next.",
+    href: "/programs?type=pitch_off",
+    Icon: Mic,
+  },
+];
+
+/**
+ * Landing-page entry point to all WebZero programs: one "space" per program
+ * type, with a culture blurb. Counts are derived from the programs already
+ * loaded by HomePage (no extra fetch).
+ */
+export function ProgramSpaces({ programs }: { programs: ApiProgram[] }) {
+  const countFor = (t: ApiProgram["programType"]) =>
+    programs.filter((p) => p.programType === t).length;
+
+  return (
+    <section className="mb-10">
+      <div className="flex items-center justify-between mb-3 pb-3 border-b border-hairline">
+        <div className="label-hw text-display flex items-center gap-2">
+          <span className="led led-sm led-pulse" aria-hidden="true" /> ·PROGRAMS / WHAT WE DO
+        </div>
+      </div>
+      <p className="text-body text-sm md:text-base max-w-2xl leading-relaxed mb-3">
+        WebZero is where builders ship — then keep going. Start at a hackathon, go deeper in M2,
+        get real feedback at a dogfooding, and put it in front of the room at PitchOff. Find your lane.
+      </p>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+        {SPACES.map(({ type, label, blurb, href, Icon }) => {
+          const count = countFor(type);
+          return (
+            <Link
+              key={type}
+              to={href}
+              className="lcd block px-4 py-4 transition-transform duration-150 hover:-translate-y-[1px]"
+            >
+              <div className="flex items-start gap-3">
+                <Icon className="h-5 w-5 text-display flex-shrink-0 mt-0.5" aria-hidden="true" />
+                <div className="min-w-0 flex-1">
+                  <div className="font-display text-2xl uppercase tracking-tight text-display leading-none mb-1">
+                    {label}
+                  </div>
+                  <p className="text-[12px] text-body leading-[1.6] mb-2">{blurb}</p>
+                  <div className="flex items-center justify-between">
+                    <span className="label-hw-dim">
+                      {count > 0 ? `·${count} ${count === 1 ? "EVENT" : "EVENTS"}` : "·COMING SOON"}
+                    </span>
+                    <span className="label-hw-dim" aria-hidden="true">▸</span>
+                  </div>
+                </div>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -10,7 +10,8 @@ import { InputBus } from "@/components/input-bus";
 import { HardwareToggle } from "@/components/hardware-toggle";
 import { ProjectCardSkeleton } from "@/components/ProjectCardSkeleton";
 import { NoProjectsFound } from "@/components/EmptyState";
-import { api, type ApiProject, API_BASE_URL } from "@/lib/api";
+import { ProgramSpaces } from "@/components/program-spaces";
+import { api, type ApiProject, type ApiProgram, API_BASE_URL } from "@/lib/api";
 import { isMainTrackWinner } from "@/lib/projectUtils";
 import { useToast } from "@/hooks/use-toast";
 
@@ -58,6 +59,7 @@ const HomePage = () => {
   const [projects, setProjects] = useState<ApiProject[]>([]);
   const [hackathons, setHackathons] = useState<{ id: string; name: string }[]>([]);
   const [allProjects, setAllProjects] = useState<ApiProject[]>([]);
+  const [allPrograms, setAllPrograms] = useState<ApiProgram[]>([]);
   const [statsLoading, setStatsLoading] = useState(true);
   const [loading, setLoading] = useState(true);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -78,6 +80,7 @@ const HomePage = () => {
         const apiProjects: ApiProject[] = Array.isArray(projectsResp?.data) ? projectsResp.data : [];
         setAllProjects(apiProjects);
         setStatsLoading(false);
+        setAllPrograms(programsResp?.data ?? []);
         const eventPrograms = (programsResp?.data ?? []).filter(
           (p) => p.programType === "hackathon",
         );
@@ -291,6 +294,9 @@ const HomePage = () => {
             </div>
           </div>
         </section>
+
+        {/* Programs — entry point to all WebZero program types */}
+        <ProgramSpaces programs={allPrograms} />
 
         {/* Now Showing — single featured unit */}
         {featuredUnit && (

--- a/client/src/pages/ProgramDetailPage.tsx
+++ b/client/src/pages/ProgramDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link, useNavigate } from "react-router-dom";
 import { Navigation } from "@/components/Navigation";
+import { UnitCard } from "@/components/unit-card";
 import { RotateCw } from "lucide-react";
 import { ChainPicker } from "@/components/auth/ChainPicker";
 import { getProvider } from "@/lib/auth/registry";
@@ -47,7 +48,9 @@ const ProgramDetailPage = () => {
   const [myApplications, setMyApplications] = useState<ApiProgramApplication[]>([]);
   const [sponsors, setSponsors] = useState<ApiProgramSponsor[]>([]);
   const [projects, setProjects] = useState<ApiProgramProject[]>([]);
+  const [entries, setEntries] = useState<ApiProject[]>([]);
   const [modalOpen, setModalOpen] = useState(false);
+  const navigate = useNavigate();
 
   // Admins can apply on behalf of any project (server-side `requireTeamMemberOrAdminByBodyProject`
   // accepts admins). Without this branch, the page would dead-end at "You need to be a team member"
@@ -128,6 +131,20 @@ const ProgramDetailPage = () => {
       .listProgramProjects(slug)
       .then((r) => { if (active) setProjects(r.data); })
       .catch(() => { if (active) setProjects([]); });
+    return () => { active = false; };
+  }, [slug, program]);
+
+  // Stadium project entries belonging to this program (hackathons etc.).
+  // Server filters on hackathon_id, backfilled to match program slugs.
+  useEffect(() => {
+    if (!slug || !program) { setEntries([]); return; }
+    let active = true;
+    api
+      .getProjects({ hackathonId: slug, limit: 500 })
+      .then((r: { data?: ApiProject[] }) => {
+        if (active) setEntries(Array.isArray(r?.data) ? r.data : []);
+      })
+      .catch(() => { if (active) setEntries([]); });
     return () => { active = false; };
   }, [slug, program]);
 
@@ -421,7 +438,40 @@ const ProgramDetailPage = () => {
               </div>
             )}
 
-            {projects.length > 0 && (
+            {entries.length > 0 && (
+              <div className="panel p-4 mb-4">
+                <div className="label-hw mb-3">·PROJECTS</div>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                  {entries.map((p, i) => {
+                    const isWinner = Array.isArray(p.bountyPrize) && p.bountyPrize.length > 0;
+                    const dateStr = p.completionDate || p.submittedDate || p.hackathon?.endDate;
+                    const date = dateStr
+                      ? new Date(dateStr).toLocaleDateString("en-US", { month: "short", day: "2-digit" }).toUpperCase()
+                      : undefined;
+                    return (
+                      <UnitCard
+                        key={p.id}
+                        unitNumber={String(i + 1).padStart(3, "0")}
+                        title={p.projectName}
+                        author={p.teamMembers?.[0]?.name || "Unknown"}
+                        description={p.description}
+                        track={p.bountyPrize?.[0]?.name || p.categories?.[0] || "Other"}
+                        isWinner={isWinner}
+                        isM2={p.m2Status === "completed"}
+                        date={date}
+                        prize={p.bountyPrize?.[0]?.amount ? `$${p.bountyPrize[0].amount.toLocaleString()}` : undefined}
+                        demoUrl={p.demoUrl}
+                        githubUrl={p.projectRepo}
+                        projectUrl={`/m2-program/${p.id}`}
+                        onClick={() => navigate(`/m2-program/${p.id}`)}
+                      />
+                    );
+                  })}
+                </div>
+              </div>
+            )}
+
+            {entries.length === 0 && projects.length > 0 && (
               <div className="panel p-4 mb-4">
                 <div className="label-hw mb-3">·PROJECTS</div>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">

--- a/client/src/pages/ProgramsPage.tsx
+++ b/client/src/pages/ProgramsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { Navigation } from "@/components/Navigation";
 import { api, type ApiProgram } from "@/lib/api";
 
@@ -26,9 +26,16 @@ const ProgramsPage = () => {
     };
   }, []);
 
-  const openPrograms = programs.filter((p) => p.status === "open");
+  const [searchParams] = useSearchParams();
+  const typeFilter = searchParams.get("type");
+  const typeLabel = typeFilter
+    ? PROGRAM_TYPE_LABEL[typeFilter as ApiProgram["programType"]] ?? typeFilter.toUpperCase()
+    : null;
+  const matchesType = (p: ApiProgram) => !typeFilter || p.programType === typeFilter;
+
+  const openPrograms = programs.filter((p) => p.status === "open" && matchesType(p));
   const pastPrograms = programs.filter(
-    (p) => p.status === "completed" || p.status === "closed",
+    (p) => (p.status === "completed" || p.status === "closed") && matchesType(p),
   );
 
   return (
@@ -37,7 +44,12 @@ const ProgramsPage = () => {
 
       <main className="container mx-auto px-4 py-6">
         <div className="mb-6">
-          <div className="label-hw-dim mb-2">·PROGRAMS / OPEN</div>
+          <div className="label-hw-dim mb-2 flex items-center gap-2">
+            <span>·PROGRAMS / {typeLabel ?? "OPEN"}</span>
+            {typeFilter && (
+              <Link to="/programs" className="text-display hover:underline">· ALL ▸</Link>
+            )}
+          </div>
           <h1 className="font-display text-5xl md:text-6xl uppercase tracking-tight text-display leading-[0.95] mb-2">
             Programs
           </h1>


### PR DESCRIPTION
## Summary

Two related pieces that turn the landing page into an entry point for all WebZero programs and let a program show its projects.

### Part A — Program spaces on the landing page
- New `client/src/components/program-spaces.tsx`: 4 evergreen **type** spaces (Hackathons, M2 Incubator, Dogfooding, PitchOff) — lucide icon + one-line blurb + per-type event count + a WebZero culture blurb, in the existing rack/LCD aesthetic.
- Rendered on `HomePage` right after the Index stats panel; reuses the programs already fetched there (no extra request). The entries directory stays below.
- `ProgramsPage` now reads `?type=` (`useSearchParams`) and filters the open + past lists, with a "· ALL ▸" reset. So each space is a real category link: Hackathons/Dogfooding/PitchOff → `/programs?type=…`; **M2 → `/m2-program`** (its dedicated page).

### Part B — "All projects for this program"
- `ProgramDetailPage` fetches the program's Stadium entries via `api.getProjects({ hackathonId: slug, limit: 500 })` (server filters on `hackathon_id`, backfilled to match program slugs) and renders them as a `·PROJECTS` grid of **`UnitCard`**, each linking to `/m2-program/:id`.
- Falls back to the existing **signup-derived** project cards for programs whose projects only exist as submissions (PitchOff/Dogfooding). Most programs have exactly one source.

Drill-down now works: type space → `/programs?type=hackathon` → click a program → `/programs/:slug` → its entries → a project page.

## Files
- **NEW** `client/src/components/program-spaces.tsx`
- `client/src/pages/HomePage.tsx` — keep full programs list; render `<ProgramSpaces>`
- `client/src/pages/ProgramsPage.tsx` — `?type=` filter
- `client/src/pages/ProgramDetailPage.tsx` — program's entries grid

## Test plan
- [x] `npm run build` + `npm run lint` (client) — green.
- [x] `stadium-tester` @ localhost (mock) — **7/7 PASS**.

## stadium-tester report
```
**Scenarios**: 7 total, 7 pass, 0 fail
| Scenario | Result |
| home: PROGRAMS / WHAT WE DO — 4 spaces + culture blurb + HACKATHONS shows 4 EVENTS | PASS |
| home: space links → /programs?type=… (M2 → /m2-program)                            | PASS |
| /programs?type=dogfooding lists only dogfooding programs (no hackathons in grid)    | PASS |
| /programs/symmetry-2024 shows ·PROJECTS entries grid; click → /m2-program/:id       | PASS |
| /programs/pitchoff-2026-denver still shows signup-derived cards                     | PASS |
| home: entries directory still renders below                                        | PASS |
| preview-mode sanity (window.__STADIUM_MOCK__ = true)                               | PASS |

console errors: 0
```

## Notes
- Client-only — no server, schema, or data changes (`getProjects` already supports `hackathonId`; a dedicated `programId` filter is a possible future server nicety).
- Culture blurb copy is editable.
- Per CLAUDE.md §6: draft, never merging.