### PR TITLE
feat(programs): templatable rich content sections per program

### DIFF
--- a/client/src/components/program/ProgramContent.tsx
+++ b/client/src/components/program/ProgramContent.tsx
@@ -1,0 +1,195 @@
+import type { ProgramContentSection } from "@/lib/api";
+import { LCDStat } from "@/components/lcd-stat";
+
+/**
+ * Renders a program's templatable `content` (ordered, typed sections) as
+ * on-brand hardware panels. Mirrors the panel/lcd styling used elsewhere on
+ * ProgramDetailPage so curated event content reads as part of the console.
+ */
+export function ProgramContent({
+  sections,
+}: {
+  sections?: ProgramContentSection[] | null;
+}) {
+  if (!sections || sections.length === 0) return null;
+
+  return (
+    <>
+      {sections.map((section, i) => (
+        <Section key={i} section={section} />
+      ))}
+    </>
+  );
+}
+
+const PanelHeading = ({ title }: { title?: string }) =>
+  title ? <div className="label-hw mb-3">·{title.toUpperCase()}</div> : null;
+
+function Section({ section }: { section: ProgramContentSection }) {
+  switch (section.type) {
+    case "text":
+      return (
+        <div className="panel p-4 mb-4">
+          <PanelHeading title={section.title} />
+          <p className="text-body text-base leading-relaxed whitespace-pre-line">
+            {section.body}
+          </p>
+        </div>
+      );
+
+    case "steps":
+      return (
+        <div className="panel p-4 mb-4">
+          <PanelHeading title={section.title} />
+          <ol className="space-y-2">
+            {section.items.map((item, i) => (
+              <li key={i} className="flex gap-3">
+                <span className="font-mono text-[11px] tracking-[0.12em] text-label-dim border border-hairline bg-panel-deep px-2 py-[1px] leading-none mt-[2px] shrink-0">
+                  {String(i + 1).padStart(2, "0")}
+                </span>
+                <span className="text-body text-base leading-relaxed">{item}</span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      );
+
+    case "schedule":
+      return (
+        <div className="panel p-4 mb-4">
+          <PanelHeading title={section.title} />
+          <div className="space-y-2">
+            {section.rows.map((row, i) => (
+              <div
+                key={i}
+                className="flex items-baseline justify-between gap-3 border-b border-hairline-subtle pb-2 last:border-b-0 last:pb-0"
+              >
+                <span className="font-mono text-[12px] text-display tabular-nums shrink-0">
+                  {row.time}
+                </span>
+                <span className="text-body text-sm text-right">{row.label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      );
+
+    case "lineup":
+      return (
+        <div className="panel p-4 mb-4">
+          <PanelHeading title={section.title} />
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {section.items.map((item, i) => (
+              <div key={i} className="lcd p-3 space-y-2">
+                <div className="font-display text-base tracking-tight text-display uppercase leading-tight">
+                  {item.name}
+                </div>
+                {item.blurb && (
+                  <p className="text-body text-sm leading-relaxed">{item.blurb}</p>
+                )}
+                {item.tryItems && item.tryItems.length > 0 && (
+                  <div className="pt-1">
+                    <div className="label-hw-dim mb-1">·WHAT YOU'LL TRY</div>
+                    <ol className="space-y-1">
+                      {item.tryItems.map((t, j) => (
+                        <li key={j} className="flex gap-2 text-body text-sm leading-snug">
+                          <span className="text-label-dim font-mono text-[11px] shrink-0">
+                            {j + 1}.
+                          </span>
+                          <span>{t}</span>
+                        </li>
+                      ))}
+                    </ol>
+                  </div>
+                )}
+                {item.links && item.links.length > 0 && (
+                  <div className="flex flex-wrap gap-3 pt-1">
+                    {item.links.map((l, j) => (
+                      <a
+                        key={j}
+                        href={l.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-mono text-[11px] tracking-[0.08em] text-display hover:underline break-all uppercase"
+                      >
+                        {l.label} ▸
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      );
+
+    case "stats":
+      return (
+        <div className="panel p-4 mb-4">
+          <PanelHeading title={section.title} />
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+            {section.items.map((stat, i) => (
+              <LCDStat key={i} value={stat.value} label={stat.label} size="sm" />
+            ))}
+          </div>
+        </div>
+      );
+
+    case "feedback":
+      return (
+        <div className="panel p-4 mb-4">
+          <PanelHeading title={section.title} />
+          <div className="space-y-2">
+            {section.items.map((item, i) => (
+              <figure key={i} className="lcd p-3 space-y-2">
+                <blockquote className="text-body text-sm leading-relaxed">
+                  "{item.quote}"
+                </blockquote>
+                {(item.product || item.rating || item.recommend !== undefined) && (
+                  <figcaption className="flex flex-wrap items-center gap-2">
+                    {item.product && (
+                      <span className="border border-hairline text-display bg-panel-deep px-2 py-[1px] font-mono text-[10px] tracking-[0.12em] uppercase">
+                        {item.product}
+                      </span>
+                    )}
+                    {item.rating && (
+                      <span className="border border-hairline text-label-mid px-2 py-[1px] font-mono text-[10px] tracking-[0.12em] uppercase">
+                        EASE {item.rating}
+                      </span>
+                    )}
+                    {item.recommend !== undefined && (
+                      <span className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.12em] text-label-dim uppercase">
+                        <span
+                          className={`led led-sm ${item.recommend ? "" : "opacity-30"}`}
+                          aria-hidden="true"
+                        />
+                        {item.recommend ? "WOULD RECOMMEND" : "WOULD NOT"}
+                      </span>
+                    )}
+                  </figcaption>
+                )}
+              </figure>
+            ))}
+          </div>
+        </div>
+      );
+
+    case "cta":
+      return (
+        <div className="panel p-4 mb-4">
+          <PanelHeading title={section.title} />
+          <a
+            href={section.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim px-4 py-2 uppercase"
+          >
+            {section.label} ▸
+          </a>
+        </div>
+      );
+
+    default:
+      return null;
+  }
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -252,6 +252,41 @@ export type ApiAuditLogEntry = {
 };
 
 /** Shape of a row in the `programs` table (Phase 1 revamp). */
+/** A single curated link on a lineup item (website, docs, more-info). */
+export type ProgramContentLink = { label: string; url: string };
+
+/** One product/project showcased in a `lineup` content section. */
+export type ProgramLineupItem = {
+  name: string;
+  blurb?: string;
+  tryItems?: string[];
+  links?: ProgramContentLink[];
+};
+
+/** One verbatim highlight in a `feedback` content section. */
+export type ProgramFeedbackItem = {
+  product?: string;
+  quote: string;
+  rating?: string;
+  recommend?: boolean;
+};
+
+/** One metric tile in a `stats` content section. */
+export type ProgramStat = { label: string; value: string };
+
+/**
+ * Ordered, typed section that renders as an on-brand panel on the program
+ * detail page. Stored as JSONB in `programs.content`; reusable per program.
+ */
+export type ProgramContentSection =
+  | { type: "text"; title?: string; body: string }
+  | { type: "steps"; title?: string; items: string[] }
+  | { type: "schedule"; title?: string; rows: { time: string; label: string }[] }
+  | { type: "lineup"; title?: string; items: ProgramLineupItem[] }
+  | { type: "stats"; title?: string; items: ProgramStat[] }
+  | { type: "feedback"; title?: string; items: ProgramFeedbackItem[] }
+  | { type: "cta"; title?: string; label: string; url: string };
+
 export type ApiProgram = {
   id: string;
   name: string;
@@ -267,6 +302,7 @@ export type ApiProgram = {
   location?: string | null;
   maxApplicants?: number | null;
   eventUrl?: string | null;
+  content?: ProgramContentSection[] | null;
   createdAt?: string;
   updatedAt?: string;
 };

--- a/client/src/lib/mockPrograms.ts
+++ b/client/src/lib/mockPrograms.ts
@@ -132,6 +132,175 @@ export const mockPrograms: ApiProgram[] = [
     location: "Denver",
     maxApplicants: null,
     eventUrl: "https://luma.com/dogfooding",
+    content: [
+      {
+        type: "text",
+        title: "Why you're here",
+        body:
+          "The products you're about to try are early. Really early. They're being built right now by teams coming out of WebZero hackathons — and they need people like you to use them, break them, and tell them what's working, what's not, what you like and what could be improved.\n\nThis isn't a demo. You're not here to watch. You're here to get your hands on things before anyone else and have a real say in what gets built next.\n\nPlay a role in helping our builders validate what they're creating. Your feedback goes directly to them.",
+      },
+      {
+        type: "text",
+        title: "What makes this different",
+        body:
+          "Most web3 events are panels and pitches. You sit, you listen, you leave.\n\nToday you'll actually use products. You'll get stuck, figure things out, maybe get frustrated, hopefully get surprised. That's the point. Real usage, real feedback, real impact — and getting to be among the first to try cutting-edge web3 products.",
+      },
+      {
+        type: "steps",
+        title: "What you need to do",
+        items: [
+          "Pick a product",
+          "Use it for ~30 minutes (follow the guided tasks)",
+          "Fill out the feedback form for that product",
+          "Repeat with another product if you want",
+        ],
+      },
+      {
+        type: "text",
+        title: "The debrief",
+        body:
+          "At the end, we'll come together and share what stood out — what surprised you, what worked, what didn't. The builders aren't all here in person, but we're keeping track of your feedback and sending it straight to them. At the end we'll also draw the lucky raffle winner.",
+      },
+      {
+        type: "cta",
+        title: "Feedback form",
+        label: "Open the feedback form",
+        url: "https://vuqtecqlwni.typeform.com/to/SRtkKFuI",
+      },
+      {
+        type: "schedule",
+        title: "Schedule",
+        rows: [
+          { time: "1:00 PM", label: "Doors open" },
+          { time: "1:15 PM", label: "Product previews" },
+          { time: "1:25 PM", label: "Hands-on time" },
+          { time: "3:15 PM", label: "Group debrief" },
+          { time: "3:40 PM", label: "Raffle & wrap-up" },
+        ],
+      },
+      {
+        type: "lineup",
+        title: "The products",
+        items: [
+          {
+            name: "Open Arkiv",
+            blurb:
+              "A censorship-resistant, offline-first data submission protocol for journalists, whistleblowers, and citizens in high-risk environments.",
+            tryItems: ["Download the TestFlight app", "Start sending messages"],
+            links: [
+              { label: "Website", url: "https://openarkiv.vercel.app/" },
+              {
+                label: "More info",
+                url: "https://stadium.joinwebzero.com/m2-program/openarkiv-8bc72d",
+              },
+            ],
+          },
+          {
+            name: "Khoj",
+            blurb: "A treasure hunt app that turns Web3 onboarding into an adventure.",
+            tryItems: [
+              "Create or join a team to start the treasure hunt",
+              "Complete the treasure hunt",
+            ],
+            links: [
+              { label: "Play", url: "https://playkhoj.com/" },
+              { label: "Docs", url: "https://docs.playkhoj.com/" },
+            ],
+          },
+          {
+            name: "Kinectica",
+            blurb: "Access to eSIM data plans using any stablecoin.",
+            tryItems: [
+              "Go to the dashboard and connect your wallet",
+              "Mint an account",
+              "Mint an NFT",
+              "Load the account into the NFT",
+              "Load the QR code into your phone as an eSIM",
+            ],
+            links: [{ label: "Dashboard", url: "https://dash.kinecta.app/" }],
+          },
+          {
+            name: "Station",
+            blurb: "Music streaming for the decentralized curious.",
+            tryItems: [
+              "Set up your own cloud server (Hetzner credits provided — no out-of-pocket cost)",
+              "Host your own music",
+              "Play it back via the web app",
+            ],
+            links: [
+              { label: "Docs", url: "https://docs.qnch.network/getting-started/quick-start" },
+              { label: "Listener app", url: "https://beta.qnch.network" },
+            ],
+          },
+        ],
+      },
+      {
+        type: "text",
+        title: "Giving good feedback",
+        body:
+          "Be honest. \"This confused me\" is more useful than \"it was fine.\" The builders want to know: What was confusing? Where did you get stuck? What worked well? Would you use this again?",
+      },
+      {
+        type: "stats",
+        title: "Feedback snapshot",
+        items: [
+          { label: "Products tested", value: "4" },
+          { label: "Khoj ease (avg)", value: "5/7" },
+          { label: "Would recommend", value: "All yes" },
+        ],
+      },
+      {
+        type: "feedback",
+        title: "What attendees said",
+        items: [
+          {
+            product: "Station / Kinectica",
+            quote:
+              "It worked. Currently there are a lot of steps and it does require a wallet — which is fine, but will be a barrier for non-web3 users.",
+            recommend: true,
+          },
+          {
+            product: "Station / Kinectica",
+            quote:
+              "Pretty easy! But knowing you need to connect via the in-wallet browser would be a good tip in the documentation.",
+            recommend: true,
+          },
+          {
+            product: "Station / Kinectica",
+            quote:
+              "It was complicated and a teammate had to help me. Confusing at first having to be in MetaMask and explore for Kinectica.",
+            recommend: true,
+          },
+          {
+            product: "Khoj",
+            quote:
+              "If I wasn't already familiar with web3 wallets, getting testnet funds would have been challenging. Make it clearer that a team shares the same set of picture clues — we thought there were 6 per user. And there's no way to skip a clue if you're playing in a bigger space.",
+            rating: "5/7",
+            recommend: true,
+          },
+          {
+            product: "Khoj",
+            quote:
+              "I'd like to see in-app instructions — more one step at a time. It's hard to bounce back and forth to an instructions list. The steps themselves were easy.",
+            rating: "5/7",
+            recommend: true,
+          },
+          {
+            product: "Khoj",
+            quote:
+              "Confusing because you needed to refer to the docs — the in-game screens didn't have the necessary detail. Thankfully an organiser helped us.",
+            rating: "6/7",
+            recommend: true,
+          },
+        ],
+      },
+      {
+        type: "text",
+        title: "Raffle",
+        body:
+          "Every feedback survey you submit = one raffle entry. More surveys, more chances to win exclusive WebZero merch.",
+      },
+    ],
     createdAt: "2026-02-01T00:00:00Z",
     updatedAt: "2026-02-21T00:00:00Z",
   },

--- a/client/src/pages/ProgramDetailPage.tsx
+++ b/client/src/pages/ProgramDetailPage.tsx
@@ -19,6 +19,7 @@ import { useWalletAuth } from "@/lib/auth/useWalletAuth";
 import { isAdmin } from "@/lib/constants";
 import { ApplyToProgramModal } from "@/components/program/ApplyToProgramModal";
 import { NonMemberApplyModal } from "@/components/program/NonMemberApplyModal";
+import { ProgramContent } from "@/components/program/ProgramContent";
 
 const formatDateRange = (from?: string | null, to?: string | null) => {
   if (!from && !to) return null;
@@ -363,6 +364,8 @@ const ProgramDetailPage = () => {
                 </p>
               </div>
             )}
+
+            <ProgramContent sections={program.content} />
 
             {(applicationsRange || eventRange || program.eventUrl) && (
               <div className="panel p-4 mb-4">

--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -24,6 +24,12 @@ Do **not** manually edit `- **Promoted**` lines.
 
 <!-- entries start below this line -->
 
+## [2026-05-22] Admin editing for program `content` (templatable sections)
+- **Severity**: minor
+- **File(s)**: `client/src/components/admin/ProgramFormModal.tsx`; renderer `client/src/components/program/ProgramContent.tsx`; type `ApiProgram.content` in `client/src/lib/api.ts`
+- **Observed during**: adding templatable `programs.content` JSONB + section renderer (Dogfooding Denver rich content)
+- **Suggestion**: the `content` column + server validation (`validateProgramContent`) + renderer ship now, but admins can't author it in the UI — prod content is set by migration/seed and previews use the mock fixture. Add a per-section editor (or a validated raw-JSON textarea gated by `validateProgramContent`) to `ProgramFormModal` so events can be authored without a redeploy.
+
 ## [2026-04-23] `requireTeamMemberOrAdmin` missing SIWS domain check
 - **Severity**: minor
 - **File(s)**: `server/api/middleware/auth.middleware.js` (`requireTeamMemberOrAdmin`)

--- a/server/api/repositories/program.repository.js
+++ b/server/api/repositories/program.repository.js
@@ -18,6 +18,7 @@ const transformProgram = (row) => {
     location: row.location,
     maxApplicants: row.max_applicants,
     eventUrl: row.event_url ?? null,
+    content: row.content ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -39,6 +40,7 @@ const toSnakeCase = (data) => {
   if ('location' in data) row.location = data.location ?? null;
   if ('maxApplicants' in data) row.max_applicants = data.maxApplicants ?? null;
   if ('eventUrl' in data) row.event_url = data.eventUrl ?? null;
+  if ('content' in data) row.content = data.content ?? null;
   return row;
 };
 

--- a/server/api/utils/__tests__/validation.test.js
+++ b/server/api/utils/__tests__/validation.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import { validateProgram, validateProgramContent } from '../validation.js';
+
+describe('validateProgramContent', () => {
+  it('accepts null / undefined (clears content)', () => {
+    expect(validateProgramContent(null).valid).toBe(true);
+    expect(validateProgramContent(undefined).valid).toBe(true);
+  });
+
+  it('rejects a non-array', () => {
+    const r = validateProgramContent({ type: 'text', body: 'x' });
+    expect(r.valid).toBe(false);
+    expect(r.error).toMatch(/array or null/);
+  });
+
+  it('accepts an empty array', () => {
+    expect(validateProgramContent([]).valid).toBe(true);
+  });
+
+  it('rejects more than 40 sections', () => {
+    const many = Array.from({ length: 41 }, () => ({ type: 'text', body: 'x' }));
+    expect(validateProgramContent(many).valid).toBe(false);
+  });
+
+  it('rejects an unknown section type', () => {
+    const r = validateProgramContent([{ type: 'banner', body: 'x' }]);
+    expect(r.valid).toBe(false);
+    expect(r.error).toMatch(/content\[0\]\.type/);
+  });
+
+  it('accepts a full, well-formed content array', () => {
+    const content = [
+      { type: 'text', title: 'Why', body: 'Because.' },
+      { type: 'steps', title: 'Do', items: ['Pick a product', 'Use it'] },
+      { type: 'schedule', rows: [{ time: '1:00 PM', label: 'Doors open' }] },
+      {
+        type: 'lineup',
+        items: [
+          {
+            name: 'Open Arkiv',
+            blurb: 'Censorship-resistant data.',
+            tryItems: ['Download the app', 'Send a message'],
+            links: [{ label: 'Website', url: 'https://openarkiv.vercel.app/' }],
+          },
+        ],
+      },
+      { type: 'stats', items: [{ label: 'Products tested', value: '4' }] },
+      {
+        type: 'feedback',
+        items: [{ product: 'Khoj', quote: 'Steps were easy.', rating: '5/7', recommend: true }],
+      },
+      { type: 'cta', label: 'Feedback form', url: 'https://example.com/form' },
+    ];
+    expect(validateProgramContent(content).valid).toBe(true);
+  });
+
+  it('requires a body on text sections', () => {
+    expect(validateProgramContent([{ type: 'text' }]).valid).toBe(false);
+  });
+
+  it('requires http(s) urls on cta', () => {
+    const r = validateProgramContent([{ type: 'cta', label: 'x', url: 'ftp://nope' }]);
+    expect(r.valid).toBe(false);
+    expect(r.error).toMatch(/http\(s\) URL/);
+  });
+
+  it('requires http(s) urls on lineup links', () => {
+    const r = validateProgramContent([
+      { type: 'lineup', items: [{ name: 'X', links: [{ label: 'site', url: 'nope' }] }] },
+    ]);
+    expect(r.valid).toBe(false);
+  });
+
+  it('rejects a non-string step item', () => {
+    const r = validateProgramContent([{ type: 'steps', items: ['ok', 42] }]);
+    expect(r.valid).toBe(false);
+  });
+
+  it('rejects a non-boolean recommend on feedback', () => {
+    const r = validateProgramContent([
+      { type: 'feedback', items: [{ quote: 'hi', recommend: 'yes' }] },
+    ]);
+    expect(r.valid).toBe(false);
+  });
+});
+
+describe('validateProgram with content', () => {
+  const base = { name: 'Dogfooding', slug: 'dogfooding-x', programType: 'dogfooding', status: 'open' };
+
+  it('accepts a program carrying valid content', () => {
+    const r = validateProgram({ ...base, content: [{ type: 'text', body: 'hi' }] });
+    expect(r.valid).toBe(true);
+  });
+
+  it('rejects a program carrying invalid content', () => {
+    const r = validateProgram({ ...base, content: [{ type: 'text' }] });
+    expect(r.valid).toBe(false);
+  });
+
+  it('allows clearing content with null in a partial patch', () => {
+    const r = validateProgram({ content: null }, { partial: true });
+    expect(r.valid).toBe(true);
+  });
+});

--- a/server/api/utils/validation.js
+++ b/server/api/utils/validation.js
@@ -407,6 +407,113 @@ export const ALLOWED_PROGRAM_TYPES = ['dogfooding', 'pitch_off', 'hackathon', 'm
 export const ALLOWED_PROGRAM_STATUSES = ['draft', 'open', 'closed', 'completed'];
 const SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 
+// --- Program content (templatable, typed sections rendered as panels) ---
+
+export const ALLOWED_CONTENT_TYPES = [
+  'text', 'steps', 'schedule', 'lineup', 'stats', 'feedback', 'cta',
+];
+
+const isStr = (v, min, max) =>
+  typeof v === 'string' && v.length >= min && v.length <= max;
+const isOptStr = (v, max) =>
+  v === undefined || v === null || (typeof v === 'string' && v.length <= max);
+const isHttpUrl = (v, max) =>
+  typeof v === 'string' && v.length <= max && /^https?:\/\//i.test(v);
+const isArr = (v, max) => Array.isArray(v) && v.length <= max;
+
+const validateSection = (s, i) => {
+  const where = `content[${i}]`;
+  if (!s || typeof s !== 'object' || Array.isArray(s)) {
+    return `${where} must be an object`;
+  }
+  if (!ALLOWED_CONTENT_TYPES.includes(s.type)) {
+    return `${where}.type must be one of: ${ALLOWED_CONTENT_TYPES.join(', ')}`;
+  }
+  if (!isOptStr(s.title, 200)) return `${where}.title must be a string (max 200)`;
+
+  switch (s.type) {
+    case 'text':
+      if (!isStr(s.body, 1, 6000)) return `${where}.body is required (1–6000 chars)`;
+      return null;
+    case 'steps':
+      if (!isArr(s.items, 50)) return `${where}.items must be an array (max 50)`;
+      if (!s.items.every((it) => isStr(it, 1, 500))) {
+        return `${where}.items must be strings (1–500 chars)`;
+      }
+      return null;
+    case 'schedule':
+      if (!isArr(s.rows, 50)) return `${where}.rows must be an array (max 50)`;
+      for (const r of s.rows) {
+        if (!r || typeof r !== 'object') return `${where}.rows[] must be objects`;
+        if (!isStr(r.time, 1, 60)) return `${where}.rows[].time is required (1–60 chars)`;
+        if (!isStr(r.label, 1, 200)) return `${where}.rows[].label is required (1–200 chars)`;
+      }
+      return null;
+    case 'lineup':
+      if (!isArr(s.items, 50)) return `${where}.items must be an array (max 50)`;
+      for (const it of s.items) {
+        if (!it || typeof it !== 'object') return `${where}.items[] must be objects`;
+        if (!isStr(it.name, 1, 200)) return `${where}.items[].name is required (1–200 chars)`;
+        if (!isOptStr(it.blurb, 2000)) return `${where}.items[].blurb must be a string (max 2000)`;
+        if (it.tryItems !== undefined) {
+          if (!isArr(it.tryItems, 30) || !it.tryItems.every((t) => isStr(t, 1, 500))) {
+            return `${where}.items[].tryItems must be an array of strings (max 30, 1–500 chars)`;
+          }
+        }
+        if (it.links !== undefined) {
+          if (!isArr(it.links, 20)) return `${where}.items[].links must be an array (max 20)`;
+          for (const l of it.links) {
+            if (!l || typeof l !== 'object') return `${where}.items[].links[] must be objects`;
+            if (!isStr(l.label, 1, 120)) return `${where}.items[].links[].label is required (1–120 chars)`;
+            if (!isHttpUrl(l.url, 500)) return `${where}.items[].links[].url must be an http(s) URL (max 500)`;
+          }
+        }
+      }
+      return null;
+    case 'stats':
+      if (!isArr(s.items, 20)) return `${where}.items must be an array (max 20)`;
+      for (const it of s.items) {
+        if (!it || typeof it !== 'object') return `${where}.items[] must be objects`;
+        if (!isStr(it.label, 1, 120)) return `${where}.items[].label is required (1–120 chars)`;
+        if (!isStr(it.value, 1, 60)) return `${where}.items[].value is required (1–60 chars)`;
+      }
+      return null;
+    case 'feedback':
+      if (!isArr(s.items, 100)) return `${where}.items must be an array (max 100)`;
+      for (const it of s.items) {
+        if (!it || typeof it !== 'object') return `${where}.items[] must be objects`;
+        if (!isStr(it.quote, 1, 2000)) return `${where}.items[].quote is required (1–2000 chars)`;
+        if (!isOptStr(it.product, 120)) return `${where}.items[].product must be a string (max 120)`;
+        if (!isOptStr(it.rating, 20)) return `${where}.items[].rating must be a string (max 20)`;
+        if (it.recommend !== undefined && typeof it.recommend !== 'boolean') {
+          return `${where}.items[].recommend must be a boolean`;
+        }
+      }
+      return null;
+    case 'cta':
+      if (!isStr(s.label, 1, 200)) return `${where}.label is required (1–200 chars)`;
+      if (!isHttpUrl(s.url, 500)) return `${where}.url must be an http(s) URL (max 500)`;
+      return null;
+    default:
+      return `${where}.type is not supported`;
+  }
+};
+
+export const validateProgramContent = (content) => {
+  if (content === null || content === undefined) return { valid: true };
+  if (!Array.isArray(content)) {
+    return { valid: false, error: 'content must be an array or null' };
+  }
+  if (content.length > 40) {
+    return { valid: false, error: 'content may have at most 40 sections' };
+  }
+  for (let i = 0; i < content.length; i += 1) {
+    const err = validateSection(content[i], i);
+    if (err) return { valid: false, error: err };
+  }
+  return { valid: true };
+};
+
 export const validateProgram = (data, { partial = false } = {}) => {
   if (!data || typeof data !== 'object') {
     return { valid: false, error: 'Program payload must be an object' };
@@ -457,6 +564,10 @@ export const validateProgram = (data, { partial = false } = {}) => {
     if (!/^https?:\/\//i.test(data.eventUrl)) {
       return { valid: false, error: 'eventUrl must start with http:// or https://' };
     }
+  }
+  if (has('content')) {
+    const c = validateProgramContent(data.content);
+    if (!c.valid) return c;
   }
 
   const isoOrNull = (val) => {

--- a/supabase/migrations/20260522100000_program_content.sql
+++ b/supabase/migrations/20260522100000_program_content.sql
@@ -1,0 +1,17 @@
+-- Templatable rich program content.
+-- Adds a nullable `content` JSONB column to `programs` holding an ordered list
+-- of typed sections that render as on-brand panels on the program detail page.
+-- Each section is one of:
+--   { "type": "text",     "title"?, "body" }
+--   { "type": "steps",    "title"?, "items": [string] }
+--   { "type": "schedule", "title"?, "rows":  [{ "time", "label" }] }
+--   { "type": "lineup",   "title"?, "items": [{ "name", "blurb"?, "tryItems"?: [string], "links"?: [{ "label", "url" }] }] }
+--   { "type": "stats",    "title"?, "items": [{ "label", "value" }] }
+--   { "type": "feedback", "title"?, "items": [{ "product"?, "quote", "rating"?, "recommend"? }] }
+--   { "type": "cta",      "title"?, "label", "url" }
+--
+-- One column keeps every program templatable without a schema change per
+-- section type. Additive and idempotent — safe to re-run.
+
+ALTER TABLE programs
+  ADD COLUMN IF NOT EXISTS content JSONB;


### PR DESCRIPTION
## Summary
- Adds a nullable `content` JSONB column to `programs` holding an **ordered list of typed sections** — reusable for every program without a per-section schema change.
- Section types: `text`, `steps`, `schedule`, `lineup` (products with "what you'll try" + links), `stats` (LCD tiles), `feedback` (quote highlights), `cta`.
- New `ProgramContent` renderer draws each section as an on-brand hardware panel (reuses `LCDStat`), placed right after the description on the program detail page.
- **Dogfooding Denver** fixture populated as a worked template (future-tense, so it can be cloned for the next event), including the Typeform **feedback highlights** + a stats snapshot.

## Files
- `supabase/migrations/20260522100000_program_content.sql` — `content jsonb` (additive, idempotent)
- `server/api/repositories/program.repository.js` — maps `content` both ways
- `server/api/utils/validation.js` — `validateProgramContent()` (typed sections, size caps, http(s)-only URLs) wired into `validateProgram`
- `server/api/utils/__tests__/validation.test.js` — 14 new tests
- `client/src/lib/api.ts` — `ProgramContentSection` union + `ApiProgram.content`
- `client/src/components/program/ProgramContent.tsx` — renderer
- `client/src/pages/ProgramDetailPage.tsx` — renders content
- `client/src/lib/mockPrograms.ts` — Denver content
- `docs/improvement-backlog.md` — deferred admin editor logged

## How to test in staging
> [!IMPORTANT]
> **Vercel preview runs in mock mode** (`VITE_USE_MOCK_DATA=true`), so the Denver content renders straight from the fixture — use the preview URL for visual review.
> **Real-API staging (Railway)** needs the migration applied **and** the `content` column populated (no admin editor yet — seed/SQL). Until seeded, programs show no content panels (graceful, no error).

## Test scenarios (verified locally in mock mode)
- [x] On `/programs/dogfooding-2026-denver`, all sections render: why-you're-here, what's-different, what-to-do (numbered), debrief, **feedback-form CTA**, schedule (5 rows), **4-product lineup** with links, giving-good-feedback, **stats snapshot** (4 / 5/7 / All yes), **6 feedback quotes**, raffle.
- [x] On `/programs/dogfooding-2026-denver`, the feedback CTA points at the Typeform URL.
- [x] On `/programs/symbiosis-2025` (no content), **no** content panels render — no regression.
- [x] Server suite 285/285 pass; client build (typecheck) + lint clean.
- [ ] Reviewer: confirm on the Vercel preview URL.

## Notes
- Feedback quote helper names were anonymized for the public page ("Matthew"/"Sasha" → "a teammate"/"an organiser").
- Admin UI editing of `content` is deferred (backlog entry in this PR); content is currently authored via fixture (preview) or migration/seed (real API).