### PR TITLE
feat(brightness-rack): audio transport — prev/next + seek slider

### DIFF
--- a/client/src/components/audio/sound-cloud-audio.tsx
+++ b/client/src/components/audio/sound-cloud-audio.tsx
@@ -13,17 +13,25 @@ interface SCSound {
   user?: { username?: string | null; avatar_url?: string | null } | null;
 }
 
+interface SCProgress {
+  currentPosition?: number;
+}
+
 interface SCWidget {
-  bind(event: string, cb: () => void): void;
+  bind(event: string, cb: (data?: SCProgress) => void): void;
   play(): void;
   pause(): void;
+  next(): void;
+  prev(): void;
+  seekTo(milliseconds: number): void;
   setVolume(volume: number): void;
   getCurrentSound(cb: (sound: SCSound | null) => void): void;
+  getDuration(cb: (milliseconds: number) => void): void;
 }
 
 interface SCNamespace {
   Widget: ((iframe: HTMLIFrameElement) => SCWidget) & {
-    Events: { READY: string; PLAY: string };
+    Events: { READY: string; PLAY: string; PLAY_PROGRESS: string };
   };
 }
 
@@ -82,6 +90,12 @@ export function SoundCloudAudioProvider({ children }: { children: React.ReactNod
   const [title, setTitle] = useState("");
   const [genre, setGenre] = useState("");
   const [artworkUrl, setArtworkUrl] = useState("");
+  // Transport: current position + track length (ms) for the seek slider.
+  const [positionMs, setPositionMs] = useState(0);
+  const [durationMs, setDurationMs] = useState(0);
+  // Timestamp of the last user seek — suppresses PLAY_PROGRESS snap-back for a
+  // brief window so the thumb doesn't fight the user mid-drag.
+  const lastSeekRef = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -98,13 +112,27 @@ export function SoundCloudAudioProvider({ children }: { children: React.ReactNod
             const art = sound.artwork_url || sound.user?.avatar_url || "";
             setArtworkUrl(art ? upscaleArtwork(art) : "");
           });
+          widget.getDuration((ms) => {
+            if (!cancelled) setDurationMs(ms || 0);
+          });
         };
         widget.bind(window.SC.Widget.Events.READY, () => {
           widget.setVolume(0);
           widget.play();
           refreshTrack();
         });
-        widget.bind(window.SC.Widget.Events.PLAY, refreshTrack);
+        // New track: refresh metadata + duration and reset the position thumb.
+        widget.bind(window.SC.Widget.Events.PLAY, () => {
+          setPositionMs(0);
+          refreshTrack();
+        });
+        // Advance the seek thumb as the track plays (ignored briefly after a seek).
+        widget.bind(window.SC.Widget.Events.PLAY_PROGRESS, (data) => {
+          if (cancelled || Date.now() - lastSeekRef.current < 400) return;
+          if (data && typeof data.currentPosition === "number") {
+            setPositionMs(data.currentPosition);
+          }
+        });
       })
       .catch(() => {
         // Network-blocked or offline — leave audio inert; UI still works.
@@ -126,8 +154,26 @@ export function SoundCloudAudioProvider({ children }: { children: React.ReactNod
     });
   }, []);
 
+  const next = useCallback(() => {
+    widgetRef.current?.next();
+    setPositionMs(0);
+  }, []);
+
+  const prev = useCallback(() => {
+    widgetRef.current?.prev();
+    setPositionMs(0);
+  }, []);
+
+  const seek = useCallback((ms: number) => {
+    lastSeekRef.current = Date.now();
+    setPositionMs(ms);
+    widgetRef.current?.seekTo(ms);
+  }, []);
+
   return (
-    <SoundCloudAudioContext.Provider value={{ muted, toggle, title, genre, artworkUrl }}>
+    <SoundCloudAudioContext.Provider
+      value={{ muted, toggle, title, genre, artworkUrl, positionMs, durationMs, next, prev, seek }}
+    >
       {children}
       {/* Hidden, persistent across navigation: 1×1, transparent, no pointer events. */}
       <iframe

--- a/client/src/components/audio/sound-cloud-audio.tsx
+++ b/client/src/components/audio/sound-cloud-audio.tsx
@@ -21,8 +21,6 @@ interface SCWidget {
   bind(event: string, cb: (data?: SCProgress) => void): void;
   play(): void;
   pause(): void;
-  next(): void;
-  prev(): void;
   seekTo(milliseconds: number): void;
   setVolume(volume: number): void;
   getCurrentSound(cb: (sound: SCSound | null) => void): void;
@@ -154,16 +152,6 @@ export function SoundCloudAudioProvider({ children }: { children: React.ReactNod
     });
   }, []);
 
