### PR TITLE
fix(audio): mute toggle works on mobile (pause instead of setVolume)

### DIFF
--- a/client/src/components/audio/sound-cloud-audio.tsx
+++ b/client/src/components/audio/sound-cloud-audio.tsx
@@ -153,8 +153,16 @@ export function SoundCloudAudioProvider({ children }: { children: React.ReactNod
       const next = !prev;
       const widget = widgetRef.current;
       if (widget) {
-        widget.setVolume(next ? 0 : 100);
-        widget.play();
+        // Mute by pausing, not by setVolume(0): on mobile (notably iOS) volume is
+        // hardware-controlled and setVolume is a no-op, so volume-based muting
+        // silently failed there. play()/pause() honor the user's tap on every
+        // platform — and the tap is the gesture mobile needs to start audio.
+        if (next) {
+          widget.pause();
+        } else {
+          widget.setVolume(100);
+          widget.play();
+        }
       }
       return next;
     });


### PR DESCRIPTION
## Problem
The audio mute button doesn't work in production on mobile.

## Cause
The toggle muted via `widget.setVolume(0)`. On mobile — notably iOS — playback volume is **hardware-controlled and `setVolume` is a no-op**, so tapping "mute" left `play()` running at full volume and nothing actually muted.

## Fix
Mute by **pausing**, unmute by **playing** (with `setVolume(100)` for desktop). `play()`/`pause()` honor the user's tap on every platform — and the tap is the user gesture mobile needs anyway. Persistence-across-pages and the finish→loop behavior are unchanged.

## Test plan
- [x] `cd client && npm run build` — clean
- [x] `cd client && npm run lint` — clean (0 warnings)
- [x] Desktop (local dev): toggle flips Unmute→Mute (`aria-pressed` false→true), no console errors.
- [ ] **Mobile (real device):** audio playback can't be verified headless — please confirm on an actual phone (mute should stop sound, unmute should start it).

Draft → develop. Since this is a prod bug, promote to `main` after merge to ship it.