### PR TITLE
design: re-land round-2 polish onto develop (#162 was stranded)

### DIFF
--- a/client/src/components/TeamPaymentSection.tsx
+++ b/client/src/components/TeamPaymentSection.tsx
@@ -323,7 +323,7 @@ export function TeamPaymentSection({
             {/* Row 1: Name and Role */}
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <Label className="text-xs text-muted-foreground">Name *</Label>
+                <Label className="text-xs text-label-dim">Name *</Label>
                 <Input
                   value={member.name}
                   onChange={(e) => updateMember(index, 'name', e.target.value)}
@@ -332,7 +332,7 @@ export function TeamPaymentSection({
                 />
               </div>
               <div>
-                <Label className="text-xs text-muted-foreground">Role</Label>
+                <Label className="text-xs text-label-dim">Role</Label>
                 <Input
                   value={member.role || ""}
                   onChange={(e) => updateMember(index, 'role', e.target.value)}
@@ -345,7 +345,7 @@ export function TeamPaymentSection({
             {/* Row 2: Wallet Address + chain */}
             <div className="grid grid-cols-[1fr_auto] gap-3">
               <div>
-                <Label className="text-xs text-muted-foreground">Wallet Address</Label>
+                <Label className="text-xs text-label-dim">Wallet Address</Label>
                 <Input
                   value={member.walletAddress || ""}
                   onChange={(e) => updateMember(index, 'walletAddress', e.target.value)}
@@ -354,7 +354,7 @@ export function TeamPaymentSection({
                 />
               </div>
               <div>
-                <Label className="text-xs text-muted-foreground">Chain</Label>
+                <Label className="text-xs text-label-dim">Chain</Label>
                 <Select
                   value={member.walletChain || 'substrate'}
                   onValueChange={(v) => updateMemberChain(index, v as WalletChain)}
@@ -374,7 +374,7 @@ export function TeamPaymentSection({
             {/* Row 3: Social Links */}
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <Label className="text-xs text-muted-foreground flex items-center gap-1">
+                <Label className="text-xs text-label-dim flex items-center gap-1">
                   <Twitter className="h-3 w-3" /> Twitter
                 </Label>
                 <Input
@@ -385,7 +385,7 @@ export function TeamPaymentSection({
                 />
               </div>
               <div>
-                <Label className="text-xs text-muted-foreground flex items-center gap-1">
+                <Label className="text-xs text-label-dim flex items-center gap-1">
                   <Github className="h-3 w-3" /> GitHub
                 </Label>
                 <Input
@@ -399,7 +399,7 @@ export function TeamPaymentSection({
             
             <div className="grid grid-cols-2 gap-3">
               <div>
-                <Label className="text-xs text-muted-foreground flex items-center gap-1">
+                <Label className="text-xs text-label-dim flex items-center gap-1">
                   <Linkedin className="h-3 w-3" /> LinkedIn
                 </Label>
                 <Input
@@ -410,7 +410,7 @@ export function TeamPaymentSection({
                 />
               </div>
               <div>
-                <Label className="text-xs text-muted-foreground flex items-center gap-1">
+                <Label className="text-xs text-label-dim flex items-center gap-1">
                   <Globe className="h-3 w-3" /> Website
                 </Label>
                 <Input
@@ -481,7 +481,7 @@ export function TeamPaymentSection({
               teamMembers.length > 0 ? (
                 teamMembers.map((member, index) => renderReadOnlyMember(member, index))
               ) : (
-                <p className="text-sm text-muted-foreground">No team members listed</p>
+                <p className="text-sm text-label-dim">No team members listed</p>
               )
             )}
           </div>
@@ -499,7 +499,7 @@ export function TeamPaymentSection({
           {/* Payout Address */}
           {isEditing ? (
             <div className="space-y-2">
-              <Label className="text-xs text-muted-foreground">Payout Wallet Address</Label>
+              <Label className="text-xs text-label-dim">Payout Wallet Address</Label>
               <div className="grid grid-cols-[1fr_auto] gap-3">
                 <Input
                   value={editedPayoutAddress}
@@ -521,7 +521,7 @@ export function TeamPaymentSection({
                   </SelectContent>
                 </Select>
               </div>
-              <p className="text-xs text-muted-foreground">
+              <p className="text-xs text-label-dim">
                 This address will receive M2 milestone payments. Automated payouts
                 run on Polkadot; other chains are settled manually.
               </p>

--- a/client/src/components/brightness-rack.tsx
+++ b/client/src/components/brightness-rack.tsx
@@ -3,7 +3,6 @@ import { ChevronDown, ChevronUp, FastForward, Music, Rewind, Volume2, VolumeX } 
 import { useBrightness } from "@/hooks/use-brightness";
 import { HardwareToggle } from "@/components/hardware-toggle";
 import { useSoundCloudAudio } from "@/components/audio/use-sound-cloud-audio";
-import { solarBrightness } from "@/lib/solar";
 import { cn } from "@/lib/utils";
 
 interface BrightnessRackProps {
@@ -22,28 +21,39 @@ function formatTime(ms: number): string {
   return `${m}:${String(s).padStart(2, "0")}`;
 }
 
-// 4-hour clock ticks plotted at the brightness % the solar curve would produce
-// for that hour today. Computed once per session — positions don't drift within a
-// day at human-visible resolution.
-function buildHourTicks(): Array<{ hour: number; brightness: number; label: string }> {
-  const base = new Date();
-  base.setMinutes(0, 0, 0);
-  return [0, 4, 8, 12, 16, 20].map((h) => {
-    const d = new Date(base);
-    d.setHours(h);
-    return {
-      hour: h,
-      brightness: solarBrightness(d),
-      label: `${String(h).padStart(2, "0")}h`,
-    };
-  });
+// Time-of-day ruler: 4-hour clock ticks laid out left→right by the hour itself
+// (0h at the far left, ~24h at the far right) so the numbering reads in order and
+// matches the actual hour. (Plotting by solar brightness made 8h/16h collide.)
+const DAY_HOURS = 24;
+const hourPct = (hour: number) => (hour / DAY_HOURS) * 100;
+
+function buildHourTicks(): Array<{ hour: number; label: string }> {
+  return [0, 4, 8, 12, 16, 20].map((h) => ({
+    hour: h,
+    label: `${String(h).padStart(2, "0")}h`,
+  }));
 }
+
+// Day-phase anchors at their approximate clock times (see lib/solar.ts:
+// sunrise ~6:30, solar noon ~13:00, sunset ~19:30).
+const PHASE_MARKS: Array<{ label: string; hour: number }> = [
+  { label: "NIGHT", hour: 0 },
+  { label: "DAWN", hour: 6.5 },
+  { label: "NOON", hour: 13 },
+  { label: "DUSK", hour: 19.5 },
+];
 
 export function BrightnessRack({ className }: BrightnessRackProps) {
   const {
     brightness, mode, phase, paletteKey, palettes, solarTarget, collapsed,
     setBrightness, setAuto, setPalette, setCollapsed,
   } = useBrightness();
+
+  // Where "now" sits on the time-of-day ruler. Recomputed each render; the
+  // brightness hook re-renders this component on its minute interval, so it
+  // stays approximately current without its own timer.
+  const now = new Date();
+  const nowPct = ((now.getHours() + now.getMinutes() / 60) / DAY_HOURS) * 100;
 
   // Audio state lives in a provider above the router (persists across nav).
   const { muted, toggle, title, genre, artworkUrl, positionMs, durationMs, seek } =
@@ -115,21 +125,21 @@ export function BrightnessRack({ className }: BrightnessRackProps) {
             {/* Track */}
             <div className="absolute top-[7px] left-0 right-0 h-1 bg-panel-deep border border-hairline" />
 
-            {/* Hour ticks — every 4h plotted at its solar-brightness position */}
+            {/* Hour ticks — every 4h, laid out by time of day */}
             {hourTicks.map((t) => (
               <div
                 key={t.hour}
                 className="absolute top-[3px] w-px h-2 bg-hairline pointer-events-none"
-                style={{ left: `calc(${t.brightness}% - 0.5px)` }}
+                style={{ left: `calc(${hourPct(t.hour)}% - 0.5px)` }}
                 aria-hidden="true"
               />
             ))}
 
-            {/* Solar tick — shows where AUTO would place the dial */}
+            {/* "Now" tick — current time on the day ruler */}
             <div
               className="absolute top-0 w-[2px] h-[18px] bg-led pointer-events-none transition-all duration-1000 ease-out"
               style={{
-                left: `calc(${solarTarget}% - 1px)`,
+                left: `calc(${nowPct}% - 1px)`,
                 boxShadow: '0 0 4px hsl(var(--led))',
               }}
               aria-hidden="true"
@@ -167,18 +177,24 @@ export function BrightnessRack({ className }: BrightnessRackProps) {
               <span
                 key={t.hour}
                 className="absolute label-hw-dim text-[8px] -translate-x-1/2 tabular-nums"
-                style={{ left: `${t.brightness}%` }}
+                style={{ left: `${hourPct(t.hour)}%` }}
               >
                 {t.label}
               </span>
             ))}
           </div>
 
-          <div className="flex justify-between mt-0.5 label-hw-dim text-[8px]">
-            <span>NIGHT</span>
-            <span>DAWN</span>
-            <span>DAY</span>
-            <span>NOON</span>
+          {/* Day-phase anchors at their approximate clock times */}
+          <div className="relative h-[10px] mt-0.5">
+            {PHASE_MARKS.map((p) => (
+              <span
+                key={p.label}
+                className="absolute label-hw-dim text-[8px] -translate-x-1/2"
+                style={{ left: `${hourPct(p.hour)}%` }}
+              >
+                {p.label}
+              </span>
+            ))}
           </div>
         </div>
 

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -275,7 +275,7 @@ const HomePage = () => {
             </h1>
           </div>
           <p className="text-body text-base md:text-lg max-w-xl leading-relaxed">
-            Stuff people have built here.
+            Stuff people build here. Browse our programs, leave your mark.
           </p>
 
           <div className="pt-8">

--- a/client/src/pages/ProjectDetailsPage.tsx
+++ b/client/src/pages/ProjectDetailsPage.tsx
@@ -16,12 +16,6 @@ import {
   AlertTriangle,
   Upload,
 } from "lucide-react";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -67,7 +61,7 @@ function SummaryWithBullets({ text }: { text: string }) {
   const bulletPattern = /^[-•*·]\s+/;
   const lines = text.split("\n");
   return (
-    <ul className="list-disc pl-4 space-y-1 text-sm text-muted-foreground leading-relaxed">
+    <ul className="list-disc pl-4 space-y-1 text-body text-sm leading-relaxed">
       {lines.map((line, i) => {
         const trimmed = line.trim();
         if (!trimmed) return <li key={i} className="list-none h-2" aria-hidden="true" />;
@@ -971,10 +965,10 @@ const ProjectDetailsPage = () => {
             {/* Tabs Section */}
             <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
               <TabsList className="grid w-full grid-cols-4">
-                <TabsTrigger value="overview">Overview</TabsTrigger>
-                <TabsTrigger value="milestones">Milestones</TabsTrigger>
-                <TabsTrigger value="team">Team & Payments</TabsTrigger>
-                <TabsTrigger value="updates">Updates</TabsTrigger>
+                <TabsTrigger value="overview" className="font-mono text-[10px] sm:text-[11px] tracking-[0.12em] uppercase">Overview</TabsTrigger>
+                <TabsTrigger value="milestones" className="font-mono text-[10px] sm:text-[11px] tracking-[0.12em] uppercase">Milestones</TabsTrigger>
+                <TabsTrigger value="team" className="font-mono text-[10px] sm:text-[11px] tracking-[0.12em] uppercase">Team &amp; Payments</TabsTrigger>
+                <TabsTrigger value="updates" className="font-mono text-[10px] sm:text-[11px] tracking-[0.12em] uppercase">Updates</TabsTrigger>
               </TabsList>
 
               {/* Overview Tab */}
@@ -1007,109 +1001,104 @@ const ProjectDetailsPage = () => {
 
                 {/* Final Deliverables */}
                 {project.finalSubmission && (
-                  <Card>
-                    <CardHeader>
-                      <CardTitle className="text-lg flex items-center gap-2">
-                        <FileText className="w-5 h-5" />
-                        Final Deliverables
-                      </CardTitle>
-                    </CardHeader>
-                    <CardContent className="space-y-3">
+                  <div className="panel p-4">
+                    <div className="label-hw text-display mb-3 flex items-center gap-2">
+                      <FileText className="w-4 h-4" aria-hidden="true" /> ·FINAL DELIVERABLES
+                    </div>
+                    <div className="space-y-2">
                       {project.liveUrl && project.liveUrl !== "nan" && (
-                        <a 
+                        <a
                           href={project.liveUrl}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="flex items-center gap-3 p-3 bg-muted/30 rounded-lg hover:bg-muted/50 transition-colors"
+                          className="flex items-center gap-3 p-3 border border-hairline hover:bg-panel-deep transition-colors"
                         >
-                          <Globe className="w-5 h-5 text-muted-foreground" aria-hidden="true" />
+                          <Globe className="w-4 h-4 text-label-mid" aria-hidden="true" />
                           <div className="flex-1">
-                            <div className="text-sm font-medium">Live site</div>
-                            <div className="text-xs text-muted-foreground">Visit the project</div>
+                            <div className="font-mono text-[11px] tracking-wide text-display">LIVE SITE</div>
+                            <div className="label-hw-dim">Visit the project</div>
                           </div>
-                          <ExternalLink className="w-4 h-4 text-muted-foreground" aria-hidden="true" />
+                          <ExternalLink className="w-3.5 h-3.5 text-label-mid" aria-hidden="true" />
                         </a>
                       )}
-                      <a 
+                      <a
                         href={project.finalSubmission.repoUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="flex items-center gap-3 p-3 bg-muted/30 rounded-lg hover:bg-muted/50 transition-colors"
+                        className="flex items-center gap-3 p-3 border border-hairline hover:bg-panel-deep transition-colors"
                       >
-                        <Github className="w-5 h-5 text-muted-foreground" aria-hidden="true" />
+                        <Github className="w-4 h-4 text-label-mid" aria-hidden="true" />
                         <div className="flex-1">
-                          <div className="text-sm font-medium">GitHub Repository</div>
-                          <div className="text-xs text-muted-foreground">View source code</div>
+                          <div className="font-mono text-[11px] tracking-wide text-display">GITHUB REPOSITORY</div>
+                          <div className="label-hw-dim">View source code</div>
                         </div>
-                        <ExternalLink className="w-4 h-4 text-muted-foreground" aria-hidden="true" />
+                        <ExternalLink className="w-3.5 h-3.5 text-label-mid" aria-hidden="true" />
                       </a>
-                      
-                      <a 
+
+                      <a
                         href={project.finalSubmission.demoUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="flex items-center gap-3 p-3 bg-muted/30 rounded-lg hover:bg-muted/50 transition-colors"
+                        className="flex items-center gap-3 p-3 border border-hairline hover:bg-panel-deep transition-colors"
                       >
-                        <Video className="w-5 h-5 text-muted-foreground" aria-hidden="true" />
+                        <Video className="w-4 h-4 text-label-mid" aria-hidden="true" />
                         <div className="flex-1">
-                          <div className="text-sm font-medium">Demo Video</div>
-                          <div className="text-xs text-muted-foreground">Watch the demo</div>
+                          <div className="font-mono text-[11px] tracking-wide text-display">DEMO VIDEO</div>
+                          <div className="label-hw-dim">Watch the demo</div>
                         </div>
-                        <ExternalLink className="w-4 h-4 text-muted-foreground" aria-hidden="true" />
+                        <ExternalLink className="w-3.5 h-3.5 text-label-mid" aria-hidden="true" />
                       </a>
-                      
-                      <a 
+
+                      <a
                         href={project.finalSubmission.docsUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="flex items-center gap-3 p-3 bg-muted/30 rounded-lg hover:bg-muted/50 transition-colors"
+                        className="flex items-center gap-3 p-3 border border-hairline hover:bg-panel-deep transition-colors"
                       >
-                        <FileText className="w-5 h-5 text-muted-foreground" aria-hidden="true" />
+                        <FileText className="w-4 h-4 text-label-mid" aria-hidden="true" />
                         <div className="flex-1">
-                          <div className="text-sm font-medium">Documentation</div>
-                          <div className="text-xs text-muted-foreground">View docs</div>
+                          <div className="font-mono text-[11px] tracking-wide text-display">DOCUMENTATION</div>
+                          <div className="label-hw-dim">View docs</div>
                         </div>
-                        <ExternalLink className="w-4 h-4 text-muted-foreground" aria-hidden="true" />
+                        <ExternalLink className="w-3.5 h-3.5 text-label-mid" aria-hidden="true" />
                       </a>
-                      
+
                       {project.finalSubmission.summary && (
-                        <div className="mt-4 p-4 bg-muted/20 rounded-lg">
-                          <h4 className="text-sm font-medium mb-2">Summary:</h4>
+                        <div className="mt-3 p-3 border border-hairline">
+                          <div className="label-hw-dim mb-2">·SUMMARY</div>
                           <SummaryWithBullets text={project.finalSubmission.summary} />
                         </div>
                       )}
-                    </CardContent>
-                  </Card>
+                    </div>
+                  </div>
                 )}
 
                 {/* No final submission: show placeholder or fallback for completed/under_review */}
                 {!project.finalSubmission && (
-                  <Card>
-                    <CardContent className="py-8 text-center">
-                      <FileText className="w-12 h-12 mx-auto text-muted-foreground mb-4" />
-                      {project.m2Status === 'completed' || project.m2Status === 'under_review' ? (
-                        <>
-                          <h3 className="font-medium mb-2">Deliverables not recorded</h3>
-                          <p className="text-sm text-muted-foreground mb-4">
-                            This project was marked {project.m2Status === 'completed' ? 'completed' : 'under review'} but no final submission (repo, demo, docs) was stored. You can submit or update deliverables below to add them here.
-                          </p>
-                          {project.liveUrl && project.liveUrl !== "nan" && (
-                            <a href={project.liveUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 text-primary hover:underline">
-                              <Globe className="h-4 w-4" />
-                              <span>Visit live site</span>
-                            </a>
-                          )}
-                        </>
-                      ) : (
-                        <>
-                          <h3 className="font-medium mb-2">No Deliverables Yet</h3>
-                          <p className="text-sm text-muted-foreground">
-                            Final deliverables will appear here once the team submits them.
-                          </p>
-                        </>
-                      )}
-                    </CardContent>
-                  </Card>
+                  <div className="panel p-8 text-center">
+                    <FileText className="w-10 h-10 mx-auto text-label-mid mb-4" aria-hidden="true" />
+                    {project.m2Status === 'completed' || project.m2Status === 'under_review' ? (
+                      <>
+                        <div className="label-hw text-display mb-2">·DELIVERABLES NOT RECORDED</div>
+                        <p className="text-body text-sm mb-4 max-w-md mx-auto">
+                          This project was marked {project.m2Status === 'completed' ? 'completed' : 'under review'} but no final submission (repo, demo, docs) was stored. You can submit or update deliverables below to add them here.
+                        </p>
+                        {project.liveUrl && project.liveUrl !== "nan" && (
+                          <a href={project.liveUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep px-3 py-1.5">
+                            <Globe className="h-3 w-3" aria-hidden="true" />
+                            VISIT LIVE SITE
+                          </a>
+                        )}
+                      </>
+                    ) : (
+                      <>
+                        <div className="label-hw text-display mb-2">·NO DELIVERABLES YET</div>
+                        <p className="text-body text-sm max-w-md mx-auto">
+                          Final deliverables will appear here once the team submits them.
+                        </p>
+                      </>
+                    )}
+                  </div>
                 )}
               </TabsContent>
 
@@ -1162,81 +1151,75 @@ const ProjectDetailsPage = () => {
 
                     {/* Submission Status for building/under_review */}
                     {(project.m2Status === 'building' || project.m2Status === 'under_review') && (
-                      <Card>
-                        <CardHeader>
-                          <CardTitle className="text-lg">Submission Status</CardTitle>
-                        </CardHeader>
-                        <CardContent>
-                          {project.m2Status === 'under_review' && project.finalSubmission ? (
-                            <div className="bg-yellow-500/10 rounded-lg p-4 border border-yellow-500/30">
-                              <div className="flex items-center gap-3 mb-2">
-                                <Clock className="w-5 h-5 text-yellow-500" aria-hidden="true" />
-                                <span className="font-medium text-lg">Under Review</span>
+                      <div className="panel p-4">
+                        <div className="label-hw text-display mb-3">·SUBMISSION STATUS</div>
+                        {project.m2Status === 'under_review' && project.finalSubmission ? (
+                          <div className="bg-yellow-500/10 p-4 border border-yellow-500/30">
+                            <div className="flex items-center gap-3 mb-2">
+                              <Clock className="w-4 h-4 text-yellow-500" aria-hidden="true" />
+                              <span className="font-mono text-[12px] tracking-wide text-display">UNDER REVIEW</span>
+                            </div>
+                            <p className="text-body text-sm">
+                              Submitted on {new Date(project.finalSubmission.submittedDate).toLocaleDateString('en-US', {
+                                month: 'long',
+                                day: 'numeric',
+                                year: 'numeric'
+                              })}
+                            </p>
+                          </div>
+                        ) : (
+                          <div className="space-y-4">
+                            {project.changesRequested && (
+                              <div className="bg-yellow-500/10 p-4 border border-yellow-500/30">
+                                <div className="flex items-center gap-3 mb-3">
+                                  <AlertTriangle className="w-4 h-4 text-yellow-500" aria-hidden="true" />
+                                  <span className="font-mono text-[12px] tracking-wide text-display">CHANGES REQUESTED</span>
+                                </div>
+                                <div className="border border-hairline p-3">
+                                  <p className="text-body text-sm whitespace-pre-wrap">{project.changesRequested.feedback}</p>
+                                </div>
                               </div>
-                              <p className="text-sm text-muted-foreground">
-                                Submitted on {new Date(project.finalSubmission.submittedDate).toLocaleDateString('en-US', { 
-                                  month: 'long', 
-                                  day: 'numeric', 
-                                  year: 'numeric' 
-                                })}
+                            )}
+
+                            <div className="border border-hairline p-4">
+                              <div className="flex items-center gap-3 mb-2">
+                                <div className="w-2 h-2 rounded-full bg-blue-500" aria-hidden="true" />
+                                <span className="font-mono text-[11px] tracking-wide text-display">
+                                  STATUS: {project.changesRequested ? 'RESUBMISSION REQUIRED' : 'NOT YET SUBMITTED'}
+                                </span>
+                              </div>
+                              <p className="text-body text-sm">
+                                {project.changesRequested
+                                  ? 'Please address the requested changes and resubmit'
+                                  : 'Available for submission starting Week 5'
+                                }
                               </p>
                             </div>
-                          ) : (
-                            <div className="space-y-4">
-                              {project.changesRequested && (
-                                <div className="bg-yellow-500/10 rounded-lg p-4 border border-yellow-500/30">
-                                  <div className="flex items-center gap-3 mb-3">
-                                    <AlertTriangle className="w-5 h-5 text-yellow-500" aria-hidden="true" />
-                                    <span className="font-medium text-lg">Changes Requested</span>
-                                  </div>
-                                  <div className="bg-muted/30 rounded p-3">
-                                    <p className="text-sm whitespace-pre-wrap">{project.changesRequested.feedback}</p>
-                                  </div>
-                                </div>
-                              )}
-                              
-                              <div className="bg-muted/30 rounded-lg p-4">
-                                <div className="flex items-center gap-3 mb-2">
-                                  <div className="w-2 h-2 rounded-full bg-blue-500" aria-hidden="true" />
-                                  <span className="font-medium">
-                                    Status: {project.changesRequested ? 'Resubmission Required' : 'Not yet submitted'}
-                                  </span>
-                                </div>
-                                <p className="text-sm text-muted-foreground">
-                                  {project.changesRequested 
-                                    ? 'Please address the requested changes and resubmit'
-                                    : 'Available for submission starting Week 5'
-                                  }
-                                </p>
-                              </div>
-                              
-                              {/* Submission button */}
-                              {isTeamMember && isSubmissionWeek && (
-                                <Button 
-                                  className="w-full"
-                                  size="lg"
-                                  onClick={() => setFinalSubmissionModalOpen(true)}
-                                >
-                                  <Upload className="w-4 h-4 mr-2" aria-hidden="true" />
-                                  {project.changesRequested ? 'Resubmit M2 Deliverables' : 'Submit M2 Deliverables'}
-                                </Button>
-                              )}
-                            </div>
-                          )}
-                        </CardContent>
-                      </Card>
+
+                            {/* Submission button */}
+                            {isTeamMember && isSubmissionWeek && (
+                              <Button
+                                className="w-full"
+                                size="lg"
+                                onClick={() => setFinalSubmissionModalOpen(true)}
+                              >
+                                <Upload className="w-4 h-4 mr-2" aria-hidden="true" />
+                                {project.changesRequested ? 'Resubmit M2 Deliverables' : 'Submit M2 Deliverables'}
+                              </Button>
+                            )}
+                          </div>
+                        )}
+                      </div>
                     )}
                   </>
                 ) : (
-                  <Card>
-                    <CardContent className="py-8 text-center">
-                      <Clock className="w-12 h-12 mx-auto text-muted-foreground mb-4" />
-                      <h3 className="font-medium mb-2">Not in M2 Program</h3>
-                      <p className="text-sm text-muted-foreground">
-                        This project is not currently enrolled in the M2 Incubator program.
-                      </p>
-                    </CardContent>
-                  </Card>
+                  <div className="panel p-8 text-center">
+                    <Clock className="w-10 h-10 mx-auto text-label-mid mb-4" aria-hidden="true" />
+                    <div className="label-hw text-display mb-2">·NOT IN M2 PROGRAM</div>
+                    <p className="text-body text-sm max-w-md mx-auto">
+                      This project is not currently enrolled in the M2 Incubator program.
+                    </p>
+                  </div>
                 )}
               </TabsContent>
 


### PR DESCRIPTION
## Why
#162 was opened **stacked on #161's branch** and got merged into that base branch instead of `develop`, so its changes never reached `develop`. This re-lands the exact same commit (`a6615b4`) cleanly on top of current `develop` (via cherry-pick — avoids dragging the stale auth-bridge files that the stacked branch still carried).

## What (unchanged from #162)
- **Project-details typography** — Overview/Milestones tab content converted from shadcn `Card` + sans/muted to the app's `panel` + mono/LCD aesthetic; mono/uppercase tab labels; `TeamPaymentSection` muted token aligned to `text-label-dim`.
- **Hero tagline** — "Stuff people build here. Browse our programs, leave your mark."
- **Brightness time ruler** — hours laid out by time of day (00h→20h in order); phase anchors at real clock times; green tick marks "now".

## Test plan
- [x] Cherry-pick applied with no conflicts
- [x] `cd client && npm run build` — clean
- [x] `cd client && npm run lint` — clean (0 warnings)
- [x] Confirmed develop was missing these (old tagline + old brightness scale) before this PR

Draft, targeting `develop`.