### PR TITLE
feat(auth): social sign-in server core — Supabase + wallet account-linking (part 1)

### DIFF
--- a/server/api/auth/supabaseUser.js
+++ b/server/api/auth/supabaseUser.js
@@ -1,0 +1,29 @@
+import { supabase } from '../../db.js';
+
+/**
+ * Verify a Supabase Auth (GoTrue) access token and return the user, or null.
+ *
+ * Uses `supabase.auth.getUser(token)`, which validates the JWT against the
+ * project's GoTrue endpoint — no local JWT secret needed. The wallet remains
+ * the authorization principal; this only establishes WHO signed in socially.
+ *
+ * @param {string|null|undefined} token
+ * @returns {Promise<{ id: string, email: string|null } | null>}
+ */
+export async function getSupabaseUser(token) {
+  if (!token || typeof token !== 'string') return null;
+  try {
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data?.user) return null;
+    return { id: data.user.id, email: data.user.email ?? null };
+  } catch {
+    return null;
+  }
+}
+
+/** Extract a Supabase token from the `x-supabase-token` header (Bearer optional). */
+export function extractSupabaseToken(req) {
+  const h = req.headers?.['x-supabase-token'];
+  if (typeof h !== 'string') return null;
+  return h.replace(/^Bearer\s+/i, '').trim() || null;
+}