-  const next = useCallback(() => {
-    widgetRef.current?.next();
-    setPositionMs(0);
-  }, []);
-
-  const prev = useCallback(() => {
-    widgetRef.current?.prev();
-    setPositionMs(0);
-  }, []);
-
   const seek = useCallback((ms: number) => {
     lastSeekRef.current = Date.now();
     setPositionMs(ms);
@@ -172,7 +160,7 @@ export function SoundCloudAudioProvider({ children }: { children: React.ReactNod
 
   return (
     <SoundCloudAudioContext.Provider
-      value={{ muted, toggle, title, genre, artworkUrl, positionMs, durationMs, next, prev, seek }}
+      value={{ muted, toggle, title, genre, artworkUrl, positionMs, durationMs, seek }}
     >
       {children}
       {/* Hidden, persistent across navigation: 1×1, transparent, no pointer events. */}

--- a/client/src/components/audio/use-sound-cloud-audio.ts
+++ b/client/src/components/audio/use-sound-cloud-audio.ts
@@ -6,11 +6,9 @@ export type SoundCloudAudioValue = {
   title: string;
   genre: string;
   artworkUrl: string;
-  // Transport: current position + track length (ms) and playback controls.
+  // Transport: current position + track length (ms) and seek control.
   positionMs: number;
   durationMs: number;
-  next: () => void;
-  prev: () => void;
   seek: (ms: number) => void;
 };
 
@@ -22,8 +20,6 @@ export const SoundCloudAudioContext = createContext<SoundCloudAudioValue>({
   artworkUrl: "",
   positionMs: 0,
   durationMs: 0,
-  next: () => {},
-  prev: () => {},
   seek: () => {},
 });
 

--- a/client/src/components/audio/use-sound-cloud-audio.ts
+++ b/client/src/components/audio/use-sound-cloud-audio.ts
@@ -6,6 +6,12 @@ export type SoundCloudAudioValue = {
   title: string;
   genre: string;
   artworkUrl: string;
+  // Transport: current position + track length (ms) and playback controls.
+  positionMs: number;
+  durationMs: number;
+  next: () => void;
+  prev: () => void;
+  seek: (ms: number) => void;
 };
 
 export const SoundCloudAudioContext = createContext<SoundCloudAudioValue>({
@@ -14,6 +20,11 @@ export const SoundCloudAudioContext = createContext<SoundCloudAudioValue>({
   title: "",
   genre: "",
   artworkUrl: "",
+  positionMs: 0,
+  durationMs: 0,
+  next: () => {},
+  prev: () => {},
+  seek: () => {},
 });
 
 export function useSoundCloudAudio() {

--- a/client/src/components/brightness-rack.tsx
+++ b/client/src/components/brightness-rack.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ChevronDown, ChevronUp, Volume2, VolumeX } from "lucide-react";
+import { ChevronDown, ChevronUp, SkipBack, SkipForward, Volume2, VolumeX } from "lucide-react";
 import { useBrightness } from "@/hooks/use-brightness";
 import { HardwareToggle } from "@/components/hardware-toggle";
 import { solarBrightness } from "@/lib/solar";
@@ -16,18 +16,35 @@ interface SCSound {
   genre?: string | null;
 }
 
+interface SCProgress {
+  currentPosition?: number;
+}
+
 interface SCWidget {
-  bind(event: string, cb: () => void): void;
+  bind(event: string, cb: (data?: SCProgress) => void): void;
   play(): void;
   pause(): void;
+  next(): void;
+  prev(): void;
+  seekTo(milliseconds: number): void;
   setVolume(volume: number): void;
   getCurrentSound(cb: (sound: SCSound | null) => void): void;
+  getDuration(cb: (milliseconds: number) => void): void;
 }
 
 interface SCNamespace {
   Widget: ((iframe: HTMLIFrameElement) => SCWidget) & {
-    Events: { READY: string; PLAY: string };
+    Events: { READY: string; PLAY: string; PLAY_PROGRESS: string };
   };
+}
+
+// SoundCloud reports times in ms. Render as m:ss.
+function formatTime(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return "0:00";
+  const total = Math.floor(ms / 1000);
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
 }
 
 declare global {
@@ -117,6 +134,12 @@ export function BrightnessRack({ className }: BrightnessRackProps) {
   const [muted, setMuted] = useState(true);
   // Now-playing metadata pulled from the widget: current track title + genre.
   const [nowPlaying, setNowPlaying] = useState("");
+  // Transport state for the seek slider: current position + track length (ms).
+  const [positionMs, setPositionMs] = useState(0);
+  const [durationMs, setDurationMs] = useState(0);
+  // Timestamp of the last user seek — suppresses PLAY_PROGRESS snap-back for a
+  // brief window so the thumb doesn't fight the user mid-drag.
+  const lastSeekRef = useRef(0);
 
   useEffect(() => {
     let cancelled = false;
@@ -131,14 +154,27 @@ export function BrightnessRack({ className }: BrightnessRackProps) {
             const parts = [sound.title, sound.genre].filter(Boolean);
             setNowPlaying(parts.join(" · "));
           });
+          widget.getDuration((ms) => {
+            if (!cancelled) setDurationMs(ms || 0);
+          });
         };
         widget.bind(window.SC.Widget.Events.READY, () => {
           widget.setVolume(0);
           widget.play();
           refreshTrack();
         });
-        // Each time a new track starts, refresh the displayed title + genre.
-        widget.bind(window.SC.Widget.Events.PLAY, refreshTrack);
+        // Each time a new track starts, refresh title + genre + duration, reset position.
+        widget.bind(window.SC.Widget.Events.PLAY, () => {
+          setPositionMs(0);
+          refreshTrack();
+        });
+        // Advance the seek thumb as the track plays (ignored briefly after a seek).
+        widget.bind(window.SC.Widget.Events.PLAY_PROGRESS, (data) => {
+          if (cancelled || Date.now() - lastSeekRef.current < 400) return;
+          if (data && typeof data.currentPosition === "number") {
+            setPositionMs(data.currentPosition);
+          }
+        });
       })
       .catch(() => {
         // Network-blocked or offline — leave audio inert; UI still works.
@@ -146,6 +182,22 @@ export function BrightnessRack({ className }: BrightnessRackProps) {
     return () => {
       cancelled = true;
     };
+  }, []);
+
+  const playNext = useCallback(() => {
+    widgetRef.current?.next();
+    setPositionMs(0);
+  }, []);
+
+  const playPrev = useCallback(() => {
+    widgetRef.current?.prev();
+    setPositionMs(0);
+  }, []);
+
+  const handleSeek = useCallback((ms: number) => {
+    lastSeekRef.current = Date.now();
+    setPositionMs(ms);
+    widgetRef.current?.seekTo(ms);
   }, []);
 
   const toggleAudio = useCallback(() => {
@@ -363,61 +415,137 @@ export function BrightnessRack({ className }: BrightnessRackProps) {
           />
         </div>
 
-        {/* Audio — artist credit + external links + mute toggle */}
-        <div className="flex items-center gap-3 mt-2 pt-2 border-t border-hairline-subtle">
-          <span className="label-hw min-w-[78px]">AUDIO</span>
-          <span className="font-mono text-[11px] text-display tabular-nums shrink-0">
-            pommeshdrms
-          </span>
-          {nowPlaying && (
-            <span
-              className="label-hw-dim truncate min-w-0"
-              title={nowPlaying}
-            >
-              · {nowPlaying}
+        {/* Audio — curated music: artist credit, transport + seek, external links */}
+        <div className="mt-2 pt-2 border-t border-hairline-subtle space-y-2">
+          {/* Row 1 — artist credit + now playing + links + mute */}
+          <div className="flex items-center gap-3">
+            <span className="label-hw min-w-[78px]">AUDIO</span>
+            <span className="font-mono text-[11px] text-display tabular-nums shrink-0">
+              pommeshdrms
             </span>
-          )}
-          <span className="flex-1" />
-          <a
-            href="https://soundcloud.com/pommeshdrms"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="pommeshdrms on SoundCloud (opens in new tab)"
-            title="pommeshdrms on SoundCloud"
-            className="lcd px-2 py-1 label-hw-dim hover:text-display transition-colors duration-200"
-          >
-            SC
-          </a>
-          <a
-            href="https://www.instagram.com/pommes_hdrms"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="pommes_hdrms on Instagram (opens in new tab)"
-            title="pommes_hdrms on Instagram"
-            className="lcd px-2 py-1 label-hw-dim hover:text-display transition-colors duration-200"
-          >
-            IG
-          </a>
-          <button
-            type="button"
-            onClick={toggleAudio}
-            aria-label={muted ? "Unmute audio" : "Mute audio"}
-            aria-pressed={!muted}
-            title={muted ? "Unmute audio" : "Mute audio"}
-            className="lcd p-1 hover:bg-panel-deep transition-colors duration-150 group"
-          >
-            {muted ? (
-              <VolumeX
+            {nowPlaying && (
+              <span className="label-hw-dim truncate min-w-0" title={nowPlaying}>
+                · {nowPlaying}
+              </span>
+            )}
+            <span className="flex-1" />
+            <a
+              href="https://soundcloud.com/pommeshdrms"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="pommeshdrms on SoundCloud (opens in new tab)"
+              title="pommeshdrms on SoundCloud"
+              className="lcd px-2 py-1 label-hw-dim hover:text-display transition-colors duration-200"
+            >
+              SC
+            </a>
+            <a
+              href="https://www.instagram.com/pommes_hdrms"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="pommes_hdrms on Instagram (opens in new tab)"
+              title="pommes_hdrms on Instagram"
+              className="lcd px-2 py-1 label-hw-dim hover:text-display transition-colors duration-200"
+            >
+              IG
+            </a>
+            <button
+              type="button"
+              onClick={toggleAudio}
+              aria-label={muted ? "Unmute audio" : "Mute audio"}
+              aria-pressed={!muted}
+              title={muted ? "Unmute audio" : "Mute audio"}
+              className="lcd p-1 hover:bg-panel-deep transition-colors duration-150 group"
+            >
+              {muted ? (
+                <VolumeX
+                  className="h-3.5 w-3.5 text-label-mid group-hover:text-display transition-colors duration-150"
+                  aria-hidden="true"
+                />
+              ) : (
+                <Volume2
+                  className="h-3.5 w-3.5 text-display transition-colors duration-150"
+                  aria-hidden="true"
+                />
+              )}
+            </button>
+          </div>
+
+          {/* Row 2 — transport: previous · seek · next + elapsed/total */}
+          <div className="flex items-center gap-2">
+            <span className="min-w-[78px]" aria-hidden="true" />
+            <button
+              type="button"
+              onClick={playPrev}
+              aria-label="Previous track"
+              title="Previous track"
+              className="lcd p-1 hover:bg-panel-deep transition-colors duration-150 group shrink-0"
+            >
+              <SkipBack
                 className="h-3.5 w-3.5 text-label-mid group-hover:text-display transition-colors duration-150"
                 aria-hidden="true"
               />
-            ) : (
-              <Volume2
-                className="h-3.5 w-3.5 text-display transition-colors duration-150"
+            </button>
+
+            <div className="flex-1 relative h-[18px]">
+              {/* Track */}
+              <div className="absolute top-[8px] left-0 right-0 h-[2px] bg-panel-deep border border-hairline" />
+              {/* Elapsed fill */}
+              <div
+                className="absolute top-[8px] left-0 h-[2px] bg-display pointer-events-none"
+                style={{ width: `${durationMs > 0 ? (positionMs / durationMs) * 100 : 0}%` }}
                 aria-hidden="true"
               />
-            )}
-          </button>
+              <input
+                type="range"
+                min={0}
+                max={durationMs > 0 ? durationMs : 1}
+                step={1000}
+                value={positionMs}
+                disabled={durationMs <= 0}
+                aria-label="Seek track position"
+                onChange={(e) => handleSeek(parseInt(e.target.value, 10))}
+                className={cn(
+                  "absolute inset-0 w-full h-[18px] bg-transparent appearance-none cursor-ew-resize z-10",
+                  "disabled:cursor-not-allowed",
+                  "[&::-webkit-slider-thumb]:appearance-none",
+                  "[&::-webkit-slider-thumb]:w-[10px] [&::-webkit-slider-thumb]:h-[14px]",
+                  "[&::-webkit-slider-thumb]:bg-gradient-to-b [&::-webkit-slider-thumb]:from-[#DDDDDD] [&::-webkit-slider-thumb]:to-[#888888]",
+                  "[&::-webkit-slider-thumb]:border [&::-webkit-slider-thumb]:border-black",
+                  "[&::-webkit-slider-thumb]:cursor-ew-resize",
+                  "[&::-moz-range-thumb]:w-[10px] [&::-moz-range-thumb]:h-[14px]",
+                  "[&::-moz-range-thumb]:bg-[linear-gradient(180deg,#DDDDDD_0%,#888888_100%)]",
+                  "[&::-moz-range-thumb]:border [&::-moz-range-thumb]:border-black",
+                  "[&::-moz-range-thumb]:rounded-none [&::-moz-range-thumb]:cursor-ew-resize",
+                )}
+              />
+            </div>
+
+            <button
+              type="button"
+              onClick={playNext}
+              aria-label="Next track"
+              title="Next track"
+              className="lcd p-1 hover:bg-panel-deep transition-colors duration-150 group shrink-0"
+            >
+              <SkipForward
+                className="h-3.5 w-3.5 text-label-mid group-hover:text-display transition-colors duration-150"
+                aria-hidden="true"
+              />
+            </button>
+
+            <span className="label-hw-dim text-[9px] tabular-nums shrink-0 min-w-[66px] text-right">
+              {formatTime(positionMs)} / {formatTime(durationMs)}
+            </span>
+          </div>
+
+          {/* Row 3 — curation framing */}
+          <div className="flex items-center gap-3">
+            <span className="min-w-[78px]" aria-hidden="true" />
+            <span className="label-hw-dim text-[8px] tracking-[0.18em]">
+              FEATURING ARTISTS WE LOVE
+            </span>
+          </div>
         </div>
       </div>
     </>

--- a/client/src/components/brightness-rack.tsx
+++ b/client/src/components/brightness-rack.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ChevronDown, ChevronUp, SkipBack, SkipForward, Volume2, VolumeX } from "lucide-react";
+import { useEffect, useMemo, useRef } from "react";
+import { ChevronDown, ChevronUp, Music, SkipBack, SkipForward, Volume2, VolumeX } from "lucide-react";
 import { useBrightness } from "@/hooks/use-brightness";
 import { HardwareToggle } from "@/components/hardware-toggle";
 import { useSoundCloudAudio } from "@/components/audio/use-sound-cloud-audio";
@@ -10,35 +10,6 @@ interface BrightnessRackProps {
   className?: string;
 }
 
-// --- SoundCloud Widget API integration ---
-
-interface SCSound {
-  title?: string | null;
-  genre?: string | null;
-}
-
-interface SCProgress {
-  currentPosition?: number;
-}
-
-interface SCWidget {
-  bind(event: string, cb: (data?: SCProgress) => void): void;
-  play(): void;
-  pause(): void;
-  next(): void;
-  prev(): void;
-  seekTo(milliseconds: number): void;
-  setVolume(volume: number): void;
-  getCurrentSound(cb: (sound: SCSound | null) => void): void;
-  getDuration(cb: (milliseconds: number) => void): void;
-}
-
-interface SCNamespace {
-  Widget: ((iframe: HTMLIFrameElement) => SCWidget) & {
-    Events: { READY: string; PLAY: string; PLAY_PROGRESS: string };
-  };
-}
-
 // SoundCloud reports times in ms. Render as m:ss.
 function formatTime(ms: number): string {
   if (!Number.isFinite(ms) || ms <= 0) return "0:00";
@@ -46,45 +17,6 @@ function formatTime(ms: number): string {
   const m = Math.floor(total / 60);
   const s = total % 60;
   return `${m}:${String(s).padStart(2, "0")}`;
-}
-
-declare global {
-  interface Window {
-    SC?: SCNamespace;
-  }
-}
-
-const SC_WIDGET_SCRIPT = "https://w.soundcloud.com/player/api.js";
-const SC_PROFILE_URL = "https://soundcloud.com/pommeshdrms";
-const SC_IFRAME_SRC =
-  `https://w.soundcloud.com/player/?url=${encodeURIComponent(SC_PROFILE_URL)}` +
-  "&auto_play=false&hide_related=true&show_comments=false&show_user=false" +
-  "&show_reposts=false&show_teaser=false&visual=false&buying=false" +
-  "&sharing=false&download=false&show_artwork=false";
-
-let scScriptPromise: Promise<void> | null = null;
-function loadSoundCloudWidget(): Promise<void> {
-  if (typeof window === "undefined") return Promise.resolve();
-  if (window.SC) return Promise.resolve();
-  if (scScriptPromise) return scScriptPromise;
-  scScriptPromise = new Promise<void>((resolve, reject) => {
-    const existing = document.querySelector<HTMLScriptElement>(
-      `script[src="${SC_WIDGET_SCRIPT}"]`,
-    );
-    if (existing) {
-      if (window.SC) return resolve();
-      existing.addEventListener("load", () => resolve(), { once: true });
-      existing.addEventListener("error", () => reject(new Error("SC script failed")), { once: true });
-      return;
-    }
-    const script = document.createElement("script");
-    script.src = SC_WIDGET_SCRIPT;
-    script.async = true;
-    script.onload = () => resolve();
-    script.onerror = () => reject(new Error("SC script failed"));
-    document.head.appendChild(script);
-  });
-  return scScriptPromise;
 }
 
 // 4-hour clock ticks plotted at the brightness % the solar curve would produce
@@ -111,7 +43,8 @@ export function BrightnessRack({ className }: BrightnessRackProps) {
   } = useBrightness();
 
   // Audio state lives in a provider above the router (persists across nav).
-  const { muted, toggle, title, genre, artworkUrl } = useSoundCloudAudio();
+  const { muted, toggle, title, genre, artworkUrl, positionMs, durationMs, next, prev, seek } =
+    useSoundCloudAudio();
 
   // Once the user touches anything (slider, AUTO toggle, palette), collapse
   // automatically. After that, expand/collapse is entirely user-driven via the
@@ -131,90 +64,6 @@ export function BrightnessRack({ className }: BrightnessRackProps) {
       setCollapsed(true);
     }
   }, [brightness, mode, paletteKey, collapsed, setCollapsed]);
-
-  // --- SoundCloud audio: muted-by-default autoplay through the profile ---
-  const iframeRef = useRef<HTMLIFrameElement | null>(null);
-  const widgetRef = useRef<SCWidget | null>(null);
-  const [muted, setMuted] = useState(true);
-  // Now-playing metadata pulled from the widget: current track title + genre.
-  const [nowPlaying, setNowPlaying] = useState("");
-  // Transport state for the seek slider: current position + track length (ms).
-  const [positionMs, setPositionMs] = useState(0);
-  const [durationMs, setDurationMs] = useState(0);
-  // Timestamp of the last user seek — suppresses PLAY_PROGRESS snap-back for a
-  // brief window so the thumb doesn't fight the user mid-drag.
-  const lastSeekRef = useRef(0);
-
-  useEffect(() => {
-    let cancelled = false;
-    loadSoundCloudWidget()
-      .then(() => {
-        if (cancelled || !iframeRef.current || !window.SC) return;
-        const widget = window.SC.Widget(iframeRef.current);
-        widgetRef.current = widget;
-        const refreshTrack = () => {
-          widget.getCurrentSound((sound) => {
-            if (cancelled || !sound) return;
-            const parts = [sound.title, sound.genre].filter(Boolean);
-            setNowPlaying(parts.join(" · "));
-          });
-          widget.getDuration((ms) => {
-            if (!cancelled) setDurationMs(ms || 0);
-          });
-        };
-        widget.bind(window.SC.Widget.Events.READY, () => {
-          widget.setVolume(0);
-          widget.play();
-          refreshTrack();
-        });
-        // Each time a new track starts, refresh title + genre + duration, reset position.
-        widget.bind(window.SC.Widget.Events.PLAY, () => {
-          setPositionMs(0);
-          refreshTrack();
-        });
-        // Advance the seek thumb as the track plays (ignored briefly after a seek).
-        widget.bind(window.SC.Widget.Events.PLAY_PROGRESS, (data) => {
-          if (cancelled || Date.now() - lastSeekRef.current < 400) return;
-          if (data && typeof data.currentPosition === "number") {
-            setPositionMs(data.currentPosition);
-          }
-        });
-      })
-      .catch(() => {
-        // Network-blocked or offline — leave audio inert; UI still works.
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const playNext = useCallback(() => {
-    widgetRef.current?.next();
-    setPositionMs(0);
-  }, []);
-
-  const playPrev = useCallback(() => {
-    widgetRef.current?.prev();
-    setPositionMs(0);
-  }, []);
-
-  const handleSeek = useCallback((ms: number) => {
-    lastSeekRef.current = Date.now();
-    setPositionMs(ms);
-    widgetRef.current?.seekTo(ms);
-  }, []);
-
-  const toggleAudio = useCallback(() => {
-    setMuted((prev) => {
-      const next = !prev;
-      const widget = widgetRef.current;
-      if (widget) {
-        widget.setVolume(next ? 0 : 100);
-        widget.play();
-      }
-      return next;
-    });
-  }, []);
 
   const hourTicks = useMemo(() => buildHourTicks(), []);
   const activePalette = palettes.find((p) => p.key === paletteKey);
@@ -399,138 +248,148 @@ export function BrightnessRack({ className }: BrightnessRackProps) {
         />
       </div>
 
-        {/* Audio — curated music: artist credit, transport + seek, external links */}
-        <div className="mt-2 pt-2 border-t border-hairline-subtle space-y-2">
-          {/* Row 1 — artist credit + now playing + links + mute */}
-          <div className="flex items-center gap-3">
-            <span className="label-hw min-w-[78px]">AUDIO</span>
-            <span className="font-mono text-[11px] text-display tabular-nums shrink-0">
-              pommeshdrms
-            </span>
-            {nowPlaying && (
-              <span className="label-hw-dim truncate min-w-0" title={nowPlaying}>
-                · {nowPlaying}
-              </span>
-            )}
-            <span className="flex-1" />
-            <a
-              href="https://soundcloud.com/pommeshdrms"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="pommeshdrms on SoundCloud (opens in new tab)"
-              title="pommeshdrms on SoundCloud"
-              className="lcd px-2 py-1 label-hw-dim hover:text-display transition-colors duration-200"
-            >
-              SC
-            </a>
-            <a
-              href="https://www.instagram.com/pommes_hdrms"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="pommes_hdrms on Instagram (opens in new tab)"
-              title="pommes_hdrms on Instagram"
-              className="lcd px-2 py-1 label-hw-dim hover:text-display transition-colors duration-200"
-            >
-              IG
-            </a>
-            <button
-              type="button"
-              onClick={toggleAudio}
-              aria-label={muted ? "Unmute audio" : "Mute audio"}
-              aria-pressed={!muted}
-              title={muted ? "Unmute audio" : "Mute audio"}
-              className="lcd p-1 hover:bg-panel-deep transition-colors duration-150 group"
-            >
-              {muted ? (
-                <VolumeX
-                  className="h-3.5 w-3.5 text-label-mid group-hover:text-display transition-colors duration-150"
-                  aria-hidden="true"
-                />
-              ) : (
-                <Volume2
-                  className="h-3.5 w-3.5 text-display transition-colors duration-150"
-                  aria-hidden="true"
-                />
-              )}
-            </button>
-          </div>
-
-          {/* Row 2 — transport: previous · seek · next + elapsed/total */}
-          <div className="flex items-center gap-2">
-            <span className="min-w-[78px]" aria-hidden="true" />
-            <button
-              type="button"
-              onClick={playPrev}
-              aria-label="Previous track"
-              title="Previous track"
-              className="lcd p-1 hover:bg-panel-deep transition-colors duration-150 group shrink-0"
-            >
-              <SkipBack
-                className="h-3.5 w-3.5 text-label-mid group-hover:text-display transition-colors duration-150"
-                aria-hidden="true"
-              />
-            </button>
-
-            <div className="flex-1 relative h-[18px]">
-              {/* Track */}
-              <div className="absolute top-[8px] left-0 right-0 h-[2px] bg-panel-deep border border-hairline" />
-              {/* Elapsed fill */}
-              <div
-                className="absolute top-[8px] left-0 h-[2px] bg-display pointer-events-none"
-                style={{ width: `${durationMs > 0 ? (positionMs / durationMs) * 100 : 0}%` }}
-                aria-hidden="true"
-              />
-              <input
-                type="range"
-                min={0}
-                max={durationMs > 0 ? durationMs : 1}
-                step={1000}
-                value={positionMs}
-                disabled={durationMs <= 0}
-                aria-label="Seek track position"
-                onChange={(e) => handleSeek(parseInt(e.target.value, 10))}
-                className={cn(
-                  "absolute inset-0 w-full h-[18px] bg-transparent appearance-none cursor-ew-resize z-10",
-                  "disabled:cursor-not-allowed",
-                  "[&::-webkit-slider-thumb]:appearance-none",
-                  "[&::-webkit-slider-thumb]:w-[10px] [&::-webkit-slider-thumb]:h-[14px]",
-                  "[&::-webkit-slider-thumb]:bg-gradient-to-b [&::-webkit-slider-thumb]:from-[#DDDDDD] [&::-webkit-slider-thumb]:to-[#888888]",
-                  "[&::-webkit-slider-thumb]:border [&::-webkit-slider-thumb]:border-black",
-                  "[&::-webkit-slider-thumb]:cursor-ew-resize",
-                  "[&::-moz-range-thumb]:w-[10px] [&::-moz-range-thumb]:h-[14px]",
-                  "[&::-moz-range-thumb]:bg-[linear-gradient(180deg,#DDDDDD_0%,#888888_100%)]",
-                  "[&::-moz-range-thumb]:border [&::-moz-range-thumb]:border-black",
-                  "[&::-moz-range-thumb]:rounded-none [&::-moz-range-thumb]:cursor-ew-resize",
-                )}
-              />
+      {/* Audio — now-playing card: artwork + track + discreet links + mute */}
+      <div className="flex items-start gap-3 mt-2 pt-2 border-t border-hairline-subtle">
+        <span className="label-hw min-w-[78px] mt-1">AUDIO</span>
+        <div className="flex items-start gap-3 flex-1 min-w-0">
+          {artworkUrl ? (
+            <img
+              src={artworkUrl}
+              alt=""
+              className="w-12 h-12 object-cover border border-hairline flex-shrink-0"
+            />
+          ) : (
+            <div className="w-12 h-12 border border-hairline bg-panel-deep flex items-center justify-center flex-shrink-0">
+              <Music className="h-4 w-4 text-label-mid" aria-hidden="true" />
             </div>
-
-            <button
-              type="button"
-              onClick={playNext}
-              aria-label="Next track"
-              title="Next track"
-              className="lcd p-1 hover:bg-panel-deep transition-colors duration-150 group shrink-0"
-            >
-              <SkipForward
+          )}
+          <div className="min-w-0 flex-1">
+            <div className="font-mono text-[11px] text-display truncate" title={title || "pommeshdrms"}>
+              {title || "pommeshdrms"}
+            </div>
+            <div className="label-hw-dim truncate">
+              {["pommeshdrms", genre].filter(Boolean).join(" · ")}
+            </div>
+            <div className="flex items-center gap-3 mt-1">
+              <a
+                href="https://soundcloud.com/pommeshdrms"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="pommeshdrms on SoundCloud (opens in new tab)"
+                className="label-hw-dim hover:text-display transition-colors duration-200"
+              >
+                SOUNDCLOUD ↗
+              </a>
+              <a
+                href="https://www.instagram.com/pommes_hdrms"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="pommes_hdrms on Instagram (opens in new tab)"
+                className="label-hw-dim hover:text-display transition-colors duration-200"
+              >
+                INSTAGRAM ↗
+              </a>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={toggle}
+            aria-label={muted ? "Unmute audio" : "Mute audio"}
+            aria-pressed={!muted}
+            title={muted ? "Unmute audio" : "Mute audio"}
+            className="lcd p-1 hover:bg-panel-deep transition-colors duration-150 group flex-shrink-0 self-center"
+          >
+            {muted ? (
+              <VolumeX
                 className="h-3.5 w-3.5 text-label-mid group-hover:text-display transition-colors duration-150"
                 aria-hidden="true"
               />
-            </button>
-
-            <span className="label-hw-dim text-[9px] tabular-nums shrink-0 min-w-[66px] text-right">
-              {formatTime(positionMs)} / {formatTime(durationMs)}
-            </span>
-          </div>
-
-          {/* Row 3 — curation framing */}
-          <div className="flex items-center gap-3">
-            <span className="min-w-[78px]" aria-hidden="true" />
-            <span className="label-hw-dim text-[8px] tracking-[0.18em]">
-              FEATURING ARTISTS WE LOVE
-            </span>
-          </div>
+            ) : (
+              <Volume2
+                className="h-3.5 w-3.5 text-display transition-colors duration-150"
+                aria-hidden="true"
+              />
+            )}
+          </button>
         </div>
+      </div>
+
+      {/* Audio transport — previous · seek · next + elapsed/total */}
+      <div className="flex items-center gap-3 mt-2">
+        <span className="min-w-[78px]" aria-hidden="true" />
+        <div className="flex items-center gap-2 flex-1 min-w-0">
+          <button
+            type="button"
+            onClick={prev}
+            aria-label="Previous track"
+            title="Previous track"
+            className="lcd p-1 hover:bg-panel-deep transition-colors duration-150 group shrink-0"
+          >
+            <SkipBack
+              className="h-3.5 w-3.5 text-label-mid group-hover:text-display transition-colors duration-150"
+              aria-hidden="true"
+            />
+          </button>
+
+          <div className="flex-1 relative h-[18px] min-w-0">
+            {/* Track */}
+            <div className="absolute top-[8px] left-0 right-0 h-[2px] bg-panel-deep border border-hairline" />
+            {/* Elapsed fill */}
+            <div
+              className="absolute top-[8px] left-0 h-[2px] bg-display pointer-events-none"
+              style={{ width: `${durationMs > 0 ? (positionMs / durationMs) * 100 : 0}%` }}
+              aria-hidden="true"
+            />
+            <input
+              type="range"
+              min={0}
+              max={durationMs > 0 ? durationMs : 1}
+              step={1000}
+              value={positionMs}
+              disabled={durationMs <= 0}
+              aria-label="Seek track position"
+              onChange={(e) => seek(parseInt(e.target.value, 10))}
+              className={cn(
+                "absolute inset-0 w-full h-[18px] bg-transparent appearance-none cursor-ew-resize z-10",
+                "disabled:cursor-not-allowed",
+                "[&::-webkit-slider-thumb]:appearance-none",
+                "[&::-webkit-slider-thumb]:w-[10px] [&::-webkit-slider-thumb]:h-[14px]",
+                "[&::-webkit-slider-thumb]:bg-gradient-to-b [&::-webkit-slider-thumb]:from-[#DDDDDD] [&::-webkit-slider-thumb]:to-[#888888]",
+                "[&::-webkit-slider-thumb]:border [&::-webkit-slider-thumb]:border-black",
+                "[&::-webkit-slider-thumb]:cursor-ew-resize",
+                "[&::-moz-range-thumb]:w-[10px] [&::-moz-range-thumb]:h-[14px]",
+                "[&::-moz-range-thumb]:bg-[linear-gradient(180deg,#DDDDDD_0%,#888888_100%)]",
+                "[&::-moz-range-thumb]:border [&::-moz-range-thumb]:border-black",
+                "[&::-moz-range-thumb]:rounded-none [&::-moz-range-thumb]:cursor-ew-resize",
+              )}
+            />
+          </div>
+
+          <button
+            type="button"
+            onClick={next}
+            aria-label="Next track"
+            title="Next track"
+            className="lcd p-1 hover:bg-panel-deep transition-colors duration-150 group shrink-0"
+          >
+            <SkipForward
+              className="h-3.5 w-3.5 text-label-mid group-hover:text-display transition-colors duration-150"
+              aria-hidden="true"
+            />
+          </button>
+
+          <span className="label-hw-dim text-[9px] tabular-nums shrink-0 min-w-[66px] text-right">
+            {formatTime(positionMs)} / {formatTime(durationMs)}
+          </span>
+        </div>
+      </div>
+
+      {/* Curation framing */}
+      <div className="flex items-center gap-3 mt-1">
+        <span className="min-w-[78px]" aria-hidden="true" />
+        <span className="label-hw-dim text-[8px] tracking-[0.18em]">
+          FEATURING ARTISTS WE LOVE
+        </span>
       </div>
     </div>
   );

--- a/client/src/components/brightness-rack.tsx
+++ b/client/src/components/brightness-rack.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from "react";
-import { ChevronDown, ChevronUp, Music, SkipBack, SkipForward, Volume2, VolumeX } from "lucide-react";
+import { ChevronDown, ChevronUp, FastForward, Music, Rewind, Volume2, VolumeX } from "lucide-react";
 import { useBrightness } from "@/hooks/use-brightness";
 import { HardwareToggle } from "@/components/hardware-toggle";
 import { useSoundCloudAudio } from "@/components/audio/use-sound-cloud-audio";
@@ -9,6 +9,9 @@ import { cn } from "@/lib/utils";
 interface BrightnessRackProps {
   className?: string;
 }
+
+// How far the rewind / fast-forward buttons jump within the current track.
+const SKIP_MS = 15000;
 
 // SoundCloud reports times in ms. Render as m:ss.
 function formatTime(ms: number): string {
@@ -43,7 +46,7 @@ export function BrightnessRack({ className }: BrightnessRackProps) {
   } = useBrightness();
 
   // Audio state lives in a provider above the router (persists across nav).
-  const { muted, toggle, title, genre, artworkUrl, positionMs, durationMs, next, prev, seek } =
+  const { muted, toggle, title, genre, artworkUrl, positionMs, durationMs, seek } =
     useSoundCloudAudio();
 
   // Once the user touches anything (slider, AUTO toggle, palette), collapse
@@ -314,18 +317,19 @@ export function BrightnessRack({ className }: BrightnessRackProps) {
         </div>
       </div>
 
-      {/* Audio transport — previous · seek · next + elapsed/total */}
+      {/* Audio transport — rewind 15s · seek · forward 15s + elapsed/total */}
       <div className="flex items-center gap-3 mt-2">
         <span className="min-w-[78px]" aria-hidden="true" />
         <div className="flex items-center gap-2 flex-1 min-w-0">
           <button
             type="button"
-            onClick={prev}
-            aria-label="Previous track"
-            title="Previous track"
-            className="lcd p-1 hover:bg-panel-deep transition-colors duration-150 group shrink-0"
+            onClick={() => seek(Math.max(0, positionMs - SKIP_MS))}
+            disabled={durationMs <= 0}
+            aria-label="Skip back 15 seconds"
+            title="Skip back 15 seconds"
+            className="lcd p-1 hover:bg-panel-deep transition-colors duration-150 group shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            <SkipBack
+            <Rewind
               className="h-3.5 w-3.5 text-label-mid group-hover:text-display transition-colors duration-150"
               aria-hidden="true"
             />
@@ -367,12 +371,13 @@ export function BrightnessRack({ className }: BrightnessRackProps) {
 
           <button
             type="button"
-            onClick={next}
-            aria-label="Next track"
-            title="Next track"
-            className="lcd p-1 hover:bg-panel-deep transition-colors duration-150 group shrink-0"
+            onClick={() => seek(Math.min(durationMs, positionMs + SKIP_MS))}
+            disabled={durationMs <= 0}
+            aria-label="Skip forward 15 seconds"
+            title="Skip forward 15 seconds"
+            className="lcd p-1 hover:bg-panel-deep transition-colors duration-150 group shrink-0 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            <SkipForward
+            <FastForward
               className="h-3.5 w-3.5 text-label-mid group-hover:text-display transition-colors duration-150"
               aria-hidden="true"
             />


### PR DESCRIPTION
## Summary
- Adds **previous / next track** buttons and a **seek slider** to the AUDIO row of the brightness rack.
- Wired to the SoundCloud Widget API: `next()` / `prev()` / `seekTo(ms)`, `PLAY_PROGRESS` event for the live position, `getDuration()` for track length.
- Shows **elapsed / total** time (e.g. `0:41 / 81:04`) and a **"FEATURING ARTISTS WE LOVE"** caption framing the music as curated to support the local scene.

## Files
- `client/src/components/brightness-rack.tsx` — extended the SC widget types (`next`/`prev`/`seekTo`/`getDuration`, `PLAY_PROGRESS`), added position/duration state, transport handlers, and the new transport + caption rows.

## Behavior notes
- Seek is debounced against `PLAY_PROGRESS` snap-back for 400ms after a user seek so the thumb doesn't fight the drag.
- The slider is disabled until a duration is known.
- Player stays muted-by-default; transport works regardless of mute.
- These controls live in the **expanded** rack (same as the existing AUDIO row). After the rack auto-collapses on first brightness/AUTO/palette change, they're hidden until re-expanded — see open question below.

## Test plan (verified locally in mock mode)
- [x] Build (typecheck) + lint clean.
- [x] AUDIO row renders artist + now-playing + SC/IG/mute + transport + caption.
- [x] Seek thumb advances with playback (observed `0:04` → `0:41`).
- [x] Seek slider is interactive; time display updates.
- [x] Next/prev call the widget API (cycle when the profile has multiple tracks; current `pommeshdrms` profile is one long set so the title may not change).
- [ ] Reviewer: confirm on the Vercel preview with audio unmuted.

## Open question
Should the transport (and now-playing) stay visible when the rack is **collapsed**, so you can skip tracks without re-expanding? Easy follow-up if yes.