### PR TITLE
fix(security): rate-limit the public non-member apply route

### DIFF
--- a/server/api/routes/program.routes.js
+++ b/server/api/routes/program.routes.js
@@ -1,4 +1,5 @@
 import { Router, text, json } from 'express';
+import rateLimit from 'express-rate-limit';
 import programController from '../controllers/program.controller.js';
 import requireAdmin, {
   requireTeamMemberOrAdminByBodyProject,
@@ -15,6 +16,21 @@ const csvBody = [
   text({ type: 'text/csv', limit: '5mb' }),
   json({ limit: '5mb' }),
 ];
+
+// The non-member apply route is public, unauthenticated, and emails the team.
+// The global apiLimiter (200/min) is too loose to stop someone flooding the
+// inbox, so cap this one route hard per IP. Generous enough for a real person
+// applying to a few programs (incl. retries); tight enough to kill a flood.
+const nonMemberApplyLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 5,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: {
+    status: 'error',
+    message: 'Too many applications from this network. Please try again later.',
+  },
+});
 
 // --- Public, Read-Only Routes ---
 router.get('/', programController.list);
@@ -38,7 +54,13 @@ router.post(
   programController.createApplication,
 );
 // Public: someone without a Stadium project applies; emails the team (no auth).
-router.post('/:slug/applications/non-member', programController.submitNonMemberApplication);
+// Rate-limited per IP (see nonMemberApplyLimiter) since it's an unauthenticated
+// email trigger.
+router.post(
+  '/:slug/applications/non-member',
+  nonMemberApplyLimiter,
+  programController.submitNonMemberApplication,
+);
 router.patch(
   '/:slug/applications/:applicationId',
   requireProgramAdmin('slug'),


### PR DESCRIPTION
## Summary
Adds a tight per-IP rate limit to the **public, unauthenticated** `POST /:slug/applications/non-member` route, which emails the team (`info@` cc `sacha@`) on every call.

Before, it was only covered by the global limiter (200/min), so one IP could flood the team inbox. Now: **5 requests per 15 min per IP** on this route only.

## Why this is the only app-level spam surface worth tightening
- It can **not** be used to spam arbitrary third parties — recipients are fixed (the applicant's address only appears in the email body), so it's not an open relay. Worst case was flooding *our own* inbox.
- All admin email triggers (program-admin invite, etc.) are already auth-gated.
- Magic-link sign-in emails are sent + rate-limited by Supabase, not this server.

## Change
- `server/api/routes/program.routes.js`: new `nonMemberApplyLimiter` (express-rate-limit, already a dep) applied to the non-member route. Generous for a real applicant (incl. retries), tight enough to kill a flood.

## Test plan
- [x] `npm test` — 36 files, 291 pass (no regressions).
- [ ] Manual: 6th submission from one IP within 15 min returns 429 with the friendly message.

## Related hardening (not in this PR — yours)
- Enable CAPTCHA (Turnstile/hCaptcha) on Supabase Auth to stop automated magic-link abuse.
- Add a DMARC DNS record for joinwebzero.com.