### PR TITLE
feat(admin): add program admins by email + onboarding sign-in (full feature)

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -9,6 +9,14 @@ VITE_API_BASE_URL=http://localhost:2000/api
 # Example: VITE_ADMIN_ADDRESSES=5Grw...,ethereum:0xAbC123...
 VITE_ADMIN_ADDRESSES=
 
+# Supabase Auth (social sign-in / email magic link). Used by the client to let
+# email-invited program admins sign in without a wallet. Both must be set or
+# email sign-in shows as "not configured". The ANON key is public (safe to ship
+# to the browser); the server still authorizes via program_admin_emails.
+# Get these from the Supabase dashboard (Project Settings → API).
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
+
 # Preview / offline mode: when "true", the client serves fixtures from
 # src/lib/mockWinners.ts instead of calling the API. Writes are simulated in
 # localStorage. Production must leave this unset or "false". Set to "true" in

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -43,6 +43,7 @@
         "@radix-ui/react-toggle": "^1.1.9",
         "@radix-ui/react-toggle-group": "^1.1.10",
         "@radix-ui/react-tooltip": "^1.2.7",
+        "@supabase/supabase-js": "^2.106.1",
         "@talismn/siws": "^1.0.0",
         "@tanstack/react-query": "^5.56.2",
         "bs58": "^6.0.0",
@@ -4093,6 +4094,90 @@
       "integrity": "sha512-TWDurLiPxndFgKjVavCniytBIw+t4ViOi7TYp9h/D0NMmkEc9klFTo+827eyEJ0lELpqO207Ey7uGxUa+BS1jQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.106.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.106.1.tgz",
