### PR TITLE
feat(programs): non-member apply flow — emails the team (#140)

### DIFF
--- a/client/src/components/program/NonMemberApplyModal.tsx
+++ b/client/src/components/program/NonMemberApplyModal.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Loader2 } from "lucide-react";
+import { api, type ApiProgram } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+
+const PITCH_MAX = 1000;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function NonMemberApplyModal({
+  open,
+  onOpenChange,
+  program,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  program: ApiProgram;
+}) {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [wallet, setWallet] = useState("");
+  const [pitch, setPitch] = useState("");
+  const [company, setCompany] = useState(""); // honeypot
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (open) {
+      setName("");
+      setEmail("");
+      setWallet("");
+      setPitch("");
+      setCompany("");
+      setError(null);
+    }
+  }, [open]);
+
+  const validate = (): string | null => {
+    if (!name.trim()) return "Your name is required.";
+    if (!EMAIL_RE.test(email.trim())) return "A valid email is required.";
+    if (!pitch.trim()) return "Tell us briefly what you're building.";
+    if (pitch.trim().length > PITCH_MAX) return `Pitch must be ${PITCH_MAX} characters or fewer.`;
+    return null;
+  };
+
+  const handleSubmit = async () => {
+    const err = validate();
+    if (err) {
+      setError(err);
+      return;
+    }
+    setError(null);
+    setSubmitting(true);
+    try {
+      await api.submitNonMemberApplication(program.slug, {
+        name: name.trim(),
+        email: email.trim(),
+        walletAddress: wallet.trim() || undefined,
+        pitch: pitch.trim(),
+        company,
+      });
+      toast({ title: "Application sent", description: "We'll be in touch by email." });
+      onOpenChange(false);
+    } catch (e) {
+      toast({
+        title: "Couldn't send application",
+        description: (e as Error)?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => (submitting ? null : onOpenChange(v))}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="font-display tracking-tight">
+            APPLY TO {program.name.toUpperCase()}
+          </DialogTitle>
+          <DialogDescription className="text-body">
+            Don't have a Stadium project yet? Send your details and we'll get you set up.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="nm-name" className="label-hw-dim">NAME</Label>
+            <Input id="nm-name" value={name} onChange={(e) => setName(e.target.value)} className="font-mono text-sm" />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="nm-email" className="label-hw-dim">EMAIL</Label>
+            <Input id="nm-email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} className="font-mono text-sm" />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="nm-wallet" className="label-hw-dim">WALLET (OPTIONAL)</Label>
+            <Input id="nm-wallet" value={wallet} onChange={(e) => setWallet(e.target.value)} className="font-mono text-sm" />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="nm-pitch" className="label-hw-dim">WHAT ARE YOU BUILDING?</Label>
+            <Textarea
+              id="nm-pitch"
+              rows={5}
+              value={pitch}
+              onChange={(e) => setPitch(e.target.value)}
+              placeholder="A few sentences on your project and why you'd like to join."
+              className="font-mono text-sm"
+            />
+            <div className="flex items-center justify-between">
+              <span className="label-hw text-destructive">{error ? `·${error.toUpperCase()}` : ""}</span>
+              <span className={pitch.trim().length > PITCH_MAX ? "label-hw text-destructive" : "label-hw-dim"}>
+                {pitch.trim().length} / {PITCH_MAX}
+              </span>
+            </div>
+          </div>
+          {/* Honeypot — hidden from users; bots fill it and get silently dropped. */}
+          <input
+            type="text"
+            tabIndex={-1}
+            autoComplete="off"
+            aria-hidden="true"
+            value={company}
+            onChange={(e) => setCompany(e.target.value)}
+            className="hidden"
+          />
+        </div>
+        <DialogFooter>
+          <button
+            type="button"
+            onClick={() => (submitting ? null : onOpenChange(false))}
+            disabled={submitting}
+            className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep disabled:opacity-50 px-3 py-1.5"
+          >
+            CANCEL
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={submitting}
+            className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-4 py-1.5 inline-flex items-center gap-1.5"
+          >
+            {submitting ? (
+              <>
+                <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" /> SENDING…
+              </>
+            ) : (
+              "SEND APPLICATION ▸"
+            )}
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1522,6 +1522,24 @@ export const api = {
   },
 
   /**
+   * Public: someone without a Stadium project applies to a program. Emails the
+   * team (info@ + cc sacha@); no auth. `company` is a honeypot — leave empty.
+   */
+  submitNonMemberApplication: async (
+    slug: string,
+    payload: { name: string; email: string; walletAddress?: string; pitch: string; company?: string },
+  ): Promise<{ status: string }> => {
+    if (USE_MOCK_DATA) {
+      return { status: "success" };
+    }
+    return request(`/programs/${encodeURIComponent(slug)}/applications/non-member`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+  },
+
+  /**
    * Per-event admins (Phase 3 #95). Read is gated on requireProgramAdmin
    * (global admins and per-program admins can list). Add/remove are gated
    * on requireAdmin (global admins only).

--- a/client/src/pages/ProgramDetailPage.tsx
+++ b/client/src/pages/ProgramDetailPage.tsx
@@ -18,6 +18,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useWalletAuth } from "@/lib/auth/useWalletAuth";
 import { isAdmin } from "@/lib/constants";
 import { ApplyToProgramModal } from "@/components/program/ApplyToProgramModal";
+import { NonMemberApplyModal } from "@/components/program/NonMemberApplyModal";
 
 const formatDateRange = (from?: string | null, to?: string | null) => {
   if (!from && !to) return null;
@@ -50,6 +51,7 @@ const ProgramDetailPage = () => {
   const [projects, setProjects] = useState<ApiProgramProject[]>([]);
   const [entries, setEntries] = useState<ApiProject[]>([]);
   const [modalOpen, setModalOpen] = useState(false);
+  const [nonMemberOpen, setNonMemberOpen] = useState(false);
   const navigate = useNavigate();
 
   // Admins can apply on behalf of any project (server-side `requireTeamMemberOrAdminByBodyProject`
@@ -537,6 +539,17 @@ const ProgramDetailPage = () => {
                   </p>
                 )}
               </div>
+              {program.status === "open" && (
+                <div className="mt-3 pt-3 border-t border-hairline-subtle">
+                  <button
+                    type="button"
+                    onClick={() => setNonMemberOpen(true)}
+                    className="font-mono text-[11px] tracking-[0.08em] text-display hover:underline"
+                  >
+                    Don't have a Stadium project yet? Apply here ▸
+                  </button>
+                </div>
+              )}
             </div>
 
             {connectedAddress && projectsForApply.length > 0 && (
@@ -549,6 +562,12 @@ const ProgramDetailPage = () => {
                 onApplied={handleApplied}
               />
             )}
+
+            <NonMemberApplyModal
+              open={nonMemberOpen}
+              onOpenChange={setNonMemberOpen}
+              program={program}
+            />
           </article>
         ) : null}
       </main>

--- a/server/api/controllers/program.controller.js
+++ b/server/api/controllers/program.controller.js
@@ -6,6 +6,7 @@ import programInboxService, { inboxToCsv } from '../services/program-inbox.servi
 import auditLog from '../services/program-audit-log.service.js';
 import projectService from '../services/project.service.js';
 import notificationService from '../services/notification.service.js';
+import nonMemberApplicationService, { validateNonMemberApplication } from '../services/non-member-application.service.js';
 import programAdminRepository from '../repositories/program-admin.repository.js';
 import programSignupRepository from '../repositories/program-signup.repository.js';
 import { validateApplicationFields } from '../utils/application-fields.validator.js';
@@ -531,6 +532,41 @@ class ProgramController {
     } catch (error) {
       console.error('❌ Error listing program projects:', error);
       res.status(500).json({ status: 'error', message: 'Failed to list program projects' });
+    }
+  }
+
+  // --- Non-member applications (public; emails the team) ---
+
+  async submitNonMemberApplication(req, res) {
+    try {
+      const { slug } = req.params;
+      // Honeypot: bots fill hidden fields. Silently accept without sending.
+      if (typeof req.body?.company === 'string' && req.body.company.trim() !== '') {
+        return res.status(200).json({ status: 'success' });
+      }
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const v = validateNonMemberApplication(req.body);
+      if (!v.ok) {
+        return res.status(400).json({ status: 'error', message: v.error });
+      }
+      const result = await nonMemberApplicationService.submit({
+        programName: program.name,
+        programSlug: program.slug,
+        ...v.value,
+      });
+      if (!result.ok) {
+        return res.status(503).json({
+          status: 'error',
+          message: 'Could not send your application right now. Please email info@joinwebzero.com directly.',
+        });
+      }
+      return res.status(200).json({ status: 'success' });
+    } catch (error) {
+      console.error('❌ Error submitting non-member application:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to submit application' });
     }
   }
 

--- a/server/api/routes/program.routes.js
+++ b/server/api/routes/program.routes.js
@@ -36,6 +36,8 @@ router.post(
   requireTeamMemberOrAdminByBodyProject,
   programController.createApplication,
 );
+// Public: someone without a Stadium project applies; emails the team (no auth).
+router.post('/:slug/applications/non-member', programController.submitNonMemberApplication);
 router.patch(
   '/:slug/applications/:applicationId',
   requireProgramAdmin('slug'),

--- a/server/api/services/__tests__/non-member-application.service.test.js
+++ b/server/api/services/__tests__/non-member-application.service.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import service, { validateNonMemberApplication } from '../non-member-application.service.js';
+import { mockResend } from './mock-resend.js';
+
+describe('validateNonMemberApplication', () => {
+  it('accepts a valid payload and trims fields', () => {
+    const r = validateNonMemberApplication({ name: '  Ada  ', email: ' ada@x.com ', pitch: '  built X ' });
+    expect(r.ok).toBe(true);
+    expect(r.value).toEqual({ name: 'Ada', email: 'ada@x.com', pitch: 'built X', walletAddress: '' });
+  });
+
+  it('rejects a missing name', () => {
+    expect(validateNonMemberApplication({ email: 'a@b.co', pitch: 'x' })).toMatchObject({ ok: false });
+  });
+
+  it('rejects an invalid email', () => {
+    expect(validateNonMemberApplication({ name: 'A', email: 'not-an-email', pitch: 'x' })).toMatchObject({ ok: false });
+  });
+
+  it('rejects a missing pitch', () => {
+    expect(validateNonMemberApplication({ name: 'A', email: 'a@b.co' })).toMatchObject({ ok: false });
+  });
+
+  it('rejects an over-long pitch', () => {
+    const r = validateNonMemberApplication({ name: 'A', email: 'a@b.co', pitch: 'x'.repeat(1001) });
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe('NonMemberApplicationService.submit', () => {
+  beforeEach(() => mockResend.send.mockClear());
+
+  it('sends ONE email to info@ with sacha@ cc and applicant details in the body', async () => {
+    const r = await service.submit({
+      programName: 'PitchOff! Denver 2026',
+      programSlug: 'pitchoff-2026-denver',
+      name: 'Ada Lovelace',
+      email: 'ada@example.com',
+      pitch: 'I built a zk thing',
+      walletAddress: '',
+    });
+    expect(r.ok).toBe(true);
+    expect(mockResend.send).toHaveBeenCalledTimes(1);
+    const arg = mockResend.send.mock.calls[0][0];
+    expect(arg.to).toBe('info@joinwebzero.com');
+    expect(arg.cc).toEqual(['sacha@joinwebzero.com']);
+    expect(arg.subject).toContain('PitchOff! Denver 2026');
+    expect(arg.text).toContain('ada@example.com');
+    expect(arg.text).toContain('I built a zk thing');
+  });
+
+  it('escapes HTML in the applicant fields (no email HTML injection)', async () => {
+    await service.submit({
+      programName: 'P',
+      programSlug: 'p',
+      name: '<script>x</script>',
+      email: 'a@b.co',
+      pitch: 'hi <b>there</b>',
+    });
+    const arg = mockResend.send.mock.calls[0][0];
+    expect(arg.html).not.toContain('<script>');
+    expect(arg.html).toContain('&lt;script&gt;');
+  });
+});

--- a/server/api/services/email-transport.js
+++ b/server/api/services/email-transport.js
@@ -15,8 +15,8 @@ export async function getEmailTransport() {
   const resend = new Resend(process.env.RESEND_API_KEY);
 
   return {
-    async send({ from, to, subject, html, text }) {
-      const { data, error } = await resend.emails.send({ from, to, subject, html, text });
+    async send({ from, to, cc, subject, html, text }) {
+      const { data, error } = await resend.emails.send({ from, to, cc, subject, html, text });
       if (error) throw new Error(error.message ?? String(error));
       return { id: data.id };
     },

--- a/server/api/services/non-member-application.service.js
+++ b/server/api/services/non-member-application.service.js
@@ -1,0 +1,74 @@
+import { getEmailTransport } from './email-transport.js';
+
+// Where applications land. Fixed recipients — the applicant's address only ever
+// appears in the body, never as a recipient, so this endpoint can't be abused
+// as an open relay to email arbitrary addresses.
+const TEAM_TO = 'info@joinwebzero.com';
+const TEAM_CC = 'sacha@joinwebzero.com';
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PITCH_MAX = 1000;
+
+/**
+ * Validate a non-member application payload. Returns
+ * { ok: true, value } or { ok: false, error }.
+ */
+export function validateNonMemberApplication(body = {}) {
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  const email = typeof body.email === 'string' ? body.email.trim() : '';
+  const pitch = typeof body.pitch === 'string' ? body.pitch.trim() : '';
+  const walletAddress = typeof body.walletAddress === 'string' ? body.walletAddress.trim() : '';
+
+  if (!name) return { ok: false, error: 'Name is required' };
+  if (!email || !EMAIL_RE.test(email)) return { ok: false, error: 'A valid email is required' };
+  if (!pitch) return { ok: false, error: 'A short pitch is required' };
+  if (pitch.length > PITCH_MAX) return { ok: false, error: `Pitch must be ${PITCH_MAX} characters or fewer` };
+
+  return { ok: true, value: { name, email, pitch, walletAddress } };
+}
+
+const escapeHtml = (s) =>
+  String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+
+class NonMemberApplicationService {
+  /**
+   * Email the team a non-member's application. Single email with fixed
+   * recipients (info@ + cc sacha@); applicant details live in the body. The
+   * team approves manually and replies. Returns { ok } or { ok:false, reason }.
+   */
+  async submit({ programName, programSlug, name, email, pitch, walletAddress }) {
+    const transport = await getEmailTransport();
+    if (!transport) return { ok: false, reason: 'provider_not_configured' };
+
+    const subject = `New applicant for ${programName}: ${name}`;
+    const text = [
+      `Program: ${programName} (${programSlug})`,
+      `Name: ${name}`,
+      `Email: ${email}`,
+      walletAddress ? `Wallet: ${walletAddress}` : null,
+      '',
+      'Pitch:',
+      pitch,
+    ]
+      .filter((l) => l !== null)
+      .join('\n');
+    const html = `<h2>New applicant for ${escapeHtml(programName)}</h2>
+<p><strong>Name:</strong> ${escapeHtml(name)}<br/>
+<strong>Email:</strong> ${escapeHtml(email)}${walletAddress ? `<br/><strong>Wallet:</strong> ${escapeHtml(walletAddress)}` : ''}<br/>
+<strong>Program:</strong> ${escapeHtml(programName)} (${escapeHtml(programSlug)})</p>
+<p><strong>Pitch:</strong></p>
+<p>${escapeHtml(pitch).replace(/\n/g, '<br/>')}</p>`;
+
+    await transport.send({
+      from: process.env.RESEND_FROM_EMAIL,
+      to: TEAM_TO,
+      cc: [TEAM_CC],
+      subject,
+      html,
+      text,
+    });
+    return { ok: true };
+  }
+}
+
+export default new NonMemberApplicationService();


### PR DESCRIPTION
## Summary

Closes #140. Lets someone **without** a Stadium project apply to a program: a public form emails the team, who approve manually and reply — exactly the original ask.

## Design decision (flag if you disagree)
The original feedback was *"sends an email to info@joinwebzero.com with sacha@ cc'd with the person's request… then I add them in and they get a mail back saying they're approved."* So the auto email goes **only to the team** (fixed recipients); the "you're approved" reply is sent **manually** later. I deliberately **did not** auto-send a confirmation to the applicant's address — doing so would let anyone use our verified Resend domain to email arbitrary addresses (open-relay / phishing amplification). The applicant's details live in the email body, never as a recipient.

## Server
- `POST /api/programs/:slug/applications/non-member` — **public, no auth** (`program.routes.js`).
- `program.controller.submitNonMemberApplication` — honeypot check, resolve program, validate, send, return 200/400/404/503.
- `non-member-application.service.js` — validates `{name, email, walletAddress?, pitch}`; sends **one** email `to: info@joinwebzero.com`, `cc: [sacha@joinwebzero.com]` with an HTML-escaped body. Returns `503` (graceful "email us directly") if Resend isn't configured.
- `email-transport.js` — forward `cc` to Resend (backward-compatible).
- Abuse mitigation: fixed recipients + honeypot field + validation. IP rate-limiting comes from the app-wide limiter in #149 once both merge.

## Client
- `NonMemberApplyModal.tsx` — name / email / wallet (optional) / pitch (≤1000) + hidden honeypot.
- `ProgramDetailPage` — a "Don't have a Stadium project yet? Apply here ▸" CTA on **open** programs opens the modal.
- `api.submitNonMemberApplication(slug, payload)` (public; mock-mode returns success).

## Test plan
- [x] `npm test` (server) — **264 passed** (7 new: validation + email to/cc/body + HTML-escaping).
- [x] `npm run build` + `npm run lint` (client) — green.
- [x] `stadium-tester` @ localhost (mock) — **6/6 PASS** (CTA on open program; modal fields; empty-submit validation w/ no success; valid submit → success toast; completed program has no CTA).

## Prod requirement
Needs `RESEND_API_KEY` + `RESEND_FROM_EMAIL` (verified domain) on the Railway env. Without them the endpoint returns 503 with a "please email info@joinwebzero.com directly" message — no crash.

Per CLAUDE.md §6: draft, never merging.