--- a/server/api/controllers/__tests__/auth.controller.test.js
+++ b/server/api/controllers/__tests__/auth.controller.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../auth/supabaseUser.js', () => ({
+  getSupabaseUser: vi.fn(),
+  extractSupabaseToken: vi.fn(() => 'supabase-token'),
+}));
+vi.mock('../../middleware/auth.middleware.js', () => ({
+  authenticateRequest: vi.fn(),
+}));
+vi.mock('../../auth/sessionToken.js', () => ({
+  issueSessionToken: vi.fn(() => ({ token: 'bearer.xyz', expiresAt: '2026-01-01T00:00:00.000Z' })),
+}));
+vi.mock('../../services/identity-link.service.js', () => ({
+  default: { getLinkedWallet: vi.fn(), linkWallet: vi.fn() },
+}));
+
+const { getSupabaseUser } = await import('../../auth/supabaseUser.js');
+const { authenticateRequest } = await import('../../middleware/auth.middleware.js');
+const identityLinkService = (await import('../../services/identity-link.service.js')).default;
+const authController = (await import('../auth.controller.js')).default;
+
+const mockRes = () => {
+  const res = {};
+  res.status = vi.fn(() => res);
+  res.json = vi.fn(() => res);
+  return res;
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('AuthController.linkWallet', () => {
+  it('401 when the social session is invalid', async () => {
+    getSupabaseUser.mockResolvedValue(null);
+    const res = mockRes();
+    await authController.linkWallet({ headers: {} }, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('401 when the wallet signature header is missing', async () => {
+    getSupabaseUser.mockResolvedValue({ id: 'u1', email: 'a@b.co' });
+    const res = mockRes();
+    await authController.linkWallet({ headers: {} }, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('propagates a SIWS verification failure', async () => {
+    getSupabaseUser.mockResolvedValue({ id: 'u1', email: 'a@b.co' });
+    authenticateRequest.mockResolvedValue({ ok: false, status: 403, body: { status: 'error', message: 'bad sig' } });
+    const res = mockRes();
+    await authController.linkWallet({ headers: { 'x-siws-auth': 'sig' } }, res);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(identityLinkService.linkWallet).not.toHaveBeenCalled();
+  });
+
+  it('links the wallet and returns a session bearer on success', async () => {
+    getSupabaseUser.mockResolvedValue({ id: 'u1', email: 'a@b.co' });
+    authenticateRequest.mockResolvedValue({ ok: true, chain: 'substrate', parsed: { address: '5Grw...' } });
+    identityLinkService.linkWallet.mockResolvedValue({});
+    const res = mockRes();
+    await authController.linkWallet({ headers: { 'x-siws-auth': 'sig' } }, res);
+    expect(identityLinkService.linkWallet).toHaveBeenCalledWith({
+      supabaseUserId: 'u1', email: 'a@b.co', walletChain: 'substrate', wallet: '5Grw...',
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    const body = res.json.mock.calls[0][0];
+    expect(body.data).toMatchObject({ token: 'bearer.xyz', address: '5Grw...', chain: 'substrate' });
+  });
+});
+
+describe('AuthController.sessionFromSocial', () => {
+  it('401 when the social session is invalid', async () => {
+    getSupabaseUser.mockResolvedValue(null);
+    const res = mockRes();
+    await authController.sessionFromSocial({ headers: {} }, res);
+    expect(res.status).toHaveBeenCalledWith(401);
+  });
+
+  it('409 needsLink when no wallet is linked', async () => {
+    getSupabaseUser.mockResolvedValue({ id: 'u1', email: 'a@b.co' });
+    identityLinkService.getLinkedWallet.mockResolvedValue(null);
+    const res = mockRes();
+    await authController.sessionFromSocial({ headers: {} }, res);
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json.mock.calls[0][0]).toMatchObject({ needsLink: true });
+  });
+
+  it('returns a wallet-scoped session bearer when linked', async () => {
+    getSupabaseUser.mockResolvedValue({ id: 'u1', email: 'a@b.co' });
+    identityLinkService.getLinkedWallet.mockResolvedValue({ wallet: '5Grw...', walletChain: 'substrate' });
+    const res = mockRes();
+    await authController.sessionFromSocial({ headers: {} }, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json.mock.calls[0][0].data).toMatchObject({ token: 'bearer.xyz', address: '5Grw...', chain: 'substrate' });
+  });
+});

--- a/server/api/controllers/auth.controller.js
+++ b/server/api/controllers/auth.controller.js
@@ -1,0 +1,78 @@
+import { getSupabaseUser, extractSupabaseToken } from '../auth/supabaseUser.js';
+import { authenticateRequest } from '../middleware/auth.middleware.js';
+import { issueSessionToken } from '../auth/sessionToken.js';
+import identityLinkService from '../services/identity-link.service.js';
+
+class AuthController {
+  /**
+   * POST /api/auth/link-wallet — link the signed-in Supabase user to a wallet.
+   * Requires BOTH a valid Supabase session (`x-supabase-token`) AND a fresh
+   * SIWS wallet signature (`x-siws-auth`), proving ownership of each. On
+   * success, returns the same HMAC session bearer the SIWS admin flow issues,
+   * scoped to the wallet — so every existing route middleware works unchanged.
+   */
+  async linkWallet(req, res) {
+    try {
+      const user = await getSupabaseUser(extractSupabaseToken(req));
+      if (!user) {
+        return res.status(401).json({ status: 'error', message: 'Invalid or missing social session' });
+      }
+      const siwsHeader = req.headers['x-siws-auth'];
+      if (!siwsHeader) {
+        return res.status(401).json({ status: 'error', message: 'Missing wallet signature (x-siws-auth)' });
+      }
+      const auth = await authenticateRequest(siwsHeader, { checkDomain: true });
+      if (!auth.ok) {
+        return res.status(auth.status).json(auth.body);
+      }
+      const walletChain = auth.chain;
+      const wallet = auth.parsed.address;
+      await identityLinkService.linkWallet({
+        supabaseUserId: user.id,
+        email: user.email,
+        walletChain,
+        wallet,
+      });
+      const { token, expiresAt } = issueSessionToken({ address: wallet, chain: walletChain });
+      return res.status(200).json({
+        status: 'success',
+        data: { token, address: wallet, chain: walletChain, expiresAt },
+      });
+    } catch (error) {
+      console.error('❌ Error linking wallet:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to link wallet' });
+    }
+  }
+
+  /**
+   * POST /api/auth/session-from-social — exchange a Supabase session for a
+   * wallet-scoped session bearer, if a wallet is already linked. Returns 409
+   * `{ needsLink: true }` when the user must link a wallet first.
+   */
+  async sessionFromSocial(req, res) {
+    try {
+      const user = await getSupabaseUser(extractSupabaseToken(req));
+      if (!user) {
+        return res.status(401).json({ status: 'error', message: 'Invalid or missing social session' });
+      }
+      const link = await identityLinkService.getLinkedWallet(user.id);
+      if (!link) {
+        return res.status(409).json({
+          status: 'error',
+          needsLink: true,
+          message: 'No wallet linked to this account yet',
+        });
+      }
+      const { token, expiresAt } = issueSessionToken({ address: link.wallet, chain: link.walletChain });
+      return res.status(200).json({
+        status: 'success',
+        data: { token, address: link.wallet, chain: link.walletChain, expiresAt },
+      });
+    } catch (error) {
+      console.error('❌ Error creating session from social:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to create session' });
+    }
+  }
+}
+
+export default new AuthController();

--- a/server/api/repositories/identity-link.repository.js
+++ b/server/api/repositories/identity-link.repository.js
@@ -1,0 +1,44 @@
+import { supabase } from '../../db.js';
+
+const transform = (row) =>
+  row
+    ? {
+        supabaseUserId: row.supabase_user_id,
+        email: row.email,
+        walletChain: row.wallet_chain || 'substrate',
+        wallet: row.wallet,
+      }
+    : null;
+
+class IdentityLinkRepository {
+  async findBySupabaseUser(supabaseUserId) {
+    const { data, error } = await supabase
+      .from('auth_identity_links')
+      .select('*')
+      .eq('supabase_user_id', supabaseUserId)
+      .maybeSingle();
+    if (error) throw error;
+    return transform(data);
+  }
+
+  async upsert({ supabaseUserId, email, walletChain, wallet }) {
+    const { data, error } = await supabase
+      .from('auth_identity_links')
+      .upsert(
+        {
+          supabase_user_id: supabaseUserId,
+          email: email ?? null,
+          wallet_chain: walletChain,
+          wallet,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'supabase_user_id' },
+      )
+      .select('*')
+      .single();
+    if (error) throw error;
+    return transform(data);
+  }
+}
+
+export default new IdentityLinkRepository();

--- a/server/api/routes/auth.routes.js
+++ b/server/api/routes/auth.routes.js
@@ -1,0 +1,11 @@
+import { Router } from 'express';
+import authController from '../controllers/auth.controller.js';
+
+const router = Router();
+
+// Social sign-in (Supabase Auth) → wallet account-linking + session exchange.
+// Public: each enforces its own proof (Supabase token, and SIWS for linking).
+router.post('/link-wallet', authController.linkWallet);
+router.post('/session-from-social', authController.sessionFromSocial);
+
+export default router;

--- a/server/api/services/identity-link.service.js
+++ b/server/api/services/identity-link.service.js
@@ -1,0 +1,27 @@
+import identityLinkRepository from '../repositories/identity-link.repository.js';
+import walletContactRepository from '../repositories/wallet-contact.repository.js';
+
+class IdentityLinkService {
+  async getLinkedWallet(supabaseUserId) {
+    return identityLinkRepository.findBySupabaseUser(supabaseUserId);
+  }
+
+  /**
+   * Link a Supabase user to a wallet (the authorization principal). Optionally
+   * mirrors the social email into wallet_contacts so the wallet has an email on
+   * file — best-effort, never blocks the link.
+   */
+  async linkWallet({ supabaseUserId, email, walletChain, wallet }) {
+    const row = await identityLinkRepository.upsert({ supabaseUserId, email, walletChain, wallet });
+    if (email) {
+      try {
+        await walletContactRepository.upsertByWallet(wallet, { email }, walletChain);
+      } catch {
+        // Optional email mirror — a failure here must not fail the link.
+      }
+    }
+    return row;
+  }
+}
+
+export default new IdentityLinkService();

--- a/server/server.js
+++ b/server/server.js
@@ -8,6 +8,7 @@ import programRoutes from './api/routes/program.routes.js';
 import walletContactRoutes from './api/routes/wallet-contact.routes.js';
 import adminSessionRoutes from './api/routes/admin-session.routes.js';
 import adminTiersRoutes from './api/routes/admin-tiers.routes.js';
+import authRoutes from './api/routes/auth.routes.js';
 import requestLogger from './api/middleware/logging.middleware.js';
 import { getAuthorizedAddresses, NETWORK_CONFIG } from './config/polkadot-config.js';
 
@@ -67,7 +68,7 @@ const allowOrigin = (origin, cb) => {
 app.use(cors({
     origin: allowOrigin,
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'x-siws-auth'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'x-siws-auth', 'x-supabase-token'],
     credentials: true,
     optionsSuccessStatus: 200
 }));
@@ -82,6 +83,7 @@ app.use('/api/programs', programRoutes);
 app.use('/api/wallet-contacts', walletContactRoutes);
 app.use('/api/admin/session', sessionLimiter, adminSessionRoutes);
 app.use('/api/admin', adminTiersRoutes);
+app.use('/api/auth', authRoutes);
 
 // Backward compatibility: Keep old /api/projects route as alias
 // TODO: Remove after frontend migration is stable

--- a/supabase/migrations/20260522000000_auth_identity_links.sql
+++ b/supabase/migrations/20260522000000_auth_identity_links.sql
@@ -1,0 +1,19 @@
+-- Social sign-in (Google / Apple / passkey via Supabase Auth) is added
+-- alongside wallet (SIWS) auth. Authorization stays wallet-based: a Supabase
+-- Auth user is LINKED to a wallet, and social sign-in then resolves to that
+-- wallet so the existing admin/team authorization works unchanged.
+--
+-- One link per Supabase user (PK). The wallet is looked up by (chain, address)
+-- when resolving a social session to its wallet principal.
+
+CREATE TABLE IF NOT EXISTS auth_identity_links (
+  supabase_user_id  UUID PRIMARY KEY,
+  email             TEXT,
+  wallet_chain      TEXT NOT NULL DEFAULT 'substrate',
+  wallet            TEXT NOT NULL,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_identity_links_wallet
+  ON auth_identity_links(wallet_chain, wallet);


### PR DESCRIPTION
## Summary

Server foundation for **Google / Apple / passkey sign-in** (via Supabase Auth) **alongside** the existing wallet (SIWS) auth. The wallet stays the **authorization principal** via account-linking, so the entire admin/builder authz layer is unchanged.

This is **part 1 (server)**. The client UI is the next slice on this branch (see "Next").

## How it works
- A Supabase Auth user is **linked to a wallet**. Social sign-in then resolves to that wallet and issues the existing HMAC session bearer — so `requireAdmin` / `requireProgramAdmin` / team checks all authorize **unchanged**.
- Supabase tokens are verified via `supabase.auth.getUser(token)` (no local JWT secret).

## Server changes
- **Migration** `auth_identity_links` (`supabase_user_id` ↔ wallet).
- `auth/supabaseUser.js` — verify a Supabase access token (`x-supabase-token` header).
- `identity-link` repository + service (best-effort mirror of email into `wallet_contacts`).
- `auth.controller` + `/api/auth` routes:
  - `POST /api/auth/link-wallet` — requires a valid Supabase session **and** a SIWS signature; records the link; returns a wallet-scoped session bearer.
  - `POST /api/auth/session-from-social` — Supabase session → linked wallet → session bearer (`409 needsLink` if not linked yet).
- CORS allows `x-supabase-token`.

## Test plan
- [x] `node --check server.js` — OK.
- [x] `npm test` (server) — **271 passed** (7 new auth-controller tests: invalid session, missing/failed SIWS, successful link, needs-link, session issue).

## ⚠️ Prerequisites (only you can do these — required before the client works)
1. **Supabase dashboard** → Authentication → Providers: enable **Google** + **Apple**; enable **Passkeys/WebAuthn**. Set redirect URLs (stadium.joinwebzero.com, Vercel previews, localhost).
2. **Google Cloud**: OAuth 2.0 client (web) → client ID/secret into Supabase.
3. **Apple**: Sign in with Apple Service ID + key → into Supabase.
4. **Env**: client `VITE_SUPABASE_URL` + `VITE_SUPABASE_ANON_KEY` (Vercel). Server already has `SUPABASE_URL`.

## Next (client, this branch)
`@supabase/supabase-js` client + Google/Apple/passkey buttons + the OAuth-return → `session-from-social` → (first time) connect-wallet `link-wallet` flow, wired into the admin sign-in. Best built against the configured providers so it's testable end-to-end.

Per CLAUDE.md §6: draft, never merging.