### PR TITLE
copy: remove em-dashes from first-party app copy

### DIFF
--- a/client/src/components/M2AgreementSection.tsx
+++ b/client/src/components/M2AgreementSection.tsx
@@ -125,7 +125,7 @@ export function M2AgreementSection({
         <div className="mb-5">
           <div className="flex items-center gap-2 mb-2">
             <CheckCircle className="w-3.5 h-3.5 text-led" />
-            <span className="label-hw text-display">·CORE FEATURES — MUST COMPLETE</span>
+            <span className="label-hw text-display">·CORE FEATURES: MUST COMPLETE</span>
           </div>
           <div className="lcd p-4">
             <ul className="space-y-2">
@@ -184,7 +184,7 @@ export function M2AgreementSection({
           ) : (
             <div className="flex items-start gap-2 lcd p-3 border-destructive">
               <AlertCircle className="w-3.5 h-3.5 mt-0.5 text-destructive flex-shrink-0" />
-              <p className="label-hw text-destructive">·ROADMAP LOCKED AFTER WEEK 4 — CONTACT YOUR MENTORS IF YOU NEED CHANGES.</p>
+              <p className="label-hw text-destructive">·ROADMAP LOCKED AFTER WEEK 4. CONTACT YOUR MENTORS IF YOU NEED CHANGES.</p>
             </div>
           )}
         </div>

--- a/client/src/components/SubmitM2DeliverablesModal.tsx
+++ b/client/src/components/SubmitM2DeliverablesModal.tsx
@@ -110,7 +110,7 @@ export function SubmitM2DeliverablesModal({
         <div className="lcd p-3 flex items-start gap-2.5">
           <AlertTriangle className="h-3.5 w-3.5 text-display flex-shrink-0 mt-0.5" />
           <p className="text-sm text-body">
-            <span className="label-hw text-display">·BEFORE SUBMITTING — </span>
+            <span className="label-hw text-display">·BEFORE SUBMITTING: </span>
             make sure your code is complete, tested, and documented according to your M2 Agreement
             roadmap.
           </p>
@@ -229,7 +229,7 @@ export function SubmitM2DeliverablesModal({
           <div className="lcd p-3 flex items-start gap-2.5">
             <Lightbulb className="h-3.5 w-3.5 text-led flex-shrink-0 mt-0.5" />
             <p className="text-sm text-body">
-              <span className="label-hw text-led">·AFTER SUBMISSION — </span>
+              <span className="label-hw text-led">·AFTER SUBMISSION: </span>
               WebZero will review within 2-3 days. You'll be notified via email and can track status on this page.
             </p>
           </div>

--- a/client/src/components/admin/AdminTierSection.tsx
+++ b/client/src/components/admin/AdminTierSection.tsx
@@ -109,7 +109,7 @@ export function AdminTierSection({
     } catch {
       toast({
         title: "Couldn't copy",
-        description: "Clipboard access denied — copy the wallet manually.",
+        description: "Clipboard access denied. Copy the wallet manually.",
         variant: "destructive",
       });
     }

--- a/client/src/components/admin/CreateProjectModal.tsx
+++ b/client/src/components/admin/CreateProjectModal.tsx
@@ -197,7 +197,7 @@ export function CreateProjectModal({
             <Label htmlFor="cp-id">
               ID{" "}
               <span className="text-muted-foreground text-xs font-normal">
-                (optional — auto-derived from name if blank)
+                (optional, auto-derived from name if blank)
               </span>
             </Label>
             <Input

--- a/client/src/components/admin/ProgramSignupsSection.tsx
+++ b/client/src/components/admin/ProgramSignupsSection.tsx
@@ -191,7 +191,7 @@ export function ProgramSignupsSection({ programSlug, signAuthHeader }: Props) {
       {isStale && (
         <div className="lcd p-3 mb-3 border border-amber-500/40">
           <p className="label-hw text-amber-500">
-            ·LUMA MAY HAVE NEW SIGNUPS — PULL A FRESH CSV AND RE-IMPORT.
+            ·LUMA MAY HAVE NEW SIGNUPS. PULL A FRESH CSV AND RE-IMPORT.
           </p>
         </div>
       )}
@@ -288,7 +288,7 @@ export function ProgramSignupsSection({ programSlug, signAuthHeader }: Props) {
             <ul className="font-mono text-[11px] space-y-0.5">
               {preview.newPreview.map((r, i) => (
                 <li key={i} className="text-body">
-                  {r.email}{r.name ? ` — ${r.name}` : ""}{r.wallet ? ` · ${truncateAddress(r.wallet)}` : ""}
+                  {r.email}{r.name ? ` · ${r.name}` : ""}{r.wallet ? ` · ${truncateAddress(r.wallet)}` : ""}
                 </li>
               ))}
             </ul>

--- a/client/src/components/admin/ProgramsTable.tsx
+++ b/client/src/components/admin/ProgramsTable.tsx
@@ -102,7 +102,7 @@ export function ProgramsTable({ connectedAddress }: { connectedAddress?: string 
         <p className="label-hw text-destructive py-6">·{error.toUpperCase()}</p>
       ) : programs.length === 0 ? (
         <p className="text-body text-sm py-6">
-          No programs yet — create one to open applications to past winners.
+          No programs yet. Create one to open applications to past winners.
         </p>
       ) : (
         <Table>

--- a/client/src/components/milestone-track.tsx
+++ b/client/src/components/milestone-track.tsx
@@ -37,7 +37,7 @@ export function MilestoneTrack({
           <div
             key={i}
             title={title}
-            aria-label={title + (isCompleted ? " — completed" : isCurrent ? " — in progress" : " — pending")}
+            aria-label={title + (isCompleted ? ", completed" : isCurrent ? ", in progress" : ", pending")}
             className={cn(
               sz.w, sz.h,
               isCurrent

--- a/client/src/components/program-spaces.tsx
+++ b/client/src/components/program-spaces.tsx
@@ -16,7 +16,7 @@ const SPACES: Space[] = [
   {
     type: "hackathon",
     label: "HACKATHONS",
-    blurb: "Weekend build sprints on Polkadot — ship something new, win bounties.",
+    blurb: "Weekend build sprints on Polkadot: ship something new, win bounties.",
     href: "/programs?type=hackathon",
     Icon: Zap,
   },
@@ -37,7 +37,7 @@ const SPACES: Space[] = [
   {
     type: "pitch_off",
     label: "PITCHOFF",
-    blurb: "Builders pitch live to the room — the crowd picks what's next.",
+    blurb: "Builders pitch live to the room, and the crowd picks what's next.",
     href: "/programs?type=pitch_off",
     Icon: Mic,
   },
@@ -61,7 +61,7 @@ export function ProgramSpaces({ programs }: { programs: ApiProgram[] }) {
       </div>
       <p className="text-body text-sm md:text-base max-w-2xl leading-relaxed mb-3">
         WebZero is where the best people come together in the same room to explore their creative
-        potential — and build something cool. Each program is tied to a specific event, with prizes
+        potential and build something cool. Each program is tied to a specific event, with prizes
         ranging from cash to event tickets to exclusive merch.
       </p>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-2">

--- a/client/src/components/program/ApplyToProgramModal.tsx
+++ b/client/src/components/program/ApplyToProgramModal.tsx
@@ -139,7 +139,7 @@ export function ApplyToProgramModal({
             APPLY TO {program.name.toUpperCase()}
           </DialogTitle>
           <DialogDescription className="text-body">
-            Bring the project you already built — we'll pull the rest from its Stadium page.
+            Bring the project you already built, and we'll pull the rest from its Stadium page.
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-4">

--- a/client/src/components/project/ProjectContinuationModal.tsx
+++ b/client/src/components/project/ProjectContinuationModal.tsx
@@ -101,7 +101,7 @@ export function ProjectContinuationModal({
         authHeader,
       );
       onSubmitted(res.data);
-      toast({ title: "Submitted — thanks for the update" });
+      toast({ title: "Submitted. Thanks for the update" });
       reset();
       onOpenChange(false);
     } catch (e) {
@@ -120,7 +120,7 @@ export function ProjectContinuationModal({
         <DialogHeader>
           <DialogTitle className="font-display tracking-tight">·WHAT'S NEXT, MILESTONE 3?</DialogTitle>
           <DialogDescription className="text-body">
-            Now that M2 is done — where is the project today, and what's the next step we should
+            Now that M2 is done, where is the project today, and what's the next step we should
             know about? Submissions go to the WebZero ops team.
           </DialogDescription>
         </DialogHeader>

--- a/client/src/lib/mockFundingSignals.ts
+++ b/client/src/lib/mockFundingSignals.ts
@@ -15,7 +15,7 @@ export const mockFundingSignals: Record<string, ApiFundingSignal> = {
     fundingType: "grant",
     amountRange: "30k–60k USD",
     description:
-      "Applying for the Web3 Foundation grant to extend the stealth-transfer primitives beyond Asset Hub — happy to chat with anyone who's been through that review.",
+      "Applying for the Web3 Foundation grant to extend the stealth-transfer primitives beyond Asset Hub. Happy to chat with anyone who's been through that review.",
     updatedBy: "mock-wallet",
     updatedAt: "2026-04-18T12:00:00Z",
   },

--- a/client/src/lib/mockProgramApplications.ts
+++ b/client/src/lib/mockProgramApplications.ts
@@ -16,7 +16,7 @@ export const mockProgramApplications: ApiProgramApplication[] = [
     status: "submitted",
     applicationFields: {
       feedback_focus:
-        "We'd love structured feedback on the UX of our stealth-transfer flow — specifically whether the one-step deposit is discoverable.",
+        "We'd love structured feedback on the UX of our stealth-transfer flow, specifically whether the one-step deposit is discoverable.",
     },
     submittedBy: "mock-wallet",
     submittedAt: "2026-04-22T11:30:00Z",

--- a/client/src/lib/mockPrograms.ts
+++ b/client/src/lib/mockPrograms.ts
@@ -122,7 +122,7 @@ export const mockPrograms: ApiProgram[] = [
     slug: "dogfooding-2026-denver",
     programType: "dogfooding",
     description:
-      "Whether you're new to web3 or deep in it — when's the last time you actually used a new product, not just heard about one? Dogfooding Denver showcased 3–4 products built by WebZero hackathon teams. No jargon-filled panels, no slideshows — just hands-on time with real apps. Attendees picked a product, spent 30 minutes on guided tasks, and submitted feedback that went directly to the builders. No technical background or wallet required — just curiosity. The feedback shapes what gets built next.",
+      "Whether you're new to web3 or deep in it: when's the last time you actually used a new product, not just heard about one? Dogfooding Denver showcased 3–4 products built by WebZero hackathon teams. No jargon-filled panels, no slideshows, just hands-on time with real apps. Attendees picked a product, spent 30 minutes on guided tasks, and submitted feedback that went directly to the builders. No technical background or wallet required, just curiosity. The feedback shapes what gets built next.",
     status: "completed",
     owner: "webzero",
     applicationsOpenAt: null,
@@ -137,13 +137,13 @@ export const mockPrograms: ApiProgram[] = [
         type: "text",
         title: "Why you're here",
         body:
-          "The products you're about to try are early. Really early. They're being built right now by teams coming out of WebZero hackathons — and they need people like you to use them, break them, and tell them what's working, what's not, what you like and what could be improved.\n\nThis isn't a demo. You're not here to watch. You're here to get your hands on things before anyone else and have a real say in what gets built next.\n\nPlay a role in helping our builders validate what they're creating. Your feedback goes directly to them.",
+          "The products you're about to try are early. Really early. They're being built right now by teams coming out of WebZero hackathons, and they need people like you to use them, break them, and tell them what's working, what's not, what you like and what could be improved.\n\nThis isn't a demo. You're not here to watch. You're here to get your hands on things before anyone else and have a real say in what gets built next.\n\nPlay a role in helping our builders validate what they're creating. Your feedback goes directly to them.",
       },
       {
         type: "text",
         title: "What makes this different",
         body:
-          "Most web3 events are panels and pitches. You sit, you listen, you leave.\n\nToday you'll actually use products. You'll get stuck, figure things out, maybe get frustrated, hopefully get surprised. That's the point. Real usage, real feedback, real impact — and getting to be among the first to try cutting-edge web3 products.",
+          "Most web3 events are panels and pitches. You sit, you listen, you leave.\n\nToday you'll actually use products. You'll get stuck, figure things out, maybe get frustrated, hopefully get surprised. That's the point. Real usage, real feedback, real impact, and getting to be among the first to try cutting-edge web3 products.",
       },
       {
         type: "steps",
@@ -159,7 +159,7 @@ export const mockPrograms: ApiProgram[] = [
         type: "text",
         title: "The debrief",
         body:
-          "At the end, we'll come together and share what stood out — what surprised you, what worked, what didn't. The builders aren't all here in person, but we're keeping track of your feedback and sending it straight to them. At the end we'll also draw the lucky raffle winner.",
+          "At the end, we'll come together and share what stood out: what surprised you, what worked, what didn't. The builders aren't all here in person, but we're keeping track of your feedback and sending it straight to them. At the end we'll also draw the lucky raffle winner.",
       },
       {
         type: "cta",
@@ -223,7 +223,7 @@ export const mockPrograms: ApiProgram[] = [
             name: "Station",
             blurb: "Music streaming for the decentralized curious.",
             tryItems: [
-              "Set up your own cloud server (Hetzner credits provided — no out-of-pocket cost)",
+              "Set up your own cloud server (Hetzner credits provided, no out-of-pocket cost)",
               "Host your own music",
               "Play it back via the web app",
             ],
@@ -256,7 +256,7 @@ export const mockPrograms: ApiProgram[] = [
           {
             product: "Station / Kinectica",
             quote:
-              "It worked. Currently there are a lot of steps and it does require a wallet — which is fine, but will be a barrier for non-web3 users.",
+              "It worked. Currently there are a lot of steps and it does require a wallet, which is fine, but will be a barrier for non-web3 users.",
             recommend: true,
           },
           {
@@ -274,21 +274,21 @@ export const mockPrograms: ApiProgram[] = [
           {
             product: "Khoj",
             quote:
-              "If I wasn't already familiar with web3 wallets, getting testnet funds would have been challenging. Make it clearer that a team shares the same set of picture clues — we thought there were 6 per user. And there's no way to skip a clue if you're playing in a bigger space.",
+              "If I wasn't already familiar with web3 wallets, getting testnet funds would have been challenging. Make it clearer that a team shares the same set of picture clues. We thought there were 6 per user. And there's no way to skip a clue if you're playing in a bigger space.",
             rating: "5/7",
             recommend: true,
           },
           {
             product: "Khoj",
             quote:
-              "I'd like to see in-app instructions — more one step at a time. It's hard to bounce back and forth to an instructions list. The steps themselves were easy.",
+              "I'd like to see in-app instructions: more one step at a time. It's hard to bounce back and forth to an instructions list. The steps themselves were easy.",
             rating: "5/7",
             recommend: true,
           },
           {
             product: "Khoj",
             quote:
-              "Confusing because you needed to refer to the docs — the in-game screens didn't have the necessary detail. Thankfully an organiser helped us.",
+              "Confusing because you needed to refer to the docs. The in-game screens didn't have the necessary detail. Thankfully an organiser helped us.",
             rating: "6/7",
             recommend: true,
           },

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -436,7 +436,7 @@ const AdminPage = () => {
 
           {projectsUnderReview.length === 0 ? (
             <p className="label-hw-dim py-6 text-center">
-              All M2 submissions are reviewed — nothing pending.
+              All M2 submissions are reviewed. Nothing pending.
             </p>
           ) : (
             <div className="space-y-3">

--- a/client/src/pages/AppAdminsPage.tsx
+++ b/client/src/pages/AppAdminsPage.tsx
@@ -130,8 +130,8 @@ const AppAdminsPage = () => {
           <>
             <AdminTierSection
               title="App Admins"
-              description="Tier 0 — manage admin lists themselves. Cannot remove the last one."
-              emptyHint="No app admins. This should be impossible — bootstrap script must have run."
+              description="Tier 0: manage admin lists themselves. Cannot remove the last one."
+              emptyHint="No app admins. This should be impossible; the bootstrap script must have run."
               load={(a) => api.listAppAdmins(a)}
               add={(p, a) => api.addAppAdmin(p, a)}
               remove={(w, c, a) => api.removeAppAdmin(w, c, a)}
@@ -139,7 +139,7 @@ const AppAdminsPage = () => {
             />
             <AdminTierSection
               title="Global Admins"
-              description="Tier 1 — administer every program. Initial entries seeded from AUTHORIZED_SIGNERS env at bootstrap."
+              description="Tier 1: administer every program. Initial entries seeded from AUTHORIZED_SIGNERS env at bootstrap."
               emptyHint="No global admins yet. Add wallets that should administer every program."
               load={(a) => api.listGlobalAdmins(a)}
               add={(p, a) => api.addGlobalAdmin(p, a)}

--- a/client/src/pages/M2ProgramPage.tsx
+++ b/client/src/pages/M2ProgramPage.tsx
@@ -159,7 +159,7 @@ const M2ProgramPage = () => {
             M2 Incubator
           </h1>
           <p className="text-[13px] text-body leading-relaxed max-w-2xl">
-            The post-event track for WebZero winners — keep building what you shipped, with a mentor and a defined Milestone 2.
+            The post-event track for WebZero winners: keep building what you shipped, with a mentor and a defined Milestone 2.
           </p>
         </div>
 

--- a/client/src/pages/ProgramDetailPage.tsx
+++ b/client/src/pages/ProgramDetailPage.tsx
@@ -266,7 +266,7 @@ const ProgramDetailPage = () => {
           </RackButton>
           {!auth.isAvailable && (
             <p className="label-hw-dim">
-              {providerLabel.toUpperCase()} EXTENSION NOT DETECTED — INSTALL IT, THEN REFRESH.
+              {providerLabel.toUpperCase()} EXTENSION NOT DETECTED. INSTALL IT, THEN REFRESH.
             </p>
           )}
         </div>
@@ -298,7 +298,7 @@ const ProgramDetailPage = () => {
           {isUserAdmin && myProjects.length === 0 ? "APPLY ON BEHALF OF…" : "APPLY WITH MY PROJECT"}
         </RackButton>
         {isUserAdmin && (
-          <p className="label-hw-dim">ADMIN MODE — APPLY ON BEHALF OF ANY PROJECT</p>
+          <p className="label-hw-dim">ADMIN MODE: APPLY ON BEHALF OF ANY PROJECT</p>
         )}
       </div>
     );

--- a/client/src/pages/ProgramsPage.tsx
+++ b/client/src/pages/ProgramsPage.tsx
@@ -54,7 +54,7 @@ const ProgramsPage = () => {
             Programs
           </h1>
           <p className="text-body text-base max-w-2xl leading-relaxed">
-            Open opportunities to build with WebZero — continuation tracks for past winners and upcoming events.
+            Open opportunities to build with WebZero: continuation tracks for past winners and upcoming events.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
House-style sweep: removes em-dashes (`—`) from **first-party, user-facing copy**, replacing each with a comma, period, colon, or parentheses (occasionally a light reword). 18 files, 35 swaps.

Covers: JSX text, toast messages, labels, placeholders, aria-labels, and WebZero-authored content (program descriptions + the Denver event content).

## Deliberately left untouched (per scope)
- **Code comments** (`//`, `/* */`) and **CSS comments** (`index.css`) — not app copy.
- **Builder-written project descriptions** — `mockWinners.ts`, `src/data/synergy-2025.json`, and the **PitchOff submission descriptions** in `mockPrograms.ts` (builders' own words; these mirror real Supabase data). I reverted these after the initial sweep touched them.
- **Numeric en-dashes** (e.g. `3–4 products`) — those are `–`, not `—`.
- The bare **`—` empty-value placeholder** glyph in admin tables / LCD stats (a "no data" indicator, not prose).

## Notes
- The curated Denver feedback-quote highlights *were* cleaned (they're first-party paraphrased/anonymized content I authored, not a raw data mirror). Say the word if you'd rather preserve those verbatim.
- Saved as a standing preference: no em-dashes in our copy going forward.

## Test plan
- [x] `npm run build` (typecheck) clean.
- [x] `npm run lint` clean.
- [x] Diff verified: no comment lines changed; builder content preserved.