+      "integrity": "sha512-7eyheXfAGwkB9bZewJPs+N3UYt6kra2JG6mIxNEgbkvcO15PLD1e75PTIUEYYl3zrifm3GrpShVl7QZxKrXO/w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.106.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.106.1.tgz",
+      "integrity": "sha512-XbOPnR2mW7jp/EcW447xmGwCa+/Wc00Hkw8t4tUIJjRsHQ4xAESsLKcyLRhRJjJoUnJVXUlC+w0wUxUCM7CG2A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.2.tgz",
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==",
+      "license": "MIT"
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.106.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.106.1.tgz",
+      "integrity": "sha512-Qbn6d2lqiqeaBX1Uko0e/hL90dtQGRN6CG2wMVQtJpRFstlVW45qmUTyTOsiB8dYUWu1fWYo4YzJuDbokGv3tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.106.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.106.1.tgz",
+      "integrity": "sha512-eQCYri5E8KsjpDgC7g28cOOS2britjUWdNSJluFMainqrMRepzjOnaxqXc3RoAz7H0dxmBrfLUNF6NGP8C+YaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.106.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.106.1.tgz",
+      "integrity": "sha512-HWcLIhqinhWKpOQ3WzglR2unjW0eh9J7yOu3IZrZNIEkraK4La/HDvTqndljGsNw0itPtyHhuKBxRoPG1VUARw==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.106.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.106.1.tgz",
+      "integrity": "sha512-gP4HurGkGu7Z3xoOCjtAI17BKKp7jpsmwY0Ssbsks9XQRzJ7ZhK7LxfLdBSYgUdgZCQgjRK+Mr7+cl4Gxrk0Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.106.1",
+        "@supabase/functions-js": "2.106.1",
+        "@supabase/postgrest-js": "2.106.1",
+        "@supabase/realtime-js": "2.106.1",
+        "@supabase/storage-js": "2.106.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/core": {
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.13.2.tgz",
@@ -6285,6 +6370,15 @@
         "hash.js": "^1.0.3",
         "minimalistic-assert": "^1.0.0",
         "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/ignore": {

--- a/client/package.json
+++ b/client/package.json
@@ -45,6 +45,7 @@
     "@radix-ui/react-toggle": "^1.1.9",
     "@radix-ui/react-toggle-group": "^1.1.10",
     "@radix-ui/react-tooltip": "^1.2.7",
+    "@supabase/supabase-js": "^2.106.1",
     "@talismn/siws": "^1.0.0",
     "@tanstack/react-query": "^5.56.2",
     "bs58": "^6.0.0",

--- a/client/src/components/admin/ApplicationCard.tsx
+++ b/client/src/components/admin/ApplicationCard.tsx
@@ -29,20 +29,25 @@ export function ApplicationCard({
   programSlug,
   signAuthHeader,
   onUpdated,
+  readOnly = false,
 }: {
   application: ApiProgramApplication;
   programSlug: string;
   /**
    * Returns admin auth headers — either a cached session bearer or a fresh
    * one-shot SIWS payload. Same shape as `useWalletAuth.getAdminBearerHeaders`.
+   * Optional when `readOnly` (no mutating actions are rendered).
    */
-  signAuthHeader: () => Promise<AdminAuthArg>;
-  onUpdated: (next: ApiProgramApplication) => void;
+  signAuthHeader?: () => Promise<AdminAuthArg>;
+  onUpdated?: (next: ApiProgramApplication) => void;
+  /** Hide accept/reject — used for view-only (email) admins. */
+  readOnly?: boolean;
 }) {
   const [working, setWorking] = useState<"accept" | "reject" | null>(null);
   const { toast } = useToast();
 
   const doUpdate = async (next: ApiProgramApplication["status"]) => {
+    if (!signAuthHeader) return;
     setWorking(next === "accepted" ? "accept" : "reject");
     try {
       const authHeader = await signAuthHeader();
@@ -52,7 +57,7 @@ export function ApplicationCard({
         { status: next },
         authHeader,
       );
-      onUpdated(res.data);
+      onUpdated?.(res.data);
       toast({ title: `Application ${next}` });
     } catch (e) {
       const err = e as Error;
@@ -104,7 +109,7 @@ export function ApplicationCard({
             </p>
           </div>
         )}
-        {application.status === "submitted" && (
+        {!readOnly && application.status === "submitted" && (
           <div className="flex flex-wrap gap-2 pt-1">
             <button
               type="button"

--- a/client/src/components/admin/ProgramAdminsSection.tsx
+++ b/client/src/components/admin/ProgramAdminsSection.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState, useCallback } from "react";
-import { Trash2, Loader2 } from "lucide-react";
-import { api, type ApiProgramAdmin, ApiError } from "@/lib/api";
+import { Trash2, Loader2, Mail } from "lucide-react";
+import { api, type ApiProgramAdmin, type ApiProgramAdminEmail, ApiError } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
 
 type ChainOption = ApiProgramAdmin["walletChain"];
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 /**
  * Per-event admin management (Phase 3 #95). Lists `program_admins` and lets
@@ -24,17 +26,24 @@ export function ProgramAdminsSection({
 }) {
   const { toast } = useToast();
   const [admins, setAdmins] = useState<ApiProgramAdmin[]>([]);
+  const [emailAdmins, setEmailAdmins] = useState<ApiProgramAdminEmail[]>([]);
   const [loading, setLoading] = useState(false);
   const [adding, setAdding] = useState(false);
   const [wallet, setWallet] = useState("");
   const [chain, setChain] = useState<ChainOption>("substrate");
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviting, setInviting] = useState(false);
 
   const load = useCallback(async () => {
     setLoading(true);
     try {
       const authHeader = await signAuthHeader();
-      const res = await api.listProgramAdmins(programSlug, authHeader);
-      setAdmins(res.data);
+      const [walletRes, emailRes] = await Promise.all([
+        api.listProgramAdmins(programSlug, authHeader),
+        api.listProgramAdminEmails(programSlug, authHeader),
+      ]);
+      setAdmins(walletRes.data);
+      setEmailAdmins(emailRes.data);
     } catch (e) {
       const err = e as Error;
       toast({
@@ -46,6 +55,46 @@ export function ProgramAdminsSection({
       setLoading(false);
     }
   }, [programSlug, signAuthHeader, toast]);
+
+  const handleInvite = async () => {
+    const email = inviteEmail.trim();
+    if (!EMAIL_RE.test(email)) {
+      toast({ title: "Enter a valid email", variant: "destructive" });
+      return;
+    }
+    setInviting(true);
+    try {
+      const authHeader = await signAuthHeader();
+      const res = await api.inviteProgramAdminEmail(programSlug, email, authHeader);
+      setEmailAdmins((prev) =>
+        prev.some((a) => a.email === res.data.email) ? prev : [...prev, res.data],
+      );
+      setInviteEmail("");
+      toast({
+        title: "Admin invited",
+        description: res.emailSent
+          ? `Onboarding email sent to ${res.data.email}.`
+          : `Added, but no email went out (${res.emailReason ?? "email not configured"}). Share the sign-in link manually.`,
+      });
+    } catch (e) {
+      const msg = e instanceof ApiError ? e.message : (e as Error)?.message;
+      toast({ title: "Couldn't invite admin", description: msg || "Unknown error", variant: "destructive" });
+    } finally {
+      setInviting(false);
+    }
+  };
+
+  const handleRemoveEmail = async (admin: ApiProgramAdminEmail) => {
+    try {
+      const authHeader = await signAuthHeader();
+      await api.removeProgramAdminEmail(programSlug, admin.email, authHeader);
+      setEmailAdmins((prev) => prev.filter((a) => a.email !== admin.email));
+      toast({ title: "Admin removed" });
+    } catch (e) {
+      const err = e as Error;
+      toast({ title: "Couldn't remove admin", description: err?.message || "Unknown error", variant: "destructive" });
+    }
+  };
 
   useEffect(() => {
     if (programSlug) load();
@@ -169,6 +218,62 @@ export function ProgramAdminsSection({
           </button>
         </div>
       )}
+
+      {/* Email admins — onboard non-wallet partners via an email magic link. */}
+      <div className="mt-4 border-t border-hairline pt-4">
+        <div className="mb-2 flex items-baseline justify-between gap-3">
+          <div className="label-hw text-display">·EMAIL ADMINS</div>
+          <p className="label-hw-dim hidden md:block">
+            View-only. They sign in with their email, no wallet needed.
+          </p>
+        </div>
+
+        {emailAdmins.length === 0 ? (
+          <p className="label-hw-dim py-1">No email admins yet.</p>
+        ) : (
+          <ul className="divide-y divide-hairline">
+            {emailAdmins.map((a) => (
+              <li key={a.email} className="flex items-center justify-between gap-3 py-2">
+                <div className="min-w-0 flex items-center gap-2">
+                  <Mail className="h-3.5 w-3.5 text-label-mid shrink-0" aria-hidden="true" />
+                  <span className="truncate font-mono text-[12px] text-display">{a.email}</span>
+                </div>
+                {isGlobalAdmin && (
+                  <button
+                    type="button"
+                    onClick={() => handleRemoveEmail(a)}
+                    aria-label={`Remove ${a.email}`}
+                    className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-destructive hover:bg-destructive/10 px-2 py-1 inline-flex items-center gap-1"
+                  >
+                    <Trash2 className="h-3 w-3" />
+                    REMOVE
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {isGlobalAdmin && (
+          <div className="mt-3 flex flex-col gap-2 md:flex-row">
+            <input
+              type="email"
+              placeholder="invitee@email.com"
+              value={inviteEmail}
+              onChange={(e) => setInviteEmail(e.target.value)}
+              className="md:flex-1 font-mono text-[12px] bg-panel-deep border border-hairline text-display px-2 py-1.5 focus:outline-none focus:border-display"
+            />
+            <button
+              type="button"
+              onClick={handleInvite}
+              disabled={inviting || !inviteEmail.trim()}
+              className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-4 py-1.5 inline-flex items-center justify-center gap-1.5"
+            >
+              {inviting ? "INVITING…" : "INVITE BY EMAIL"}
+            </button>
+          </div>
+        )}
+      </div>
     </section>
   );
 }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -203,6 +203,14 @@ export type ApiProgramAdmin = {
   createdAt: string;
 };
 
+/** An email-keyed program admin (social sign-in onboarding). View-only. */
+export type ApiProgramAdminEmail = {
+  programId: string;
+  email: string;
+  invitedBy: string | null;
+  createdAt: string;
+};
+
 /** One row in the unified program inbox (signups + applications merged). */
 export type ApiInboxEntry = {
   source: "signup" | "application";
@@ -1622,6 +1630,55 @@ export const api = {
     if (USE_MOCK_DATA) return;
     await request(
       `/programs/${encodeURIComponent(slug)}/admins/${encodeURIComponent(wallet)}?chain=${encodeURIComponent(walletChain)}`,
+      {
+        method: "DELETE",
+        headers: adminAuthHeaders(authHeader),
+      },
+    );
+  },
+
+  // --- Email-keyed program admins (social sign-in onboarding) ---
+
+  listProgramAdminEmails: async (
+    slug: string,
+    authHeader: AdminAuthArg,
+  ): Promise<{ status: string; data: ApiProgramAdminEmail[] }> => {
+    if (USE_MOCK_DATA) {
+      return { status: "success", data: [] };
+    }
+    return request(`/programs/${encodeURIComponent(slug)}/admins/emails`, {
+      headers: adminAuthHeaders(authHeader),
+    });
+  },
+
+  inviteProgramAdminEmail: async (
+    slug: string,
+    email: string,
+    authHeader: AdminAuthArg,
+  ): Promise<{ status: string; data: ApiProgramAdminEmail; emailSent: boolean; emailReason: string | null }> => {
+    if (USE_MOCK_DATA) {
+      return {
+        status: "success",
+        data: { programId: slug, email: email.trim().toLowerCase(), invitedBy: null, createdAt: new Date().toISOString() },
+        emailSent: false,
+        emailReason: "mock_mode",
+      };
+    }
+    return request(`/programs/${encodeURIComponent(slug)}/admins/invite`, {
+      method: "POST",
+      headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
+      body: JSON.stringify({ email }),
+    });
+  },
+
+  removeProgramAdminEmail: async (
+    slug: string,
+    email: string,
+    authHeader: AdminAuthArg,
+  ): Promise<void> => {
+    if (USE_MOCK_DATA) return;
+    await request(
+      `/programs/${encodeURIComponent(slug)}/admins/emails/${encodeURIComponent(email)}`,
       {
         method: "DELETE",
         headers: adminAuthHeaders(authHeader),

--- a/client/src/lib/auth/useSocialAuth.ts
+++ b/client/src/lib/auth/useSocialAuth.ts
@@ -1,0 +1,73 @@
+import { useCallback, useEffect, useState } from "react";
+import { supabase, isSupabaseConfigured } from "@/lib/supabase";
+import type { AdminAuthArg } from "@/lib/api";
+
+/**
+ * Social (email magic link) auth via Supabase. Parallel to useWalletAuth: it
+ * tracks the current Supabase session and exposes the access token, which admin
+ * API calls pass as `x-supabase-token` (via authHeader()). The server checks
+ * the verified email against program_admin_emails for view access.
+ *
+ * Degrades gracefully when Supabase isn't configured (isAvailable === false).
+ */
+export function useSocialAuth() {
+  const [token, setToken] = useState<string | null>(null);
+  const [email, setEmail] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!supabase) {
+      setLoading(false);
+      return;
+    }
+    let active = true;
+    supabase.auth.getSession().then(({ data }) => {
+      if (!active) return;
+      setToken(data.session?.access_token ?? null);
+      setEmail(data.session?.user?.email ?? null);
+      setLoading(false);
+    });
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      setToken(session?.access_token ?? null);
+      setEmail(session?.user?.email ?? null);
+    });
+    return () => {
+      active = false;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
+
+  /** Send a one-time magic-link to `address`; they return to `redirectTo`. */
+  const signInWithEmail = useCallback(async (address: string, redirectTo?: string) => {
+    if (!supabase) throw new Error("Email sign-in is not configured.");
+    const { error } = await supabase.auth.signInWithOtp({
+      email: address.trim(),
+      options: { emailRedirectTo: redirectTo ?? window.location.href },
+    });
+    if (error) throw error;
+  }, []);
+
+  const signOut = useCallback(async () => {
+    if (!supabase) return;
+    await supabase.auth.signOut();
+    setToken(null);
+    setEmail(null);
+  }, []);
+
+  /** Header arg for the API client when a social session is active. */
+  const authHeader = useCallback(
+    (): AdminAuthArg => (token ? { "x-supabase-token": token } : undefined),
+    [token],
+  );
+
+  return {
+    isAvailable: isSupabaseConfigured,
+    loading,
+    token,
+    email,
+    isAuthed: !!token,
+    signInWithEmail,
+    signOut,
+    authHeader,
+  };
+}

--- a/client/src/lib/supabase.ts
+++ b/client/src/lib/supabase.ts
@@ -1,0 +1,15 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+// Client-side Supabase Auth (email magic link) for social sign-in. The server
+// still authorizes — it verifies the access token and checks the email against
+// program_admin_emails. This client only establishes WHO signed in.
+//
+// Null when the project isn't configured (local dev / preview / mock mode), so
+// callers degrade to "email sign-in unavailable" instead of crashing.
+const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
+const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
+
+export const supabase: SupabaseClient | null =
+  url && anonKey ? createClient(url, anonKey) : null;
+
+export const isSupabaseConfigured = supabase !== null;

--- a/client/src/pages/AdminProgramPage.tsx
+++ b/client/src/pages/AdminProgramPage.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
+import { Loader2 } from "lucide-react";
 import { Navigation } from "@/components/Navigation";
 import { HardwareToggle } from "@/components/hardware-toggle";
 import { useWalletAuth } from "@/lib/auth/useWalletAuth";
+import { useSocialAuth } from "@/lib/auth/useSocialAuth";
 import { isAdmin as checkIsAdmin, ADMIN_ADDRESSES } from "@/lib/constants";
 import {
   api,
@@ -55,6 +57,17 @@ const AdminProgramPage = () => {
   const { getAdminBearerHeaders } = auth;
   const getAdminAuth = useCallback(() => getAdminBearerHeaders(), [getAdminBearerHeaders]);
 
+  // Social (email magic link) auth — a parallel, view-only path. An invited
+  // email admin signs in here and reads their program; the server gates access
+  // on program_admin_emails. Wallet auth always takes precedence when present.
+  const social = useSocialAuth();
+  const [isSocialViewer, setIsSocialViewer] = useState(false);
+  const [socialProbing, setSocialProbing] = useState(false);
+  const [socialError, setSocialError] = useState<string | null>(null);
+  const [socialEmailInput, setSocialEmailInput] = useState("");
+  const [sendingLink, setSendingLink] = useState(false);
+  const [linkSent, setLinkSent] = useState(false);
+
   const [program, setProgram] = useState<ApiProgram | null>(null);
   const [applications, setApplications] = useState<ApiProgramApplication[]>([]);
   const [loading, setLoading] = useState(true);
@@ -92,6 +105,73 @@ const AdminProgramPage = () => {
       toast({
         title: "Couldn't load applications",
         description: err?.message || "Unknown error",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const sendMagicLink = async () => {
+    const email = socialEmailInput.trim();
+    if (!email) return;
+    setSendingLink(true);
+    try {
+      await social.signInWithEmail(email, window.location.href);
+      setLinkSent(true);
+      toast({ title: "Check your inbox", description: `We sent a sign-in link to ${email}.` });
+    } catch (e) {
+      toast({
+        title: "Couldn't send sign-in link",
+        description: (e as Error)?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setSendingLink(false);
+    }
+  };
+
+  // After a social session appears (e.g. returning from the magic link), probe
+  // the program: a 200 means the email is authorized, a 403 means it isn't.
+  useEffect(() => {
+    if (!slug || !program || isAdminWallet) {
+      setIsSocialViewer(false);
+      return;
+    }
+    if (!social.isAuthed || !social.token) {
+      setIsSocialViewer(false);
+      return;
+    }
+    let active = true;
+    setSocialProbing(true);
+    setSocialError(null);
+    api
+      .listProgramApplications(slug, { "x-supabase-token": social.token })
+      .then((res) => {
+        if (!active) return;
+        setApplications(res.data);
+        setIsSocialViewer(true);
+      })
+      .catch((e: unknown) => {
+        if (!active) return;
+        setIsSocialViewer(false);
+        if (e instanceof ApiError && e.status === 403) {
+          setSocialError(`${social.email ?? "This email"} is not an admin for this program.`);
+        } else {
+          setSocialError((e as Error)?.message ?? "Couldn't load this program.");
+        }
+      })
+      .finally(() => { if (active) setSocialProbing(false); });
+    return () => { active = false; };
+  }, [slug, program, isAdminWallet, social.isAuthed, social.token, social.email]);
+
+  const refreshSocial = async () => {
+    if (!slug || !social.token) return;
+    try {
+      const res = await api.listProgramApplications(slug, { "x-supabase-token": social.token });
+      setApplications(res.data);
+    } catch (e) {
+      toast({
+        title: "Couldn't refresh",
+        description: (e as Error)?.message || "Unknown error",
         variant: "destructive",
       });
     }
@@ -197,37 +277,7 @@ const AdminProgramPage = () => {
               </div>
             </header>
 
-            {!isAdminWallet ? (
-              <div className="panel p-6">
-                <div className="label-hw text-display mb-3">·ADMIN WALLET REQUIRED</div>
-                <p className="text-body text-sm mb-4">
-                  Connect a global admin wallet, or a wallet that has been assigned to this program via the admins panel.
-                </p>
-                <button
-                  type="button"
-                  onClick={connectWallet}
-                  disabled={auth.isConnecting}
-                  className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-4 py-2"
-                >
-                  {auth.isConnecting ? "CONNECTING…" : "CONNECT ADMIN WALLET"}
-                </button>
-                {errorData && (
-                  <div className="mt-4 lcd p-3 space-y-2">
-                    <div className="label-hw text-destructive">·NOT AN ADMIN</div>
-                    {errorData.walletAddresses.length > 0 && (
-                      <div>
-                        <div className="label-hw-dim mb-1">Your wallet addresses:</div>
-                        <ul className="space-y-1">
-                          {errorData.walletAddresses.map((a, i) => (
-                            <li key={i} className="font-mono text-[11px] text-body break-all">{a}</li>
-                          ))}
-                        </ul>
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            ) : (
+            {isAdminWallet ? (
               <>
                 <ProgramAdminsSection
                   programSlug={program.slug}
@@ -291,6 +341,127 @@ const AdminProgramPage = () => {
                   </div>
                 )}
               </>
+            ) : isSocialViewer ? (
+              <>
+                <div className="panel px-3 py-2.5 mb-3 flex flex-wrap items-center gap-2">
+                  <span className="lcd inline-flex items-center gap-2 px-3 py-1.5">
+                    <span className="led led-sm" aria-hidden="true" />
+                    <span className="label-hw text-display">VIEW-ONLY</span>
+                  </span>
+                  <span className="label-hw-dim truncate min-w-0">{social.email}</span>
+                  <div className="flex-1" />
+                  <HardwareToggle options={FILTER_OPTIONS} value={filter} onChange={setFilter} />
+                  <button
+                    type="button"
+                    onClick={refreshSocial}
+                    className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep px-3 py-1.5"
+                  >
+                    REFRESH
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => social.signOut()}
+                    className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-label-dim hover:text-display px-3 py-1.5"
+                  >
+                    SIGN OUT
+                  </button>
+                </div>
+
+                {filtered.length === 0 ? (
+                  <div className="panel px-4 py-10 text-center">
+                    <div className="label-hw text-display mb-2">·NO APPLICATIONS</div>
+                    <p className="label-hw-dim">No applications match the current filter.</p>
+                  </div>
+                ) : (
+                  <div className="space-y-3">
+                    {filtered.map((a) => (
+                      <ApplicationCard
+                        key={a.id}
+                        application={a}
+                        programSlug={program.slug}
+                        readOnly
+                      />
+                    ))}
+                  </div>
+                )}
+              </>
+            ) : (
+              <div className="panel p-6 space-y-5">
+                <div>
+                  <div className="label-hw text-display mb-3">·SIGN IN TO ADMINISTER</div>
+                  <p className="text-body text-sm mb-4">
+                    Connect a global or per-program admin wallet, or sign in with the email you were invited with.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={connectWallet}
+                    disabled={auth.isConnecting}
+                    className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-4 py-2"
+                  >
+                    {auth.isConnecting ? "CONNECTING…" : "CONNECT ADMIN WALLET"}
+                  </button>
+                  {errorData && (
+                    <div className="mt-4 lcd p-3 space-y-2">
+                      <div className="label-hw text-destructive">·NOT AN ADMIN</div>
+                      {errorData.walletAddresses.length > 0 && (
+                        <div>
+                          <div className="label-hw-dim mb-1">Your wallet addresses:</div>
+                          <ul className="space-y-1">
+                            {errorData.walletAddresses.map((a, i) => (
+                              <li key={i} className="font-mono text-[11px] text-body break-all">{a}</li>
+                            ))}
+                          </ul>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+
+                <div className="border-t border-hairline pt-5">
+                  <div className="label-hw text-display mb-2">·SIGN IN WITH EMAIL</div>
+                  {!social.isAvailable ? (
+                    <p className="label-hw-dim">Email sign-in isn't configured in this environment.</p>
+                  ) : socialProbing ? (
+                    <div className="flex items-center gap-2 label-hw-dim">
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" /> CHECKING ACCESS…
+                    </div>
+                  ) : social.isAuthed ? (
+                    <div className="lcd p-3 space-y-2">
+                      <div className="label-hw text-destructive">·NOT AUTHORIZED</div>
+                      <p className="label-hw-dim">
+                        {socialError ?? `${social.email} is not an admin for this program.`}
+                      </p>
+                      <button
+                        type="button"
+                        onClick={() => social.signOut()}
+                        className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep px-3 py-1.5"
+                      >
+                        SIGN OUT
+                      </button>
+                    </div>
+                  ) : linkSent ? (
+                    <p className="label-hw-dim">Check your inbox for a one-time sign-in link.</p>
+                  ) : (
+                    <div className="flex flex-col gap-2 md:flex-row">
+                      <input
+                        type="email"
+                        placeholder="you@email.com"
+                        value={socialEmailInput}
+                        onChange={(e) => setSocialEmailInput(e.target.value)}
+                        className="md:flex-1 font-mono text-[12px] bg-panel-deep border border-hairline text-display px-2 py-1.5 focus:outline-none focus:border-display"
+                      />
+                      <button
+                        type="button"
+                        onClick={sendMagicLink}
+                        disabled={sendingLink || !socialEmailInput.trim()}
+                        className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-4 py-2"
+                      >
+                        {sendingLink ? "SENDING…" : "EMAIL ME A LINK"}
+                      </button>
+                    </div>
+                  )}
+                </div>
+              </div>
             )}
           </>
         ) : null}

--- a/server/.env.example
+++ b/server/.env.example
@@ -44,6 +44,10 @@ AUTHORIZED_SIGNERS=
 RESEND_API_KEY=
 RESEND_FROM_EMAIL=
 
+# Public base URL of the client, used to build links in outbound email (e.g. the
+# program-admin onboarding link). Defaults to the prod URL if unset.
+FRONTEND_URL=https://stadium.joinwebzero.com
+
 # Offline data tooling (Mongo via Mongoose) — only needed for `npm run seed:dev`,
 # `db:migrate`, `db:reset`, `list:winners-zero-paid`, and other scripts/*.js.
 # Not used by the running API.

--- a/server/api/controllers/program.controller.js
+++ b/server/api/controllers/program.controller.js
@@ -8,6 +8,8 @@ import projectService from '../services/project.service.js';
 import notificationService from '../services/notification.service.js';
 import nonMemberApplicationService, { validateNonMemberApplication } from '../services/non-member-application.service.js';
 import programAdminRepository from '../repositories/program-admin.repository.js';
+import programAdminEmailRepository from '../repositories/program-admin-email.repository.js';
+import programAdminInviteService from '../services/program-admin-invite.service.js';
 import programSignupRepository from '../repositories/program-signup.repository.js';
 import { validateApplicationFields } from '../utils/application-fields.validator.js';
 import { validateProgram, validateSponsor } from '../utils/validation.js';
@@ -15,6 +17,7 @@ import { randomUUID } from 'node:crypto';
 import logger from '../utils/logger.js';
 
 const VALID_CHAINS = ['substrate', 'ethereum', 'solana'];
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 class ProgramController {
   async list(req, res) {
@@ -409,6 +412,92 @@ class ProgramController {
     } catch (error) {
       console.error('❌ Error removing program admin:', error);
       res.status(500).json({ status: 'error', message: 'Failed to remove program admin' });
+    }
+  }
+
+  // --- Email-keyed program admins (social sign-in onboarding) ---
+
+  async listAdminEmails(req, res) {
+    try {
+      const { slug } = req.params;
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const admins = await programAdminEmailRepository.list(program.id);
+      res.status(200).json({ status: 'success', data: admins });
+    } catch (error) {
+      console.error('❌ Error listing email admins:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to list email admins' });
+    }
+  }
+
+  async inviteAdminEmail(req, res) {
+    try {
+      const { slug } = req.params;
+      const email = typeof req.body?.email === 'string' ? req.body.email.trim() : '';
+      if (!email || !EMAIL_RE.test(email)) {
+        return res.status(422).json({ status: 'error', message: 'A valid email is required' });
+      }
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      const added = await programAdminEmailRepository.add(program.id, email, req.user?.address ?? null);
+
+      // The grant has landed; emailing the invite is best-effort so a missing
+      // Resend config (or a transient send error) never loses the grant.
+      let emailSent = false;
+      let emailReason = null;
+      try {
+        const result = await programAdminInviteService.send({
+          email: added.email,
+          programName: program.name,
+          slug: program.slug,
+        });
+        emailSent = result.ok;
+        emailReason = result.ok ? null : result.reason;
+      } catch (err) {
+        emailReason = 'send_failed';
+        logger.error('Program admin invite email failed:', err);
+      }
+
+      res.status(201).json({ status: 'success', data: added, emailSent, emailReason });
+      auditLog.logSafe({
+        programId: program.id,
+        actor: { chain: req.user?.chain, wallet: req.user?.address },
+        action: 'admin.invite_email',
+        targetType: 'admin',
+        targetId: `email:${added.email}`,
+        metadata: { emailSent },
+      });
+    } catch (error) {
+      console.error('❌ Error inviting email admin:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to invite admin' });
+    }
+  }
+
+  async removeAdminEmail(req, res) {
+    try {
+      const { slug, email } = req.params;
+      const target = decodeURIComponent(email);
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      await programAdminEmailRepository.remove(program.id, target);
+      res.status(204).end();
+      auditLog.logSafe({
+        programId: program.id,
+        actor: { chain: req.user?.chain, wallet: req.user?.address },
+        action: 'admin.remove_email',
+        targetType: 'admin',
+        targetId: `email:${target}`,
+        metadata: null,
+      });
+    } catch (error) {
+      console.error('❌ Error removing email admin:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to remove email admin' });
     }
   }
 

--- a/server/api/middleware/__tests__/auth.middleware.test.js
+++ b/server/api/middleware/__tests__/auth.middleware.test.js
@@ -74,6 +74,20 @@ vi.mock('../../repositories/global-admin.repository.js', () => ({
   },
 }));
 
+vi.mock('../../repositories/program-admin-email.repository.js', () => ({
+  default: {
+    isAdminByEmail: vi.fn().mockResolvedValue(false),
+    list: vi.fn(),
+    add: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock('../../auth/supabaseUser.js', () => ({
+  getSupabaseUser: vi.fn().mockResolvedValue(null),
+  extractSupabaseToken: () => null,
+}));
+
 // Now import what we need
 import { verifySIWS, parseMessage } from '@talismn/siws';
 import { signatureVerify, decodeAddress } from '@polkadot/util-crypto';

--- a/server/api/middleware/__tests__/program-viewer.middleware.test.js
+++ b/server/api/middleware/__tests__/program-viewer.middleware.test.js
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the SIWS / chain stack so importing the middleware doesn't pull real
+// crypto, and so the wallet fallback path can run without a signature.
+vi.mock('@talismn/siws', () => ({
+  verifySIWS: vi.fn(),
+  parseMessage: vi.fn(),
+  SiwsMessage: vi.fn(),
+}));
+vi.mock('@polkadot/util-crypto', () => ({
+  cryptoWaitReady: vi.fn().mockResolvedValue(true),
+  signatureVerify: vi.fn(),
+  decodeAddress: vi.fn(),
+}));
+vi.mock('@polkadot/util', () => ({ u8aToHex: vi.fn() }));
+vi.mock('chalk', () => {
+  const passthrough = (s) => s;
+  return { default: new Proxy(passthrough, { get: () => passthrough }) };
+});
+vi.mock('dotenv', () => ({ default: { config: vi.fn() } }));
+vi.mock('../../../config/polkadot-config.js', () => ({
+  getAuthorizedAddresses: () => ['5FakeAdmin1'],
+  CURRENT_MULTISIG: '5FakeMultisig',
+  NETWORK_CONFIG: { networkName: 'testnet', environment: 'development' },
+}));
+vi.mock('../../auth/authorizedSigners.js', () => ({
+  isAuthorizedSigner: vi.fn(),
+  authorizedSignerCount: () => 1,
+}));
+vi.mock('../../services/project.service.js', () => ({ default: { getProjectById: vi.fn() } }));
+vi.mock('../../auth/nonceStore.js', () => ({ consumeNonce: vi.fn() }));
+vi.mock('../../repositories/program.repository.js', () => ({ default: { findBySlug: vi.fn() } }));
+vi.mock('../../repositories/program-admin.repository.js', () => ({ default: { isAdmin: vi.fn() } }));
+vi.mock('../../repositories/app-admin.repository.js', () => ({
+  default: { isAppAdmin: vi.fn().mockResolvedValue(false) },
+}));
+vi.mock('../../repositories/global-admin.repository.js', () => ({
+  default: { isGlobalAdmin: vi.fn().mockResolvedValue(false) },
+}));
+
+// The two pieces this middleware adds on top of requireProgramAdmin.
+vi.mock('../../auth/supabaseUser.js', () => ({
+  getSupabaseUser: vi.fn(),
+  extractSupabaseToken: (req) => req.headers?.['x-supabase-token'] ?? null,
+}));
+vi.mock('../../repositories/program-admin-email.repository.js', () => ({
+  default: { isAdminByEmail: vi.fn() },
+}));
+
+const { requireProgramViewer } = await import('../auth.middleware.js');
+const programRepository = (await import('../../repositories/program.repository.js')).default;
+const programAdminEmailRepository = (
+  await import('../../repositories/program-admin-email.repository.js')
+).default;
+const { getSupabaseUser } = await import('../../auth/supabaseUser.js');
+
+function makeReq(overrides = {}) {
+  return { method: 'GET', originalUrl: '/api/test', headers: {}, params: { slug: 'dogfooding' }, ...overrides };
+}
+function makeRes() {
+  const res = {
+    statusCode: null,
+    body: null,
+    ended: false,
+    status(code) { res.statusCode = code; return res; },
+    json(data) { res.body = data; return res; },
+    end() { res.ended = true; return res; },
+  };
+  return res;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  programRepository.findBySlug.mockResolvedValue({ id: 'prog-1', slug: 'dogfooding', name: 'Dogfooding' });
+});
+
+describe('requireProgramViewer — social (email) path', () => {
+  it('passes a valid Supabase token whose email is a program admin (view-only)', async () => {
+    getSupabaseUser.mockResolvedValue({ id: 'sb-user-1', email: 'Partner@Example.com' });
+    programAdminEmailRepository.isAdminByEmail.mockResolvedValue(true);
+
+    const req = makeReq({ headers: { 'x-supabase-token': 'valid-token' } });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireProgramViewer('slug')(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBeNull();
+    expect(req.user).toMatchObject({
+      email: 'Partner@Example.com',
+      programId: 'prog-1',
+      viewOnly: true,
+      isGlobalAdmin: false,
+    });
+  });
+
+  it('404s when the program does not exist (token valid)', async () => {
+    getSupabaseUser.mockResolvedValue({ id: 'sb-user-1', email: 'partner@example.com' });
+    programRepository.findBySlug.mockResolvedValue(null);
+
+    const req = makeReq({ headers: { 'x-supabase-token': 'valid-token' } });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireProgramViewer('slug')(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(404);
+  });
+
+  it('falls back to wallet auth (and is rejected) when the email is not an admin', async () => {
+    getSupabaseUser.mockResolvedValue({ id: 'sb-user-1', email: 'stranger@example.com' });
+    programAdminEmailRepository.isAdminByEmail.mockResolvedValue(false);
+
+    // No x-siws-auth header -> wallet path denies.
+    const req = makeReq({ headers: { 'x-supabase-token': 'valid-token' } });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireProgramViewer('slug')(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBeGreaterThanOrEqual(400);
+  });
+
+  it('falls back to wallet auth when the Supabase token is invalid', async () => {
+    getSupabaseUser.mockResolvedValue(null);
+
+    const req = makeReq({ headers: { 'x-supabase-token': 'garbage' } });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireProgramViewer('slug')(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBeGreaterThanOrEqual(400);
+    expect(programAdminEmailRepository.isAdminByEmail).not.toHaveBeenCalled();
+  });
+
+  it('falls back to wallet auth when no Supabase token is present', async () => {
+    const req = makeReq({ headers: {} });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireProgramViewer('slug')(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(getSupabaseUser).not.toHaveBeenCalled();
+    expect(res.statusCode).toBeGreaterThanOrEqual(400);
+  });
+
+  it('400s when the slug param is missing', async () => {
+    const req = makeReq({ params: {} });
+    const res = makeRes();
+    const next = vi.fn();
+
+    await requireProgramViewer('slug')(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/server/api/middleware/__tests__/wallet-contact.middleware.test.js
+++ b/server/api/middleware/__tests__/wallet-contact.middleware.test.js
@@ -57,6 +57,15 @@ vi.mock('../../repositories/program-admin.repository.js', () => ({
   default: { isAdmin: vi.fn() },
 }));
 
+vi.mock('../../repositories/program-admin-email.repository.js', () => ({
+  default: { isAdminByEmail: vi.fn().mockResolvedValue(false), list: vi.fn(), add: vi.fn(), remove: vi.fn() },
+}));
+
+vi.mock('../../auth/supabaseUser.js', () => ({
+  getSupabaseUser: vi.fn().mockResolvedValue(null),
+  extractSupabaseToken: () => null,
+}));
+
 import { parseMessage, verifySIWS } from '@talismn/siws';
 import { signatureVerify, decodeAddress } from '@polkadot/util-crypto';
 import { u8aToHex } from '@polkadot/util';

--- a/server/api/middleware/auth.middleware.js
+++ b/server/api/middleware/auth.middleware.js
@@ -25,8 +25,10 @@ import { consumeNonce } from '../auth/nonceStore.js';
 import { extractBearerToken, verifySessionToken } from '../auth/sessionToken.js';
 import programRepository from '../repositories/program.repository.js';
 import programAdminRepository from '../repositories/program-admin.repository.js';
+import programAdminEmailRepository from '../repositories/program-admin-email.repository.js';
 import appAdminRepository from '../repositories/app-admin.repository.js';
 import globalAdminRepository from '../repositories/global-admin.repository.js';
+import { getSupabaseUser, extractSupabaseToken } from '../auth/supabaseUser.js';
 
 /**
  * Admin = signer is an app_admin (tier 0) OR a global_admin (tier 1)
@@ -507,6 +509,55 @@ export const requireProgramAdmin = (slugParam = 'slug') => async (req, res, next
     logError(`Database error during program-admin check: ${err.message}`);
     return res.status(500).json({ status: 'error', message: 'Internal server error during authorization' });
   }
+};
+
+/**
+ * Read-only program access for social (email) admins, with a wallet fallback.
+ *
+ * First tries the social path: a valid Supabase Auth token (`x-supabase-token`)
+ * whose verified email is listed in `program_admin_emails` for this program.
+ * That grants VIEW access only (`req.user.viewOnly = true`) — it never unlocks
+ * the mutation routes, which keep the stricter wallet-keyed `requireProgramAdmin`
+ * / `requireAdmin` gates. If there's no valid email-admin token, behavior is
+ * identical to `requireProgramAdmin` (wallet admins are unaffected).
+ *
+ * Apply this only to GET/read routes a viewing admin needs.
+ */
+export const requireProgramViewer = (slugParam = 'slug') => async (req, res, next) => {
+  const slug = req.params?.[slugParam];
+  if (!slug || typeof slug !== 'string') {
+    return res.status(400).json({ status: 'error', message: `Program ${slugParam} is required` });
+  }
+
+  const token = extractSupabaseToken(req);
+  if (token) {
+    const user = await getSupabaseUser(token);
+    if (user?.email) {
+      try {
+        const program = await programRepository.findBySlug(slug);
+        if (!program) {
+          return res.status(404).json({ status: 'error', message: 'Program not found' });
+        }
+        if (await programAdminEmailRepository.isAdminByEmail(program.id, user.email)) {
+          logSuccess(`Email admin ${user.email} viewing program "${slug}".`);
+          req.user = {
+            email: user.email,
+            supabaseUserId: user.id,
+            programSlug: slug,
+            programId: program.id,
+            isGlobalAdmin: false,
+            viewOnly: true,
+          };
+          return next();
+        }
+      } catch (err) {
+        logError(`Email-admin viewer check failed, falling back to wallet: ${err.message}`);
+      }
+    }
+  }
+
+  // No valid email-admin token — defer entirely to the wallet program-admin gate.
+  return requireProgramAdmin(slugParam)(req, res, next);
 };
 
 /**

--- a/server/api/repositories/program-admin-email.repository.js
+++ b/server/api/repositories/program-admin-email.repository.js
@@ -1,0 +1,70 @@
+import { supabase } from '../../db.js';
+
+// Emails are stored normalized (trimmed + lowercased) so lookups against a
+// Supabase-verified email are case-insensitive and the PK stays stable.
+const normalizeEmail = (email) =>
+  typeof email === 'string' ? email.trim().toLowerCase() : '';
+
+const transform = (row) => {
+  if (!row) return null;
+  return {
+    programId: row.program_id,
+    email: row.email,
+    invitedBy: row.invited_by,
+    createdAt: row.created_at,
+  };
+};
+
+class ProgramAdminEmailRepository {
+  async list(programId) {
+    const { data, error } = await supabase
+      .from('program_admin_emails')
+      .select('*')
+      .eq('program_id', programId)
+      .order('created_at', { ascending: true });
+    if (error) throw error;
+    return (data || []).map(transform);
+  }
+
+  async add(programId, email, invitedBy) {
+    const normalized = normalizeEmail(email);
+    if (!normalized) return null;
+    const { data, error } = await supabase
+      .from('program_admin_emails')
+      .upsert(
+        { program_id: programId, email: normalized, invited_by: invitedBy ?? null },
+        { onConflict: 'program_id,email' },
+      )
+      .select('*')
+      .single();
+    if (error) throw error;
+    return transform(data);
+  }
+
+  async remove(programId, email) {
+    const normalized = normalizeEmail(email);
+    if (!normalized) return false;
+    const { error } = await supabase
+      .from('program_admin_emails')
+      .delete()
+      .eq('program_id', programId)
+      .eq('email', normalized);
+    if (error) throw error;
+    return true;
+  }
+
+  async isAdminByEmail(programId, email) {
+    const normalized = normalizeEmail(email);
+    if (!normalized) return false;
+    const { data, error } = await supabase
+      .from('program_admin_emails')
+      .select('email')
+      .eq('program_id', programId)
+      .eq('email', normalized)
+      .maybeSingle();
+    if (error) throw error;
+    return !!data;
+  }
+}
+
+export default new ProgramAdminEmailRepository();

--- a/server/api/routes/program.routes.js
+++ b/server/api/routes/program.routes.js
@@ -3,6 +3,7 @@ import programController from '../controllers/program.controller.js';
 import requireAdmin, {
   requireTeamMemberOrAdminByBodyProject,
   requireProgramAdmin,
+  requireProgramViewer,
 } from '../middleware/auth.middleware.js';
 
 const router = Router();
@@ -28,7 +29,7 @@ router.patch('/:slug', requireAdmin, programController.updateProgram);
 // --- Phase 1 revamp: applications (#43, #47) ---
 router.get(
   '/:slug/applications',
-  requireProgramAdmin('slug'),
+  requireProgramViewer('slug'),
   programController.listApplicationsForProgram,
 );
 router.post(
@@ -45,8 +46,13 @@ router.patch(
 );
 
 // --- Phase 3 (#95): per-event admins ---
-// Read = program admin or global; mutate = global only.
-router.get('/:slug/admins', requireProgramAdmin('slug'), programController.listAdmins);
+// Read = program admin (wallet or email) or global; mutate = global only.
+// Email-admin routes are placed before the wallet :wallet param route so the
+// extra path segment ("emails") is matched first.
+router.post('/:slug/admins/invite', requireAdmin, programController.inviteAdminEmail);
+router.get('/:slug/admins/emails', requireProgramViewer('slug'), programController.listAdminEmails);
+router.delete('/:slug/admins/emails/:email', requireAdmin, programController.removeAdminEmail);
+router.get('/:slug/admins', requireProgramViewer('slug'), programController.listAdmins);
 router.post('/:slug/admins', requireAdmin, programController.addAdmin);
 router.delete('/:slug/admins/:wallet', requireAdmin, programController.removeAdmin);
 
@@ -69,7 +75,7 @@ router.delete(
 // All admin — same gate as applications. CSV body parsers stack with the
 // shared SIWS middleware: parser runs first to produce req.body, then
 // requireProgramAdmin reads x-siws-auth from headers.
-router.get('/:slug/signups', requireProgramAdmin('slug'), programController.listSignups);
+router.get('/:slug/signups', requireProgramViewer('slug'), programController.listSignups);
 router.post(
   '/:slug/signups/import',
   ...csvBody,
@@ -84,10 +90,10 @@ router.delete(
 
 // --- Inbox (merged signups + applications) ---
 // Admin-only — both source rows are gated; the merge inherits that.
-router.get('/:slug/inbox', requireProgramAdmin('slug'), programController.listInbox);
-router.get('/:slug/inbox.csv', requireProgramAdmin('slug'), programController.exportInboxCsv);
+router.get('/:slug/inbox', requireProgramViewer('slug'), programController.listInbox);
+router.get('/:slug/inbox.csv', requireProgramViewer('slug'), programController.exportInboxCsv);
 
 // --- Audit log (per-program activity feed) ---
-router.get('/:slug/audit-log', requireProgramAdmin('slug'), programController.listAuditLog);
+router.get('/:slug/audit-log', requireProgramViewer('slug'), programController.listAuditLog);
 
 export default router;

--- a/server/api/services/notification-templates/index.js
+++ b/server/api/services/notification-templates/index.js
@@ -2,12 +2,14 @@ import * as applicationAccepted from './application-accepted.js';
 import * as applicationRejected from './application-rejected.js';
 import * as m2Approved from './m2-approved.js';
 import * as m2ChangesRequested from './m2-changes-requested.js';
+import * as programAdminInvite from './program-admin-invite.js';
 
 const templates = {
   application_accepted: applicationAccepted,
   application_rejected: applicationRejected,
   m2_approved: m2Approved,
   m2_changes_requested: m2ChangesRequested,
+  program_admin_invite: programAdminInvite,
 };
 
 export function renderEmail(eventType, payload) {

--- a/server/api/services/notification-templates/program-admin-invite.js
+++ b/server/api/services/notification-templates/program-admin-invite.js
@@ -1,0 +1,23 @@
+import { escapeHtml } from './escape.js';
+
+export function subject(payload) {
+  return `You're an admin for ${payload.programName}`;
+}
+
+export function html(payload) {
+  const link = payload.link ?? 'https://stadium.joinwebzero.com/admin';
+  return `<p>You've been added as an admin for <strong>${escapeHtml(payload.programName)}</strong> on Stadium.</p>
+<p>Sign in with this email address (<strong>${escapeHtml(payload.email)}</strong>) to view your program:</p>
+<p><a href="${escapeHtml(link)}">Open ${escapeHtml(payload.programName)}</a></p>
+<p>No wallet or password needed. You'll get a one-time sign-in link by email.</p>`;
+}
+
+export function text(payload) {
+  const link = payload.link ?? 'https://stadium.joinwebzero.com/admin';
+  return `You've been added as an admin for ${payload.programName} on Stadium.
+
+Sign in with this email address (${payload.email}) to view your program:
+${link}
+
+No wallet or password needed. You'll get a one-time sign-in link by email.`;
+}

--- a/server/api/services/program-admin-invite.service.js
+++ b/server/api/services/program-admin-invite.service.js
@@ -1,0 +1,34 @@
+import { getEmailTransport } from './email-transport.js';
+import { renderEmail } from './notification-templates/index.js';
+
+const FRONTEND_URL = process.env.FRONTEND_URL || 'https://stadium.joinwebzero.com';
+
+class ProgramAdminInviteService {
+  /**
+   * Email a freshly-granted program admin their onboarding link. Best-effort:
+   * returns { ok:false, reason:'provider_not_configured' } when Resend is unset
+   * so the caller can surface that the grant landed but no email went out.
+   */
+  async send({ email, programName, slug }) {
+    const transport = await getEmailTransport();
+    if (!transport) return { ok: false, reason: 'provider_not_configured' };
+
+    const link = `${FRONTEND_URL}/admin/programs/${encodeURIComponent(slug)}`;
+    const { subject, html, text } = renderEmail('program_admin_invite', {
+      email,
+      programName,
+      link,
+    });
+
+    await transport.send({
+      from: process.env.RESEND_FROM_EMAIL,
+      to: email,
+      subject,
+      html,
+      text,
+    });
+    return { ok: true };
+  }
+}
+
+export default new ProgramAdminInviteService();

--- a/supabase/migrations/20260523000000_program_admin_emails.sql
+++ b/supabase/migrations/20260523000000_program_admin_emails.sql
@@ -1,0 +1,22 @@
+-- Email-keyed program admins (social sign-in onboarding).
+-- A program admin can be granted by EMAIL instead of wallet address: an
+-- existing admin invites someone by email, that person signs in via Supabase
+-- Auth (email magic link), and if their verified email is listed here for the
+-- program they get view access. View-only — wallet-keyed `program_admins` keep
+-- their existing mutation powers; this table only grants the read surface.
+--
+-- `email` is always stored lowercased + trimmed by the repository, so the
+-- (program_id, email) primary key is effectively case-insensitive.
+--
+-- Additive and idempotent — safe to re-run.
+
+CREATE TABLE IF NOT EXISTS program_admin_emails (
+  program_id  TEXT NOT NULL REFERENCES programs(id) ON DELETE CASCADE,
+  email       TEXT NOT NULL,
+  invited_by  TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (program_id, email)
+);
+
+CREATE INDEX IF NOT EXISTS idx_program_admin_emails_email
+  ON program_admin_emails(email);


### PR DESCRIPTION
## Summary
Lets an admin **add another admin by email** (no wallet). The invitee gets an onboarding email, signs into Stadium with an **email magic link** (Supabase Auth), and **views** their program. Lays the social-sign-in foundation reusable for builders later.

Per-program admins are **view-only** for social admins — mutations stay wallet/global-gated (matches today's model).

## Backend
- **Migration** `program_admin_emails(program_id, email, invited_by)` — email lowercased ⇒ case-insensitive PK.
- **Repository** `program-admin-email.repository.js` (list/add/remove/isAdminByEmail).
- **Middleware** `requireProgramViewer` — a valid `x-supabase-token` whose verified email is a program admin (or global) gets view access; else defers to the wallet `requireProgramAdmin`. Applied to **read routes only**; mutations unchanged.
- **Routes/controller:** `POST /:slug/admins/invite {email}` (global-gated), `GET /:slug/admins/emails`, `DELETE /:slug/admins/emails/:email`.
- **Onboarding email:** `program-admin-invite` Resend template + service (best-effort; missing key never loses the grant).
- **Env:** `FRONTEND_URL` documented.

## Client
- **Supabase client** (`lib/supabase.ts`, null when `VITE_SUPABASE_*` unset) + **`useSocialAuth`** hook (email magic link).
- **api**: `listProgramAdminEmails` / `inviteProgramAdminEmail` / `removeProgramAdminEmail`.
- **ProgramAdminsSection**: invite-by-email form + email-admin list (global admins), with email-sent feedback.
- **AdminProgramPage**: three-way gate — wallet admin (unchanged) / social **view-only** viewer (read-only applications) / sign-in panel (connect wallet **or** email magic link). `ApplicationCard` gains a `readOnly` prop.
- **Env:** `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` documented.

## Security
- Tokens verified server-side via `supabase.auth.getUser()`. Email matched case-insensitively. Email admins **cannot mutate**. Invite/remove gated to global admins.

## Verification
- [x] Server: `npm test` — 36 files, **291 pass** (+6 new middleware tests).
- [x] Client: `npm run build` (typecheck) + `npm run lint` clean.
- [x] Browser (mock): the admin program page sign-in panel renders and email sign-in **degrades gracefully** ("not configured") when `VITE_SUPABASE_*` is unset. No console errors.
- [ ] Full magic-link + invite round-trip needs real Supabase Auth + Resend config — not testable in mock/preview.

## Dependencies (dashboard, yours)
- **Supabase:** enable Email auth, set Site URL + redirect allow-list (include the admin program URLs), set `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` on Vercel.
- **Resend** configured so the onboarding email sends.

## Notes
- Adds `@supabase/supabase-js` to the client.
- Originally scoped as two PRs; folded into one cohesive feature PR.