### PR TITLE
feat(landing): logo by STADIUM + looping audio + unified footer

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -1,14 +1,7 @@
-import { Link, Outlet, useLocation } from "react-router-dom";
+import { Outlet } from "react-router-dom";
+import { SiteFooter } from "@/components/SiteFooter";
 
 const Layout = () => {
-  const location = useLocation();
-
-  const isActive = (path: string) => {
-    if (path === "/" && location.pathname === "/") return true;
-    if (path !== "/" && location.pathname.startsWith(path)) return true;
-    return false;
-  };
-
   return (
     <div className="min-h-screen bg-background">
       {/* Skip to main content link for keyboard navigation */}
@@ -24,76 +17,7 @@ const Layout = () => {
         <Outlet />
       </main>
 
-      {/* Footer */}
-      <footer className="border-t bg-muted/50 py-8 mt-16">
-        <div className="container">
-          <div className="flex flex-col md:flex-row justify-between items-center space-y-4 md:space-y-0">
-            
-            
-            <div className="flex items-center space-x-2">
-              <span className="text-sm text-muted-foreground">
-                Created with ❤️ by the cracked devs at {' '}
-                <a
-                  href="https://www.joinwebzero.com/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:underline transition-colors"
-                >
-                  WebZero
-                </a>
-              </span>
-            </div>
-            <div className="flex flex-col sm:flex-row items-center justify-center gap-2 sm:gap-4">
-              <div className="flex flex-wrap items-center justify-center gap-2 sm:gap-4">
-                <a
-                  href="https://luma.com/blockspace-symmetry"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm text-primary hover:underline transition-colors"
-                >
-                  Blockspace Symmetry 2024
-                </a>
-                <span className="hidden sm:inline text-muted-foreground">•</span>
-                  <a
-                    href="https://luma.com/blockspacesynergy"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-sm text-primary hover:underline transition-colors"
-                  >
-                    Blockspace Synergy 2025
-                  </a>
-                  <span className="hidden sm:inline text-muted-foreground">•</span>
-                  <a
-                    href="https://luma.com/sub0hack"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-sm text-primary hover:underline transition-colors"
-                  >
-                    sub0 Hack 2025
-                  </a>
-              </div>
-            </div>
-            <div className="flex items-center space-x-4">
-              <Link
-                to="https://github.com/JoinWebZero/"
-                className="text-sm text-muted-foreground hover:text-primary transition-colors"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                GitHub
-              </Link>
-              <Link
-                to="https://x.com/JoinWebZero"
-                className="text-sm text-muted-foreground hover:text-primary transition-colors"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                X
-              </Link>
-            </div>
-          </div>
-        </div>
-      </footer>
+      <SiteFooter />
     </div>
   );
 };

--- a/client/src/components/Navigation.tsx
+++ b/client/src/components/Navigation.tsx
@@ -24,7 +24,12 @@ export function Navigation() {
             online label collapses to just the LED dot on small screens. */}
         <div className="flex items-center justify-between h-12 gap-2 sm:gap-4">
           <Link to="/" className="flex items-center gap-2 group flex-shrink-0">
-            <span className="led" aria-hidden="true" />
+            <img
+              src="/favicon.svg"
+              alt=""
+              aria-hidden="true"
+              className="h-5 w-5 sm:h-6 sm:w-6"
+            />
             <span className="font-mono font-bold text-[13px] sm:text-[15px] text-display tracking-wide">
               STADIUM <span className="text-label-dim font-normal text-[10px] sm:text-[11px]">|||</span>
             </span>

--- a/client/src/components/SiteFooter.tsx
+++ b/client/src/components/SiteFooter.tsx
@@ -1,0 +1,86 @@
+// Shared site footer. Single source of truth so the credit line + links don't
+// drift between Layout-wrapped pages and the standalone detail pages.
+export function SiteFooter() {
+  return (
+    <footer className="panel mt-16">
+      <div className="container mx-auto px-4 py-4 flex flex-col md:flex-row items-center justify-between gap-3 font-mono text-[10px] tracking-[0.14em] text-label-dim">
+        <div className="flex items-center gap-1">
+          <span>Created with ❤️ by</span>
+          <a
+            href="https://x.com/sachalansky"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-label-dim hover:text-display transition-colors"
+          >
+            sachalansky
+          </a>
+          <span>from</span>
+          <a
+            href="https://www.joinwebzero.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-label-dim hover:text-display transition-colors"
+          >
+            WebZero
+          </a>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-center gap-x-2.5 gap-y-1">
+          <a
+            href="https://luma.com/blockspace-symmetry"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-label-dim hover:text-display transition-colors"
+          >
+            Blockspace Symmetry 2024
+          </a>
+          <span className="text-hairline">·</span>
+          <a
+            href="https://luma.com/blockspacesynergy"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-label-dim hover:text-display transition-colors"
+          >
+            Blockspace Synergy 2025
+          </a>
+          <span className="text-hairline">·</span>
+          <a
+            href="https://luma.com/sub0hack"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-label-dim hover:text-display transition-colors"
+          >
+            sub0 Hack 2025
+          </a>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <a
+            href="https://github.com/StadiumDevs/stadium"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-label-dim hover:text-display transition-colors"
+          >
+            SOURCE
+          </a>
+          <a
+            href="https://github.com/JoinWebZero/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-label-dim hover:text-display transition-colors"
+          >
+            GITHUB
+          </a>
+          <a
+            href="https://x.com/JoinWebZero"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-label-dim hover:text-display transition-colors"
+          >
+            X
+          </a>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/client/src/components/audio/sound-cloud-audio.tsx
+++ b/client/src/components/audio/sound-cloud-audio.tsx
@@ -29,7 +29,7 @@ interface SCWidget {
 
 interface SCNamespace {
   Widget: ((iframe: HTMLIFrameElement) => SCWidget) & {
-    Events: { READY: string; PLAY: string; PLAY_PROGRESS: string };
+    Events: { READY: string; PLAY: string; PLAY_PROGRESS: string; FINISH: string };
   };
 }
 
@@ -130,6 +130,14 @@ export function SoundCloudAudioProvider({ children }: { children: React.ReactNod
           if (data && typeof data.currentPosition === "number") {
             setPositionMs(data.currentPosition);
           }
+        });
+        // Loop forever: when the profile's tracks run out, restart from the top so
+        // the music never stops (it already survives navigation — the iframe lives
+        // above the router).
+        widget.bind(window.SC.Widget.Events.FINISH, () => {
+          if (cancelled) return;
+          widget.seekTo(0);
+          widget.play();
         });
       })
       .catch(() => {

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -264,9 +264,16 @@ const HomePage = () => {
         {/* Hero */}
         <section className="pt-8 pb-10">
           <div className="label-hw-dim mb-3">·DIRECTORY / NOW SHOWING</div>
-          <h1 className="font-display text-6xl md:text-7xl lg:text-8xl uppercase tracking-tight text-display leading-[0.9] mb-4">
-            Stadium
-          </h1>
+          <div className="flex items-center gap-3 md:gap-4 mb-4">
+            <img
+              src="/favicon.svg"
+              alt="Stadium"
+              className="h-12 w-12 md:h-14 md:w-14 lg:h-16 lg:w-16 flex-shrink-0"
+            />
+            <h1 className="font-display text-6xl md:text-7xl lg:text-8xl uppercase tracking-tight text-display leading-[0.9]">
+              Stadium
+            </h1>
+          </div>
           <p className="text-body text-base md:text-lg max-w-xl leading-relaxed">
             Stuff people have built here.
           </p>

--- a/client/src/pages/ProjectDetailsPage.tsx
+++ b/client/src/pages/ProjectDetailsPage.tsx
@@ -30,6 +30,7 @@ import { api } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
 import { useWalletAuth } from '@/lib/auth/useWalletAuth';
 import { Navigation } from "@/components/Navigation";
+import { SiteFooter } from "@/components/SiteFooter";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { getCurrentProgramWeek } from "@/lib/projectUtils";
 import { calculateTotalPaidUSD, formatPaymentAmount, getTotalByCurrency } from "@/lib/paymentUtils";
@@ -1277,44 +1278,7 @@ const ProjectDetailsPage = () => {
           </div>
         </div>
       </main>
-      {/* Footer */}
-      <footer className="border-t bg-muted/50 py-8 mt-16">
-        <div className="container">
-          <div className="flex flex-col md:flex-row justify-between items-center space-y-4 md:space-y-0">
-            <div className="flex items-center space-x-2">
-            <span className="text-sm text-muted-foreground">
-                Created with ❤️ by the cracked devs at{' '}
-                <a
-                  href="https://www.joinwebzero.com/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary hover:underline transition-colors"
-                >
-                  WebZero
-                </a>
-              </span>
-            </div>
-            <div className="flex items-center space-x-4">
-              <a
-                href="https://github.com/JoinWebZero/"
-                className="text-sm text-muted-foreground hover:text-primary transition-colors"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                GitHub
-              </a>
-              <a
-                href="https://x.com/JoinWebZero"
-                className="text-sm text-muted-foreground hover:text-primary transition-colors"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                X
-              </a>
-            </div>
-          </div>
-        </div>
-      </footer>
+      <SiteFooter />
       {/* Modal for deliverable upload */}
       <Dialog open={deliverableModalOpen} onOpenChange={setDeliverableModalOpen}>
         <DialogContent className="w-full max-w-xs sm:max-w-md md:max-w-lg">


### PR DESCRIPTION
## Summary
Design polish on the landing page, audio, and footer.

- **Logo** — the `|||` brand icon (favicon) now sits to the **left of "STADIUM"** in both the top-nav brand and the landing hero headline.
- **Audio** — playback now **loops forever**: bound the SoundCloud `FINISH` event to restart. (Cross-page persistence already works — the iframe is mounted above the router — so navigation never stops it.)
- **Footer** — extracted a shared `<SiteFooter>` so the credit line + links stop drifting between `Layout` and the standalone `ProjectDetailsPage` (they had two different copies). Changes:
  - "Created with ❤️ by **sachalansky** from **WebZero**" — `sachalansky` → x.com/sachalansky, `WebZero` → joinwebzero.com
  - footer now uses the app's mono/LCD typography (was generic `text-sm text-muted-foreground`)
  - added a **SOURCE** link to the Stadium repo, beside the existing org GitHub + X

## Test plan
- [x] `cd client && npm run build` — clean
- [x] `cd client && npm run lint` — clean (0 warnings)
- [x] Visual (local dev, mock mode): logo renders left of STADIUM in nav + hero; footer shows the new credit line + SOURCE link in mono type. Screenshots reviewed.
- Note: the one console error during the run is from the third-party SoundCloud widget (`createPattern` on a 0-size canvas), not these changes.

## Not included (follow-up)
Project-details **tab** typography (the shadcn `Card` sections + `TeamPaymentSection`) still uses generic type — that's a larger consistency pass coming as a separate PR.

Draft, not merging (per CLAUDE.md §6).