### PR TITLE
security: helmet headers + express-rate-limit (#127, #128)

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -18,6 +18,8 @@
         "csv-parser": "^3.0.0",
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
+        "express-rate-limit": "^8.5.2",
+        "helmet": "^8.1.0",
         "mongoose": "^8.16.1",
         "polkadot-api": "^1.13.1",
         "resend": "^6.12.3",
@@ -5310,6 +5312,7 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -5346,6 +5349,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/fast-sha256": {
@@ -5593,6 +5614,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/hmac-drbg": {
       "version": "1.0.1",
       "license": "MIT",
@@ -5685,6 +5715,15 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/server/package.json
+++ b/server/package.json
@@ -34,6 +34,8 @@
     "csv-parser": "^3.0.0",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
+    "express-rate-limit": "^8.5.2",
+    "helmet": "^8.1.0",
     "mongoose": "^8.16.1",
     "polkadot-api": "^1.13.1",
     "resend": "^6.12.3",

--- a/server/server.js
+++ b/server/server.js
@@ -1,5 +1,7 @@
 import express from "express";
 import cors from "cors";
+import helmet from "helmet";
+import rateLimit from "express-rate-limit";
 import connectToSupabase, { supabase } from "./db.js";
 import m2ProgramRoutes from './api/routes/m2-program.routes.js';
 import programRoutes from './api/routes/program.routes.js';
@@ -11,6 +13,35 @@ import { getAuthorizedAddresses, NETWORK_CONFIG } from './config/polkadot-config
 
 const app = express();
 const PORT = process.env.PORT || 2000;
+
+// Railway terminates TLS at a proxy, so trust the first hop for correct client
+// IPs (used by rate limiting). A specific value avoids express-rate-limit's
+// permissive-trust-proxy validation error.
+app.set('trust proxy', 1);
+
+// Security headers. This is a JSON API (no HTML), so CSP is unnecessary; allow
+// the separately-hosted SPA to read responses cross-origin (#128).
+app.use(helmet({
+    contentSecurityPolicy: false,
+    crossOriginResourcePolicy: { policy: 'cross-origin' },
+}));
+
+// Rate limiting (#127): a generous app-wide default plus a tight limit on the
+// unauthenticated, signature-verifying admin session endpoint.
+const apiLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    limit: 200,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { status: 'error', message: 'Too many requests, slow down.' },
+});
+const sessionLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    limit: 10,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { status: 'error', message: 'Too many sign-in attempts, try again shortly.' },
+});
 
 // CORS Configuration: allow explicit list + any Vercel deployment (*.vercel.app)
 // In non-production, also allow any http://localhost:* or http://127.0.0.1:*
@@ -43,12 +74,13 @@ app.use(cors({
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(requestLogger);
+app.use(apiLimiter);
 
 // API Routes
 app.use('/api/m2-program', m2ProgramRoutes);
 app.use('/api/programs', programRoutes);
 app.use('/api/wallet-contacts', walletContactRoutes);
-app.use('/api/admin/session', adminSessionRoutes);
+app.use('/api/admin/session', sessionLimiter, adminSessionRoutes);
 app.use('/api/admin', adminTiersRoutes);
 
 // Backward compatibility: Keep old /api/projects route as alias


### PR DESCRIPTION
## Summary

Two quick hardening wins from the post-audit backlog, especially relevant now that we have public program/projects endpoints.

- **helmet (#128)** — sets standard security headers (X-Frame-Options, X-Content-Type-Options, etc.). CSP is **disabled** (this is a JSON API, no HTML to protect) and `crossOriginResourcePolicy` is set to `cross-origin` so the separately-hosted SPA (stadium.joinwebzero.com / *.vercel.app) can still read responses.
- **express-rate-limit (#127)** — app-wide **200/min/IP** default + a tight **10/min/IP** on `/api/admin/session` (unauthenticated and runs ~50–200ms of SIWS signature verification per call).
- **`trust proxy = 1`** so client IPs are correct behind Railway's TLS-terminating proxy (and to satisfy express-rate-limit's trust-proxy validation).

## Files
- `server/server.js` — helmet + limiters + trust proxy
- `server/package.json` + `package-lock.json` — add `helmet`, `express-rate-limit`

## Test plan
- [x] `node --check server.js` — syntax OK.
- [x] `npm test` (server) — 257 passed (no test imports `server.js`, so behavior is unchanged for handlers).
- [x] Verified `helmet(...)` + `rateLimit(...)` construct + mount cleanly against the installed v8 packages (throwaway app).
- [ ] Post-deploy: confirm `/api/health` still 200 with new headers; hammer `/api/admin/session` >10/min from one IP → 429.

## Notes
- `npm audit` reports pre-existing tree vulnerabilities unrelated to these two well-maintained packages; not addressed here.
- No test imports `server.js` today (see #133 — a boot smoke test would cover middleware wiring; out of scope here).
- Per CLAUDE.md §6: draft, never merging.