### PR TITLE
docs(env): correct stale Resend comment — email transport is live

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -34,7 +34,13 @@ ADMIN_SESSION_TTL_SECONDS=900
 NETWORK_ENV=testnet
 AUTHORIZED_SIGNERS=
 
-# Notification service (Resend) — required for P2-03 provider wiring; unused until then
+# Email (Resend). Powers ALL outbound email through one transport
+# (api/services/email-transport.js): project notifications (m2 approved /
+# changes requested, application accepted / rejected), and non-member program
+# applications (info@ + cc sacha@). If RESEND_API_KEY is unset, the transport
+# is null and every send is recorded as `provider_not_configured` — no email
+# goes out. RESEND_FROM_EMAIL must be an address on a domain you've VERIFIED in
+# Resend (e.g. notifications@joinwebzero.com), or sends are rejected.
 RESEND_API_KEY=
 RESEND_FROM_EMAIL=
 


### PR DESCRIPTION
## Summary
- `RESEND_API_KEY` / `RESEND_FROM_EMAIL` are no longer "unused" — they power **all** outbound email through one transport (`server/api/services/email-transport.js`).
- Corrects the stale `server/.env.example` comment so whoever configures the deploy knows: an unset key = no email sent (recorded as `provider_not_configured`), and `RESEND_FROM_EMAIL` must be on a **verified Resend domain**.

## What this is / isn't
- This is the **only code/repo change** needed for email to work — the feature is already fully wired.
- Turning email ON is a **dashboard/runbook step** (Resend domain verify + Railway env vars), documented below. No app code change required.

## What email this lights up (all share the one transport)
- Project notifications: `m2_approved`, `m2_changes_requested`, `application_accepted`, `application_rejected` (to team members with an email + notifications enabled)
- Non-member program applications → `info@joinwebzero.com` cc `sacha@joinwebzero.com`

## Runbook to enable on Railway staging/prod
1. In **Resend**: add + **verify** a sending domain (e.g. `joinwebzero.com`), then pick a from-address (e.g. `notifications@joinwebzero.com`).
2. Create a Resend **API key**.
3. On **Railway** (server service), set env vars: `RESEND_API_KEY=<key>` and `RESEND_FROM_EMAIL=notifications@joinwebzero.com`.
4. Redeploy. Trigger any of the 4 events (or a non-member apply) and confirm delivery.

## Test plan
- [ ] No app behavior changes from this PR (doc-only).
- [ ] After setting the env vars on staging, a non-member application delivers to info@ (cc sacha@).
- [ ] Accepting an application emails the project team members who have notifications on.