### PR TITLE
hardening: boot secret validation + req.user.chain + shared csvCell util (#129, #130, #134)

### DIFF
--- a/server/api/auth/__tests__/sessionToken.test.js
+++ b/server/api/auth/__tests__/sessionToken.test.js
@@ -3,6 +3,7 @@ import {
   issueSessionToken,
   verifySessionToken,
   extractBearerToken,
+  assertSessionSecret,
   _resetCacheForTests,
 } from '../sessionToken.js';
 
@@ -78,6 +79,26 @@ describe('issueSessionToken + verifySessionToken', () => {
     expect(() => issueSessionToken({ address: 'a', chain: 'substrate' })).toThrow(
       /ADMIN_SESSION_SECRET/,
     );
+  });
+});
+
+describe('assertSessionSecret (boot-time validation)', () => {
+  it('passes when the secret is configured and long enough', () => {
+    process.env.ADMIN_SESSION_SECRET = FRESH_SECRET;
+    _resetCacheForTests();
+    expect(() => assertSessionSecret()).not.toThrow();
+  });
+
+  it('throws at boot when the secret is missing', () => {
+    delete process.env.ADMIN_SESSION_SECRET;
+    _resetCacheForTests();
+    expect(() => assertSessionSecret()).toThrow(/ADMIN_SESSION_SECRET/);
+  });
+
+  it('throws at boot when the secret is too short', () => {
+    process.env.ADMIN_SESSION_SECRET = 'short';
+    _resetCacheForTests();
+    expect(() => assertSessionSecret()).toThrow(/ADMIN_SESSION_SECRET/);
   });
 
   it('uses the configured TTL when present', () => {

--- a/server/api/auth/sessionToken.js
+++ b/server/api/auth/sessionToken.js
@@ -43,6 +43,15 @@ function getTtlSeconds() {
   return DEFAULT_TTL_SECONDS;
 }
 
+/**
+ * Fail fast at server boot if ADMIN_SESSION_SECRET is missing or too short,
+ * rather than at the first admin sign-in (when getSecret() would otherwise
+ * throw). Call this once during startup.
+ */
+export function assertSessionSecret() {
+  getSecret();
+}
+
 /** Allow tests to reset module-scoped caches between cases. */
 export function _resetCacheForTests() {
   cachedSecret = null;

--- a/server/api/middleware/__tests__/auth.middleware.test.js
+++ b/server/api/middleware/__tests__/auth.middleware.test.js
@@ -268,6 +268,7 @@ describe('requireAdmin', () => {
     expect(next).toHaveBeenCalled();
     expect(req.user).toEqual({
       address: '5FakeAdmin1',
+      chain: 'substrate',
       multisig: '5FakeMultisig',
       network: 'development',
     });
@@ -377,6 +378,7 @@ describe('requireTeamMemberOrAdmin', () => {
     expect(next).toHaveBeenCalled();
     expect(req.user).toEqual({
       address: '5FakeAdmin1',
+      chain: 'substrate',
       multisig: '5FakeMultisig',
       network: 'development',
     });
@@ -408,7 +410,7 @@ describe('requireTeamMemberOrAdmin', () => {
     await requireTeamMemberOrAdmin(req, res, next);
 
     expect(next).toHaveBeenCalled();
-    expect(req.user).toEqual({ address: '5TeamMember1' });
+    expect(req.user).toEqual({ address: '5TeamMember1', chain: 'substrate' });
   });
 
   it('returns 403 when signer is neither admin nor team member', async () => {

--- a/server/api/middleware/auth.middleware.js
+++ b/server/api/middleware/auth.middleware.js
@@ -290,6 +290,7 @@ export const requireAdmin = async (req, res, next) => {
   logSuccess(`Admin ${signerAddress} authorized`);
   req.user = {
     address: signerAddress,
+    chain: auth.chain,
     multisig: CURRENT_MULTISIG,
     network: NETWORK_CONFIG.environment,
   };
@@ -355,6 +356,7 @@ export const requireTeamMemberOrAdmin = async (req, res, next) => {
     logSuccess(`Signer ${signerAddress} is an admin. Granting access.`);
     req.user = {
       address: signerAddress,
+      chain: auth.chain,
       multisig: CURRENT_MULTISIG,
       network: NETWORK_CONFIG.environment,
     };
@@ -384,7 +386,7 @@ export const requireTeamMemberOrAdmin = async (req, res, next) => {
 
     if (isTeamMember) {
       logSuccess(`Signer ${signerAddress} is a team member of project ${projectId}. Granting access.`);
-      req.user = { address: signerAddress };
+      req.user = { address: signerAddress, chain: auth.chain };
       return next();
     }
 

--- a/server/api/services/program-inbox.service.js
+++ b/server/api/services/program-inbox.service.js
@@ -1,6 +1,7 @@
 import programApplicationService from './program-application.service.js';
 import programSignupService from './program-signup.service.js';
 import projectService from './project.service.js';
+import { csvCell, csvRow } from '../utils/csv.js';
 
 /**
  * Per-program inbox — one merged feed of `program_signups` (Luma CSV
@@ -91,25 +92,8 @@ class ProgramInboxService {
 
 export default new ProgramInboxService();
 
-// CSV serialisation lives here so the controller stays thin. Escapes
-// double-quotes per RFC 4180.
-//
-// SECURITY: also defends against CSV formula injection (Excel / Google Sheets
-// auto-execute any cell starting with `=`, `+`, `-`, `@`, `\t`, `\r`). User-
-// submitted fields (name, email, identifier, wallet) flow into the export an
-// admin downloads, so a malicious applicant could exfiltrate the admin's data
-// via `=WEBSERVICE(…)` or `=HYPERLINK(…)`. Prefixing such cells with a single
-// quote neuters the formula while leaving the visible value intact (the quote
-// is a sentinel that the spreadsheet strips on display).
-const FORMULA_INJECTION_LEAD = /^[=+\-@\t\r]/;
-const csvCell = (val) => {
-  if (val == null) return '';
-  let s = String(val);
-  if (FORMULA_INJECTION_LEAD.test(s)) s = `'${s}`;
-  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
-  return s;
-};
-
+// CSV serialisation lives here so the controller stays thin. Cell escaping +
+// formula-injection defense come from the shared ../utils/csv.js helper.
 export function inboxToCsv(rows, { programSlug } = {}) {
   const header = [
     'source',
@@ -120,12 +104,10 @@ export function inboxToCsv(rows, { programSlug } = {}) {
     'status',
     'wallet',
   ];
-  const lines = [header.join(',')];
+  const lines = [header.map(csvCell).join(',')];
   for (const r of rows) {
     lines.push(
-      [r.source, r.when, r.identifier, r.name, r.email, r.status, r.wallet]
-        .map(csvCell)
-        .join(','),
+      csvRow([r.source, r.when, r.identifier, r.name, r.email, r.status, r.wallet]),
     );
   }
   // Stamp the slug in a trailing comment so the export is self-identifying

--- a/server/api/utils/__tests__/csv.test.js
+++ b/server/api/utils/__tests__/csv.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { csvCell, csvRow } from '../csv.js';
+
+describe('csvCell', () => {
+  it('passes plain values through unchanged', () => {
+    expect(csvCell('hello')).toBe('hello');
+    expect(csvCell(42)).toBe('42');
+  });
+
+  it('renders null/undefined as an empty string', () => {
+    expect(csvCell(null)).toBe('');
+    expect(csvCell(undefined)).toBe('');
+  });
+
+  it('quotes and escapes values containing commas, quotes, or newlines', () => {
+    expect(csvCell('a,b')).toBe('"a,b"');
+    expect(csvCell('say "hi"')).toBe('"say ""hi"""');
+    expect(csvCell('line1\nline2')).toBe('"line1\nline2"');
+  });
+
+  it('neutralizes formula-injection leads with a sentinel quote', () => {
+    expect(csvCell('=HYPERLINK(http://evil)')).toBe("'=HYPERLINK(http://evil)");
+    expect(csvCell('+1')).toBe("'+1");
+    expect(csvCell('-1')).toBe("'-1");
+    expect(csvCell('@cmd')).toBe("'@cmd");
+  });
+
+  it('still quotes a formula cell that also contains a comma', () => {
+    // sentinel is applied first, then RFC-4180 quoting wraps the comma
+    expect(csvCell('=A1,B1')).toBe('"\'=A1,B1"');
+  });
+});
+
+describe('csvRow', () => {
+  it('escapes every cell and joins with commas', () => {
+    expect(csvRow(['a', 'b,c', '=x'])).toBe('a,"b,c",\'=x');
+  });
+});

--- a/server/api/utils/csv.js
+++ b/server/api/utils/csv.js
@@ -1,0 +1,26 @@
+// Shared CSV helpers so every export inherits the same RFC-4180 quoting and,
+// critically, the same formula-injection defense.
+//
+// SECURITY: Excel / Google Sheets / Numbers auto-execute any cell starting with
+// `=`, `+`, `-`, `@`, tab or CR. User-submitted fields (name, email, identifier,
+// wallet, …) flow into exports an admin downloads, so a malicious applicant
+// could exfiltrate the admin's data via `=WEBSERVICE(…)` / `=HYPERLINK(…)`.
+// Prefixing such cells with a single quote neuters the formula while leaving the
+// visible value intact (the quote is a sentinel the spreadsheet strips on
+// display). Any new CSV export MUST route every cell through `csvCell`.
+
+const FORMULA_INJECTION_LEAD = /^[=+\-@\t\r]/;
+
+/** Escape one cell: formula-injection guard + RFC-4180 quoting. */
+export function csvCell(val) {
+  if (val == null) return '';
+  let s = String(val);
+  if (FORMULA_INJECTION_LEAD.test(s)) s = `'${s}`;
+  if (/[",\n\r]/.test(s)) return `"${s.replace(/"/g, '""')}"`;
+  return s;
+}
+
+/** Join one row of raw values into an escaped CSV line. */
+export function csvRow(cells) {
+  return cells.map(csvCell).join(',');
+}

--- a/server/server.js
+++ b/server/server.js
@@ -9,6 +9,7 @@ import walletContactRoutes from './api/routes/wallet-contact.routes.js';
 import adminSessionRoutes from './api/routes/admin-session.routes.js';
 import adminTiersRoutes from './api/routes/admin-tiers.routes.js';
 import requestLogger from './api/middleware/logging.middleware.js';
+import { assertSessionSecret } from './api/auth/sessionToken.js';
 import { getAuthorizedAddresses, NETWORK_CONFIG } from './config/polkadot-config.js';
 
 const app = express();
@@ -136,6 +137,9 @@ app.use((err, req, res, next) => {
 
 const startServer = async () => {
     try {
+        // Fail fast if the session-signing secret is missing/too short, rather
+        // than at the first admin sign-in.
+        assertSessionSecret();
         await connectToSupabase();
         app.listen(PORT, () => {
             console.log(`✅ Server is running on port ${PORT}`);


### PR DESCRIPTION
## Summary
Three quick hardening wins for the first official release.

- **#129 — validate `ADMIN_SESSION_SECRET` at boot.** Added `assertSessionSecret()` (calls the existing `getSecret()`), invoked at the top of `startServer()` in `server.js`, so a missing/short secret fails fast at boot instead of at the first admin sign-in.
- **#130 — `req.user.chain` in admin middleware.** `requireAdmin` and `requireTeamMemberOrAdmin` now set `chain` on every grant path (admin + team-member), so audit logging / forensics has the chain.
- **#134 — shared `csvCell` util.** Factored `csvCell` + the formula-injection defense out of `program-inbox.service.js` into `server/api/utils/csv.js` (`csvCell` + `csvRow`). The inbox export now imports it; future CSV exports inherit the same RFC-4180 quoting + injection guard.

## Test plan
- [x] `npm test` (server) — **293 pass** (new: csv util formula-injection/quoting, `assertSessionSecret` missing/short/ok, middleware `req.user.chain` assertions)
- [x] `node --check server.js`
- [x] `cd client && npm run build` — clean
- [x] `cd client && npm run lint` — clean (0 warnings)

Closes #129
Closes #130
Closes #134

Draft, targeting `develop`, not merging (per CLAUDE.md §6).