### PR TITLE
Minor bug fixes

### DIFF
--- a/client/src/components/M2AgreementModal.tsx
+++ b/client/src/components/M2AgreementModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -46,11 +46,21 @@ export function M2AgreementModal({
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
 
+  // Stable React keys for the three editable string lists, length-synced with
+  // their formData arrays. Keying these add/remove inputs by index lets a
+  // mid-list delete reuse the wrong DOM node and shift focus to a sibling row.
+  const keySeq = useRef(0);
+  const nextKey = () => (keySeq.current += 1);
+  const [featureKeys, setFeatureKeys] = useState<number[]>(() => formData.coreFeatures.map(() => nextKey()));
+  const [docKeys, setDocKeys] = useState<number[]>(() => formData.documentation.map(() => nextKey()));
+  const [niceKeys, setNiceKeys] = useState<number[]>(() => formData.niceToHave.map(() => nextKey()));
+
   const handleAddFeature = () => {
     setFormData(prev => ({
       ...prev,
       coreFeatures: [...prev.coreFeatures, '']
     }));
+    setFeatureKeys(prev => [...prev, nextKey()]);
   };
 
   const handleRemoveFeature = (index: number) => {
@@ -59,6 +69,7 @@ export function M2AgreementModal({
         ...prev,
         coreFeatures: prev.coreFeatures.filter((_, i) => i !== index)
       }));
+      setFeatureKeys(prev => prev.filter((_, i) => i !== index));
     }
   };
 
@@ -74,6 +85,7 @@ export function M2AgreementModal({
       ...prev,
       documentation: [...prev.documentation, '']
     }));
+    setDocKeys(prev => [...prev, nextKey()]);
   };
 
   const handleRemoveDocumentation = (index: number) => {
@@ -82,6 +94,7 @@ export function M2AgreementModal({
         ...prev,
         documentation: prev.documentation.filter((_, i) => i !== index)
       }));
+      setDocKeys(prev => prev.filter((_, i) => i !== index));
     }
   };
 
@@ -97,6 +110,7 @@ export function M2AgreementModal({
       ...prev,
       niceToHave: [...prev.niceToHave, '']
     }));
+    setNiceKeys(prev => [...prev, nextKey()]);
   };
 
   const handleRemoveNiceToHave = (index: number) => {
@@ -105,6 +119,7 @@ export function M2AgreementModal({
         ...prev,
         niceToHave: prev.niceToHave.filter((_, i) => i !== index)
       }));
+      setNiceKeys(prev => prev.filter((_, i) => i !== index));
     }
   };
 
@@ -178,6 +193,11 @@ export function M2AgreementModal({
         targetCompletionDate: '',
         mentorName: ''
       });
+      // Keep the row-key arrays length-matched to the reset defaults above
+      // (1 feature, 2 documentation, 1 nice-to-have).
+      setFeatureKeys([nextKey()]);
+      setDocKeys([nextKey(), nextKey()]);
+      setNiceKeys([nextKey()]);
       onOpenChange(false);
     } catch (error) {
       toast({
@@ -226,7 +246,7 @@ export function M2AgreementModal({
             </p>
             <div className="space-y-2">
               {formData.coreFeatures.map((feature, index) => (
-                <div key={index} className="flex gap-2">
+                <div key={featureKeys[index] ?? index} className="flex gap-2">
                   <Input
                     value={feature}
                     onChange={(e) => handleFeatureChange(index, e.target.value)}
@@ -266,7 +286,7 @@ export function M2AgreementModal({
             <Label>Documentation Required</Label>
             <div className="space-y-2">
               {formData.documentation.map((doc, index) => (
-                <div key={index} className="flex gap-2">
+                <div key={docKeys[index] ?? index} className="flex gap-2">
                   <Input
                     value={doc}
                     onChange={(e) => handleDocumentationChange(index, e.target.value)}
@@ -335,7 +355,7 @@ export function M2AgreementModal({
             <Label>Nice-to-Have (not required for approval)</Label>
             <div className="space-y-2">
               {formData.niceToHave.map((item, index) => (
-                <div key={index} className="flex gap-2">
+                <div key={niceKeys[index] ?? index} className="flex gap-2">
                   <Input
                     value={item}
                     onChange={(e) => handleNiceToHaveChange(index, e.target.value)}

--- a/client/src/components/ProjectExplorer.tsx
+++ b/client/src/components/ProjectExplorer.tsx
@@ -1,0 +1,232 @@
+import { useState, useMemo, lazy, Suspense, useCallback } from "react";
+import { Filter } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
+import { UnitCard } from "@/components/unit-card";
+import { InputBus } from "@/components/input-bus";
+import { HardwareToggle } from "@/components/hardware-toggle";
+import { ProjectCardSkeleton } from "@/components/ProjectCardSkeleton";
+import { NoProjectsFound } from "@/components/EmptyState";
+import type { ApiProject } from "@/lib/api";
+
+// Lazy load heavy components (filter sidebar + detail modal)
+const FilterSidebar = lazy(() => import("@/components/FilterSidebar").then(m => ({ default: m.FilterSidebar })));
+const UnitDetailModal = lazy(() => import("@/components/unit-detail-modal").then(m => ({ default: m.UnitDetailModal })));
+
+type UnitForCard = {
+  id: string;
+  unitNumber: string;
+  title: string;
+  author: string;
+  description: string;
+  longDescription?: string;
+  track: string;
+  isWinner: boolean;
+  isM2: boolean;
+  date?: string;
+  prize?: string;
+  demoUrl?: string;
+  githubUrl?: string;
+  projectUrl?: string;
+  techStack?: string[];
+  categories?: string[];
+  teamSize?: number;
+};
+
+const FILTER_TO_CATEGORY: Record<string, string> = {
+  gaming: "Gaming",
+  defi: "DeFi",
+  nft: "NFT",
+  "developer-tools": "Developer Tools",
+  social: "Social",
+  ai: "AI",
+  arts: "Arts",
+  mobile: "Mobile",
+};
+
+// Map an ApiProject into the rack-card shape — the index in the displayed
+// list provides a stable zero-padded "UNIT NNN" label.
+function toUnit(p: ApiProject, idx: number): UnitForCard {
+  const track = p.bountyPrize?.[0]?.name || p.categories?.[0] || "Other";
+  const isWinner = Array.isArray(p.bountyPrize) && p.bountyPrize.length > 0;
+  const isM2 = p.m2Status === "completed";
+  const dateStr = p.completionDate || p.submittedDate || p.hackathon?.endDate;
+  const date = dateStr
+    ? new Date(dateStr).toLocaleDateString("en-US", { month: "short", day: "2-digit" }).toUpperCase()
+    : undefined;
+  const prize = p.bountyPrize?.[0]?.amount
+    ? `$${p.bountyPrize[0].amount.toLocaleString()}`
+    : undefined;
+  return {
+    id: p.id,
+    unitNumber: String(idx + 1).padStart(3, "0"),
+    title: p.projectName,
+    author: p.teamMembers?.[0]?.name || "Unknown",
+    description: p.description,
+    track,
+    isWinner,
+    isM2,
+    date,
+    prize,
+    demoUrl: p.demoUrl,
+    githubUrl: p.projectRepo,
+    projectUrl: p.id ? `/m2-program/${p.id}` : undefined,
+    techStack: Array.isArray(p.techStack) ? p.techStack : undefined,
+    categories: p.categories,
+    teamSize: p.teamMembers?.length,
+  };
+}
+
+/**
+ * Searchable project browser: text search, WINNERS/ALL toggle, and category
+ * filters over a supplied project list, rendering a grid of rack cards with a
+ * detail modal. Lifted out of HomePage so any scope (e.g. a single program's
+ * entries) can reuse the same search view.
+ */
+export function ProjectExplorer({
+  projects,
+  loading = false,
+  defaultWinnersOnly = false,
+}: {
+  projects: ApiProject[];
+  loading?: boolean;
+  defaultWinnersOnly?: boolean;
+}) {
+  const [activeFilters, setActiveFilters] = useState<string[]>([]);
+  const [showWinnersOnly, setShowWinnersOnly] = useState(defaultWinnersOnly);
+  const [selectedUnit, setSelectedUnit] = useState<UnitForCard | null>(null);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [isFiltersOpen, setIsFiltersOpen] = useState(false);
+
+  const filteredProjects = useMemo(() => {
+    let filtered = projects;
+
+    if (searchQuery) {
+      const query = searchQuery.toLowerCase();
+      filtered = filtered.filter((p) =>
+        p.projectName.toLowerCase().includes(query) ||
+        p.description.toLowerCase().includes(query) ||
+        p.teamMembers?.[0]?.name?.toLowerCase().includes(query)
+      );
+    }
+
+    // When a search query is active, ignore the winners-only filter so
+    // non-winning matches still surface — the user clearly wants a
+    // specific project, regardless of category default.
+    if (showWinnersOnly && !searchQuery) {
+      filtered = filtered.filter((p) => Array.isArray(p.bountyPrize) && p.bountyPrize.length > 0);
+    }
+
+    if (activeFilters.length > 0) {
+      filtered = filtered.filter((p) => {
+        const cats = p.categories || [];
+        return activeFilters.some((id) => {
+          const name = FILTER_TO_CATEGORY[id];
+          return name && cats.some((c) => c.toLowerCase() === name.toLowerCase());
+        });
+      });
+    }
+
+    filtered = [...filtered].sort((a, b) => {
+      const compA = a.completionDate ? new Date(a.completionDate).getTime() : 0;
+      const compB = b.completionDate ? new Date(b.completionDate).getTime() : 0;
+      if (compB !== compA) return compB - compA;
+      const subA = a.submittedDate ? new Date(a.submittedDate).getTime() : 0;
+      const subB = b.submittedDate ? new Date(b.submittedDate).getTime() : 0;
+      if (subB !== subA) return subB - subA;
+      const updA = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+      const updB = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+      return updB - updA;
+    });
+
+    return filtered.map((p, i) => toUnit(p, i));
+  }, [projects, searchQuery, showWinnersOnly, activeFilters]);
+
+  const handleFilterChange = useCallback((filterId: string) => {
+    setActiveFilters((prev) => prev.includes(filterId) ? prev.filter((id) => id !== filterId) : [...prev, filterId]);
+  }, []);
+  const handleClearFilters = useCallback(() => {
+    setActiveFilters([]);
+    setShowWinnersOnly(false);
+    setSearchQuery("");
+  }, []);
+
+  return (
+    <>
+      {/* Filter bar */}
+      <section className="panel px-3 py-2.5 mb-3 flex flex-wrap items-center gap-2">
+        <InputBus
+          value={searchQuery}
+          onChange={setSearchQuery}
+          placeholder="search entries..."
+          className="flex-1 min-w-[200px]"
+        />
+        <HardwareToggle
+          options={[{ value: "winners", label: "WINNERS" }, { value: "all", label: "ALL" }]}
+          value={showWinnersOnly ? "winners" : "all"}
+          onChange={(v) => setShowWinnersOnly(v === "winners")}
+        />
+        <Sheet open={isFiltersOpen} onOpenChange={setIsFiltersOpen}>
+          <SheetTrigger asChild>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-label-mid hover:text-display hover:bg-panel-deep px-3 py-1.5 rounded-none"
+            >
+              <Filter className="h-3 w-3 mr-1.5" />
+              FILTERS{activeFilters.length > 0 && ` · ${activeFilters.length}`}
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="left" className="w-[320px] panel">
+            <SheetHeader>
+              <SheetTitle className="label-hw">·CATEGORY FILTERS</SheetTitle>
+            </SheetHeader>
+            <div className="mt-6">
+              <Suspense fallback={<div className="label-hw-dim">Loading filters…</div>}>
+                <FilterSidebar
+                  activeFilters={activeFilters}
+                  onFilterChange={handleFilterChange}
+                  onClearFilters={handleClearFilters}
+                  showWinnersOnly={showWinnersOnly}
+                  onWinnersOnlyChange={setShowWinnersOnly}
+                />
+              </Suspense>
+            </div>
+          </SheetContent>
+        </Sheet>
+      </section>
+
+      {/* Projects grid */}
+      <section>
+        <div className="flex items-center justify-between mb-3 pb-3 border-b border-hairline">
+          <div className="label-hw text-display">·PROJECTS</div>
+          <div className="label-hw-dim">{filteredProjects.length} {filteredProjects.length === 1 ? "ENTRY" : "ENTRIES"}</div>
+        </div>
+
+        {loading ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+            {Array.from({ length: 6 }).map((_, i) => <ProjectCardSkeleton key={i} />)}
+          </div>
+        ) : filteredProjects.length === 0 ? (
+          <NoProjectsFound onClearFilters={handleClearFilters} />
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
+            {filteredProjects.map((u) => (
+              <UnitCard key={u.id} {...u} onClick={() => setSelectedUnit(u)} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {selectedUnit && (
+        <Suspense fallback={null}>
+          <UnitDetailModal
+            open={!!selectedUnit}
+            onOpenChange={(open) => !open && setSelectedUnit(null)}
+            unit={selectedUnit}
+          />
+        </Suspense>
+      )}
+    </>
+  );
+}

--- a/client/src/components/TeamPaymentSection.tsx
+++ b/client/src/components/TeamPaymentSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -96,6 +96,12 @@ export function TeamPaymentSection({
   
   // Editable state
   const [editedMembers, setEditedMembers] = useState<TeamMember[]>([]);
+  // Stable React keys for the editable member rows, kept length-synced with
+  // editedMembers so deleting a middle row doesn't shift input focus/cursor
+  // onto the wrong row (the failure mode of keying controlled inputs by index).
+  const [editedMemberKeys, setEditedMemberKeys] = useState<number[]>([]);
+  const memberKeySeq = useRef(0);
+  const nextMemberKey = () => (memberKeySeq.current += 1);
   const [editedPayoutAddress, setEditedPayoutAddress] = useState("");
   const [editedPayoutChain, setEditedPayoutChain] = useState<WalletChain>('substrate');
 
@@ -105,7 +111,9 @@ export function TeamPaymentSection({
   // Initialize edited values when entering edit mode or when props change
   useEffect(() => {
     if (canEdit) {
-      setEditedMembers(teamMembers.length > 0 ? [...teamMembers] : [{ name: "", walletAddress: "" }]);
+      const init = teamMembers.length > 0 ? [...teamMembers] : [{ name: "", walletAddress: "" }];
+      setEditedMembers(init);
+      setEditedMemberKeys(init.map(() => nextMemberKey()));
       setEditedPayoutAddress(donationAddress || "");
       setEditedPayoutChain(donationChain);
     }
@@ -185,11 +193,13 @@ export function TeamPaymentSection({
 
   const addMember = () => {
     setEditedMembers(prev => [...prev, { name: "", walletAddress: "" }]);
+    setEditedMemberKeys(prev => [...prev, nextMemberKey()]);
   };
 
   const removeMember = (index: number) => {
     if (editedMembers.length > 1) {
       setEditedMembers(prev => prev.filter((_, i) => i !== index));
+      setEditedMemberKeys(prev => prev.filter((_, i) => i !== index));
     }
   };
 
@@ -236,7 +246,9 @@ export function TeamPaymentSection({
 
   const handleCancel = () => {
     // Reset to original values
-    setEditedMembers(teamMembers.length > 0 ? [...teamMembers] : [{ name: "", walletAddress: "" }]);
+    const reset = teamMembers.length > 0 ? [...teamMembers] : [{ name: "", walletAddress: "" }];
+    setEditedMembers(reset);
+    setEditedMemberKeys(reset.map(() => nextMemberKey()));
     setEditedPayoutAddress(donationAddress || "");
     setEditedPayoutChain(donationChain);
     setIsEditing(false);
@@ -244,7 +256,10 @@ export function TeamPaymentSection({
 
   // Render read-only team member card
   const renderReadOnlyMember = (member: TeamMember, index: number) => (
-    <div key={member.walletAddress || index} className="lcd p-4">
+    // Fold in the index: a wallet address is not guaranteed unique across a
+    // team's members (mock data redacts several to the same string), so keying
+    // by address alone collides and triggers React's duplicate-key warning.
+    <div key={`${member.walletAddress || "member"}-${index}`} className="lcd p-4">
       <div className="flex items-start justify-between">
         <div className="space-y-1 flex-1">
             <div className="flex items-center gap-2 flex-wrap">
@@ -317,7 +332,7 @@ export function TeamPaymentSection({
 
   // Render editable team member card
   const renderEditableMember = (member: TeamMember, index: number) => (
-    <div key={index} className="lcd p-4 space-y-3">
+    <div key={editedMemberKeys[index] ?? index} className="lcd p-4 space-y-3">
         <div className="flex items-start justify-between gap-2">
           <div className="flex-1 grid gap-3">
             {/* Row 1: Name and Role */}

--- a/client/src/components/UpdateTeamModal.tsx
+++ b/client/src/components/UpdateTeamModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -35,17 +35,26 @@ export function UpdateTeamModal({
   const [members, setMembers] = useState<TeamMember[]>(initialMembers);
   const [payoutAddress, setPayoutAddress] = useState(initialPayoutAddress);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  // Stable React keys for the member rows, length-synced with `members` so
+  // deleting a middle row keeps each controlled input bound to its own row
+  // instead of shifting focus/values (the index-key failure mode).
+  const [memberKeys, setMemberKeys] = useState<number[]>([]);
+  const memberKeySeq = useRef(0);
+  const nextMemberKey = () => (memberKeySeq.current += 1);
 
   // Reset form when modal opens/closes
   useEffect(() => {
     if (open) {
-      setMembers(initialMembers.length > 0 ? initialMembers : [{ name: '', wallet: '' }]);
+      const init = initialMembers.length > 0 ? initialMembers : [{ name: '', wallet: '' }];
+      setMembers(init);
+      setMemberKeys(init.map(() => nextMemberKey()));
       setPayoutAddress(initialPayoutAddress);
     }
   }, [open, initialMembers, initialPayoutAddress]);
 
   const handleAddMember = () => {
     setMembers([...members, { name: '', wallet: '' }]);
+    setMemberKeys([...memberKeys, nextMemberKey()]);
   };
 
   const handleRemoveMember = (index: number) => {
@@ -58,6 +67,7 @@ export function UpdateTeamModal({
       return;
     }
     setMembers(members.filter((_, i) => i !== index));
+    setMemberKeys(memberKeys.filter((_, i) => i !== index));
   };
 
   const handleMemberChange = (index: number, field: 'name' | 'wallet' | 'role' | 'twitter' | 'github' | 'linkedin', value: string) => {
@@ -122,7 +132,7 @@ export function UpdateTeamModal({
             <h3 className="label-hw text-display mb-3">·TEAM MEMBERS</h3>
             <div className="space-y-3">
               {members.map((member, index) => (
-                <div key={index} className="lcd p-4 space-y-3">
+                <div key={memberKeys[index] ?? index} className="lcd p-4 space-y-3">
                   <div className="flex gap-2">
                     <div className="flex-1">
                       <Label htmlFor={`name-${index}`} className="label-hw-dim">NAME *</Label>

--- a/client/src/components/audio/sound-cloud-audio.tsx
+++ b/client/src/components/audio/sound-cloud-audio.tsx
@@ -153,8 +153,16 @@ export function SoundCloudAudioProvider({ children }: { children: React.ReactNod
       const next = !prev;
       const widget = widgetRef.current;
       if (widget) {
-        widget.setVolume(next ? 0 : 100);
-        widget.play();
+        // Mute by pausing, not by setVolume(0): on mobile (notably iOS) volume is
+        // hardware-controlled and setVolume is a no-op, so volume-based muting
+        // silently failed there. play()/pause() honor the user's tap on every
+        // platform — and the tap is the gesture mobile needs to start audio.
+        if (next) {
+          widget.pause();
+        } else {
+          widget.setVolume(100);
+          widget.play();
+        }
       }
       return next;
     });

--- a/client/src/components/audio/sound-cloud-audio.tsx
+++ b/client/src/components/audio/sound-cloud-audio.tsx
@@ -40,9 +40,10 @@ declare global {
 }
 
 const SC_WIDGET_SCRIPT = "https://w.soundcloud.com/player/api.js";
-const SC_PROFILE_URL = "https://soundcloud.com/pommeshdrms";
+const SC_TRACK_URL =
+  "https://soundcloud.com/otherside-podcast/pomlouyen-other-side-podcast-08";
 const SC_IFRAME_SRC =
-  `https://w.soundcloud.com/player/?url=${encodeURIComponent(SC_PROFILE_URL)}` +
+  `https://w.soundcloud.com/player/?url=${encodeURIComponent(SC_TRACK_URL)}` +
   "&auto_play=false&hide_related=true&show_comments=false&show_user=false" +
   "&show_reposts=false&show_teaser=false&visual=false&buying=false" +
   "&sharing=false&download=false&show_artwork=false";
@@ -131,9 +132,9 @@ export function SoundCloudAudioProvider({ children }: { children: React.ReactNod
             setPositionMs(data.currentPosition);
           }
         });
-        // Loop forever: when the profile's tracks run out, restart from the top so
-        // the music never stops (it already survives navigation — the iframe lives
-        // above the router).
+        // Loop forever: when the track ends, restart from the top so the music
+        // never stops (it already survives navigation — the iframe lives above
+        // the router).
         widget.bind(window.SC.Widget.Events.FINISH, () => {
           if (cancelled) return;
           widget.seekTo(0);
@@ -183,7 +184,7 @@ export function SoundCloudAudioProvider({ children }: { children: React.ReactNod
       <iframe
         ref={iframeRef}
         src={SC_IFRAME_SRC}
-        title="SoundCloud audio player (pommeshdrms)"
+        title="SoundCloud audio player (otherside-podcast)"
         aria-hidden="true"
         tabIndex={-1}
         allow="autoplay; encrypted-media"

--- a/client/src/components/brightness-rack.tsx
+++ b/client/src/components/brightness-rack.tsx
@@ -283,18 +283,18 @@ export function BrightnessRack({ className }: BrightnessRackProps) {
             </div>
           )}
           <div className="min-w-0 flex-1">
-            <div className="font-mono text-[11px] text-display truncate" title={title || "pommeshdrms"}>
-              {title || "pommeshdrms"}
+            <div className="font-mono text-[11px] text-display truncate" title={title || "otherside-podcast"}>
+              {title || "otherside-podcast"}
             </div>
             <div className="label-hw-dim truncate">
-              {["pommeshdrms", genre].filter(Boolean).join(" · ")}
+              {["otherside-podcast", genre].filter(Boolean).join(" · ")}
             </div>
             <div className="flex items-center gap-3 mt-1">
               <a
-                href="https://soundcloud.com/pommeshdrms"
+                href="https://soundcloud.com/otherside-podcast"
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label="pommeshdrms on SoundCloud (opens in new tab)"
+                aria-label="otherside-podcast on SoundCloud (opens in new tab)"
                 className="label-hw-dim hover:text-display transition-colors duration-200"
               >
                 SOUNDCLOUD ↗

--- a/client/src/components/program-spaces.tsx
+++ b/client/src/components/program-spaces.tsx
@@ -56,7 +56,7 @@ export function ProgramSpaces({ programs }: { programs: ApiProgram[] }) {
     <section className="mb-10">
       <div className="flex items-center justify-between mb-3 pb-3 border-b border-hairline">
         <div className="label-hw text-display flex items-center gap-2">
-          <span className="led led-sm led-pulse" aria-hidden="true" /> ·PROGRAMS / WHAT WE DO
+          <span className="led led-sm led-pulse" aria-hidden="true" /> ·EXPLORE PAST PROGRAMS
         </div>
       </div>
       <p className="text-body text-sm md:text-base max-w-2xl leading-relaxed mb-3">

--- a/client/src/components/program-spaces.tsx
+++ b/client/src/components/program-spaces.tsx
@@ -16,7 +16,7 @@ const SPACES: Space[] = [
   {
     type: "hackathon",
     label: "HACKATHONS",
-    blurb: "Weekend build sprints on Polkadot: ship something new, win bounties.",
+    blurb: "Weekend build sprints: ship something new, win bounties.",
     href: "/programs?type=hackathon",
     Icon: Zap,
   },

--- a/client/src/hooks/use-brightness.ts
+++ b/client/src/hooks/use-brightness.ts
@@ -14,23 +14,13 @@ interface StoredState {
   collapsed: boolean;
 }
 
-// Below this viewport width we treat the device as "mobile-ish" and default
-// the brightness rack to its compact strip — otherwise the full panel eats
-// ~170px of vertical space on every page load, which felt invasive.
-const MOBILE_BREAKPOINT_PX = 640;
-
-function isMobileViewport(): boolean {
-  if (typeof window === 'undefined') return false;
-  return window.innerWidth < MOBILE_BREAKPOINT_PX;
-}
-
 function readStored(): StoredState {
   const defaults: StoredState = {
     mode: 'auto',
     manualValue: null,
     paletteKey: DEFAULT_PALETTE_KEY,
-    // Default to collapsed on mobile viewports; users can expand explicitly.
-    collapsed: isMobileViewport(),
+    // Default to collapsed everywhere; users can expand explicitly.
+    collapsed: true,
   };
   if (typeof window === 'undefined') return defaults;
   try {
@@ -42,11 +32,10 @@ function readStored(): StoredState {
       mode: parsed.mode,
       manualValue: typeof parsed.manualValue === 'number' ? parsed.manualValue : null,
       paletteKey: typeof parsed.paletteKey === 'string' ? parsed.paletteKey : DEFAULT_PALETTE_KEY,
-      // Honor a stored collapsed=true; if the user never set one, fall back
-      // to the mobile-viewport default so first-time mobile loads aren't
-      // dominated by the brightness panel.
+      // Honor a stored collapsed value; if the user never set one, default to
+      // collapsed so first loads aren't dominated by the brightness panel.
       collapsed:
-        typeof parsed.collapsed === 'boolean' ? parsed.collapsed : isMobileViewport(),
+        typeof parsed.collapsed === 'boolean' ? parsed.collapsed : true,
     };
   } catch {
     return defaults;

--- a/client/src/pages/HomePage.tsx
+++ b/client/src/pages/HomePage.tsx
@@ -1,77 +1,22 @@
-import { useState, useMemo, useEffect, lazy, Suspense, useCallback } from "react";
-import { Filter } from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
-import { Card, CardContent } from "@/components/ui/card";
+import { useState, useMemo, useEffect } from "react";
 import { Navigation } from "@/components/Navigation";
-import { UnitCard } from "@/components/unit-card";
 import { LCDStat } from "@/components/lcd-stat";
-import { InputBus } from "@/components/input-bus";
-import { HardwareToggle } from "@/components/hardware-toggle";
-import { ProjectCardSkeleton } from "@/components/ProjectCardSkeleton";
-import { NoProjectsFound } from "@/components/EmptyState";
 import { ProgramSpaces } from "@/components/program-spaces";
-import { api, type ApiProject, type ApiProgram, API_BASE_URL } from "@/lib/api";
+import { api, type ApiProject, type ApiProgram } from "@/lib/api";
 import { isMainTrackWinner } from "@/lib/projectUtils";
 import { useToast } from "@/hooks/use-toast";
 
-// Lazy load heavy components (filter sidebar + detail modal)
-const FilterSidebar = lazy(() => import("@/components/FilterSidebar").then(m => ({ default: m.FilterSidebar })));
-const UnitDetailModal = lazy(() => import("@/components/unit-detail-modal").then(m => ({ default: m.UnitDetailModal })));
-
-type UnitForCard = {
-  id: string;
-  unitNumber: string;
-  title: string;
-  author: string;
-  description: string;
-  longDescription?: string;
-  track: string;
-  isWinner: boolean;
-  isM2: boolean;
-  date?: string;
-  prize?: string;
-  demoUrl?: string;
-  githubUrl?: string;
-  projectUrl?: string;
-  techStack?: string[];
-  categories?: string[];
-  teamSize?: number;
-};
-
-const FILTER_TO_CATEGORY: Record<string, string> = {
-  gaming: "Gaming",
-  defi: "DeFi",
-  nft: "NFT",
-  "developer-tools": "Developer Tools",
-  social: "Social",
-  ai: "AI",
-  arts: "Arts",
-  mobile: "Mobile",
-};
-
 const HomePage = () => {
-  const [activeFilters, setActiveFilters] = useState<string[]>([]);
-  const [showWinnersOnly, setShowWinnersOnly] = useState(true);
-  const [selectedUnit, setSelectedUnit] = useState<UnitForCard | null>(null);
-  const [searchQuery, setSearchQuery] = useState("");
-  const [selectedHackathon, setSelectedHackathon] = useState<string>("all");
-  const [projects, setProjects] = useState<ApiProject[]>([]);
-  const [hackathons, setHackathons] = useState<{ id: string; name: string }[]>([]);
   const [allProjects, setAllProjects] = useState<ApiProject[]>([]);
   const [allPrograms, setAllPrograms] = useState<ApiProgram[]>([]);
   const [statsLoading, setStatsLoading] = useState(true);
-  const [loading, setLoading] = useState(true);
-  const [loadError, setLoadError] = useState<string | null>(null);
-  const [isFiltersOpen, setIsFiltersOpen] = useState(false);
   const { toast } = useToast();
 
-  // Load the event filter list and the project stats in parallel.
-  // Phase 2 #94: events come from `programs` (program_type='hackathon'), not
-  // from aggregating `project.hackathon.id` — so upcoming events surface
-  // even when they have zero projects yet.
+  // Load the project stats (for the index panel) and the programs list (for the
+  // program spaces) in parallel. Phase 2 #94: programs come from the `programs`
+  // table so upcoming/past events surface even with zero projects.
   useEffect(() => {
-    const loadEventsAndStats = async () => {
+    const loadStatsAndPrograms = async () => {
       try {
         const [projectsResp, programsResp] = await Promise.all([
           api.getProjects({ limit: 2000, sortBy: "updatedAt", sortOrder: "desc" }),
@@ -79,148 +24,21 @@ const HomePage = () => {
         ]);
         const apiProjects: ApiProject[] = Array.isArray(projectsResp?.data) ? projectsResp.data : [];
         setAllProjects(apiProjects);
-        setStatsLoading(false);
         setAllPrograms(programsResp?.data ?? []);
-        const eventPrograms = (programsResp?.data ?? []).filter(
-          (p) => p.programType === "hackathon",
-        );
-        if (eventPrograms.length > 0) {
-          setHackathons(eventPrograms.map((p) => ({ id: p.slug, name: p.name })));
-        } else {
-          // Fallback for environments where programs aren't seeded yet —
-          // derive the list from project rows so the filter still works.
-          const unique = new Map<string, string>();
-          for (const p of apiProjects) {
-            if (p.hackathon?.id) {
-              unique.set(p.hackathon.id, p.hackathon.name || p.hackathon.id);
-            }
-          }
-          setHackathons(Array.from(unique.entries()).map(([id, name]) => ({ id, name })));
-        }
       } catch {
         toast({
           title: "Error",
-          description: "Failed to load event list. Event filtering may be unavailable.",
+          description: "Failed to load directory stats.",
           variant: "destructive",
         });
+      } finally {
+        setStatsLoading(false);
       }
     };
-    loadEventsAndStats();
+    loadStatsAndPrograms();
     // Run once on mount; `toast` is stable across renders.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const [retryCount, setRetryCount] = useState(0);
-  useEffect(() => {
-    const load = async () => {
-      try {
-        setLoading(true);
-        setLoadError(null);
-        const params = selectedHackathon === "all"
-          ? { limit: 1000, sortBy: "updatedAt", sortOrder: "desc" as const }
-          : { hackathonId: selectedHackathon, limit: 1000, sortBy: "updatedAt", sortOrder: "desc" as const };
-        const response = await api.getProjects(params);
-        if (!Array.isArray(response?.data)) {
-          const msg = "API returned no data array. Check server response.";
-          setLoadError(msg);
-          setProjects([]);
-          toast({ title: "Could not load projects", description: msg, variant: "destructive" });
-          return;
-        }
-        setProjects(response.data);
-      } catch (error) {
-        const errMsg = error instanceof Error ? error.message : "Failed to load projects";
-        setLoadError(errMsg);
-        setProjects([]);
-        toast({ title: "Error", description: errMsg, variant: "destructive" });
-      } finally {
-        setLoading(false);
-      }
-    };
-    load();
-  }, [selectedHackathon, toast, retryCount]);
-
-  // Map an ApiProject into the rack-card shape — the index in the displayed
-  // list provides a stable zero-padded "UNIT NNN" label.
-  const toUnit = useCallback((p: ApiProject, idx: number): UnitForCard => {
-    const track = p.bountyPrize?.[0]?.name || p.categories?.[0] || "Other";
-    const isWinner = Array.isArray(p.bountyPrize) && p.bountyPrize.length > 0;
-    const isM2 = p.m2Status === "completed";
-    const dateStr = p.completionDate || p.submittedDate || p.hackathon?.endDate;
-    const date = dateStr
-      ? new Date(dateStr).toLocaleDateString("en-US", { month: "short", day: "2-digit" }).toUpperCase()
-      : undefined;
-    const prize = p.bountyPrize?.[0]?.amount
-      ? `$${p.bountyPrize[0].amount.toLocaleString()}`
-      : undefined;
-    return {
-      id: p.id,
-      unitNumber: String(idx + 1).padStart(3, "0"),
-      title: p.projectName,
-      author: p.teamMembers?.[0]?.name || "Unknown",
-      description: p.description,
-      track,
-      isWinner,
-      isM2,
-      date,
-      prize,
-      demoUrl: p.demoUrl,
-      githubUrl: p.projectRepo,
-      projectUrl: p.id ? `/m2-program/${p.id}` : undefined,
-      techStack: Array.isArray(p.techStack) ? p.techStack : undefined,
-      categories: p.categories,
-      teamSize: p.teamMembers?.length,
-    };
-  }, []);
-
-  // Filter + sort projects.
-  const filteredProjects = useMemo(() => {
-    let filtered = projects;
-
-    if (selectedHackathon !== "all") {
-      filtered = filtered.filter((p) => p.hackathon?.id === selectedHackathon);
-    }
-
-    if (searchQuery) {
-      const query = searchQuery.toLowerCase();
-      filtered = filtered.filter((p) =>
-        p.projectName.toLowerCase().includes(query) ||
-        p.description.toLowerCase().includes(query) ||
-        p.teamMembers?.[0]?.name?.toLowerCase().includes(query)
-      );
-    }
-
-    // When a search query is active, ignore the winners-only filter so
-    // non-winning matches still surface — the user clearly wants a
-    // specific project, regardless of category default.
-    if (showWinnersOnly && !searchQuery) {
-      filtered = filtered.filter((p) => Array.isArray(p.bountyPrize) && p.bountyPrize.length > 0);
-    }
-
-    if (activeFilters.length > 0) {
-      filtered = filtered.filter((p) => {
-        const cats = p.categories || [];
-        return activeFilters.some((id) => {
-          const name = FILTER_TO_CATEGORY[id];
-          return name && cats.some((c) => c.toLowerCase() === name.toLowerCase());
-        });
-      });
-    }
-
-    filtered.sort((a, b) => {
-      const compA = a.completionDate ? new Date(a.completionDate).getTime() : 0;
-      const compB = b.completionDate ? new Date(b.completionDate).getTime() : 0;
-      if (compB !== compA) return compB - compA;
-      const subA = a.submittedDate ? new Date(a.submittedDate).getTime() : 0;
-      const subB = b.submittedDate ? new Date(b.submittedDate).getTime() : 0;
-      if (subB !== subA) return subB - subA;
-      const updA = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
-      const updB = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
-      return updB - updA;
-    });
-
-    return filtered.map((p, i) => toUnit(p, i));
-  }, [projects, searchQuery, showWinnersOnly, activeFilters, selectedHackathon, toUnit]);
 
   const stats = useMemo(() => {
     const totalProjects = allProjects.length;
@@ -232,27 +50,6 @@ const HomePage = () => {
     }, 0);
     return { totalProjects, winners, m2Graduates, totalPaid };
   }, [allProjects]);
-
-  // Featured "·NOW SHOWING" unit — most recently-shipped M2 graduate.
-  const featuredUnit = useMemo<UnitForCard | null>(() => {
-    const shipped = projects
-      .filter((p) => p.m2Status === "completed" && isMainTrackWinner(p))
-      .sort((a, b) => {
-        const dA = a.completionDate ? new Date(a.completionDate).getTime() : 0;
-        const dB = b.completionDate ? new Date(b.completionDate).getTime() : 0;
-        return dB - dA;
-      });
-    return shipped[0] ? toUnit(shipped[0], 0) : null;
-  }, [projects, toUnit]);
-
-  const handleFilterChange = useCallback((filterId: string) => {
-    setActiveFilters((prev) => prev.includes(filterId) ? prev.filter((id) => id !== filterId) : [...prev, filterId]);
-  }, []);
-  const handleClearFilters = useCallback(() => {
-    setActiveFilters([]);
-    setShowWinnersOnly(false);
-    setSearchQuery("");
-  }, []);
 
   const fmtUSD = (n: number) => n >= 1000 ? `$${(n / 1000).toFixed(1)}K` : `$${n}`;
 
@@ -275,7 +72,7 @@ const HomePage = () => {
             </h1>
           </div>
           <p className="text-body text-base md:text-lg max-w-xl leading-relaxed">
-            Stuff people build here. Browse our programs, leave your mark.
+            Stuff people build here. Explore past programs, leave your mark.
           </p>
 
           <div className="pt-8">
@@ -304,121 +101,6 @@ const HomePage = () => {
 
         {/* Programs — entry point to all WebZero program types */}
         <ProgramSpaces programs={allPrograms} />
-
-        {/* Now Showing — single featured unit */}
-        {featuredUnit && (
-          <section className="mb-10">
-            <div className="flex items-center justify-between mb-3 pb-3 border-b border-hairline">
-              <div className="label-hw text-display flex items-center gap-2">
-                <span className="led led-sm led-pulse" aria-hidden="true" />
-                ·NOW SHOWING / ENTRY {featuredUnit.unitNumber}
-              </div>
-              {featuredUnit.date && <div className="label-hw-dim">{featuredUnit.date}</div>}
-            </div>
-            <UnitCard
-              {...featuredUnit}
-              onClick={() => setSelectedUnit(featuredUnit)}
-            />
-          </section>
-        )}
-
-        {/* Filter bar */}
-        <section className="panel px-3 py-2.5 mb-3 flex flex-wrap items-center gap-2">
-          <InputBus
-            value={searchQuery}
-            onChange={setSearchQuery}
-            placeholder="search entries..."
-            className="flex-1 min-w-[200px]"
-          />
-          {hackathons.length > 0 && (
-            <select
-              value={selectedHackathon}
-              onChange={(e) => setSelectedHackathon(e.target.value)}
-              className="lcd font-mono text-[11px] text-display bg-panel-deep border border-hairline-subtle px-2 py-1.5 outline-none cursor-pointer focus-visible:ring-2 focus-visible:ring-led"
-              aria-label="Filter by hackathon"
-            >
-              <option value="all">ALL EVENTS</option>
-              {hackathons.map((h) => (
-                <option key={h.id} value={h.id}>{h.name.toUpperCase()}</option>
-              ))}
-            </select>
-          )}
-          <HardwareToggle
-            options={[{ value: "winners", label: "WINNERS" }, { value: "all", label: "ALL" }]}
-            value={showWinnersOnly ? "winners" : "all"}
-            onChange={(v) => setShowWinnersOnly(v === "winners")}
-          />
-          <Sheet open={isFiltersOpen} onOpenChange={setIsFiltersOpen}>
-            <SheetTrigger asChild>
-              <Button
-                variant="ghost"
-                size="sm"
-                className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-label-mid hover:text-display hover:bg-panel-deep px-3 py-1.5 rounded-none"
-              >
-                <Filter className="h-3 w-3 mr-1.5" />
-                FILTERS{activeFilters.length > 0 && ` · ${activeFilters.length}`}
-              </Button>
-            </SheetTrigger>
-            <SheetContent side="left" className="w-[320px] panel">
-              <SheetHeader>
-                <SheetTitle className="label-hw">·CATEGORY FILTERS</SheetTitle>
-              </SheetHeader>
-              <div className="mt-6">
-                <Suspense fallback={<div className="label-hw-dim">Loading filters…</div>}>
-                  <FilterSidebar
-                    activeFilters={activeFilters}
-                    onFilterChange={handleFilterChange}
-                    onClearFilters={handleClearFilters}
-                    showWinnersOnly={showWinnersOnly}
-                    onWinnersOnlyChange={setShowWinnersOnly}
-                  />
-                </Suspense>
-              </div>
-            </SheetContent>
-          </Sheet>
-        </section>
-
-        {/* Projects grid */}
-        <section className="mb-10">
-          <div className="flex items-center justify-between mb-3 pb-3 border-b border-hairline">
-            <div className="label-hw text-display">·DIRECTORY / GRID</div>
-            <div className="label-hw-dim">{filteredProjects.length} {filteredProjects.length === 1 ? "ENTRY" : "ENTRIES"}</div>
-          </div>
-
-          {loading ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-              {Array.from({ length: 9 }).map((_, i) => <ProjectCardSkeleton key={i} />)}
-            </div>
-          ) : filteredProjects.length === 0 ? (
-            loadError ? (
-              <Card className="lcd p-6">
-                <CardContent className="space-y-3 p-0">
-                  <div className="label-hw text-destructive">·ERROR / NO PROJECTS</div>
-                  <p className="text-body text-sm break-all">{loadError}</p>
-                  <p className="label-hw-dim">
-                    API: <code className="text-display">{API_BASE_URL || "undefined"}</code>
-                  </p>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setRetryCount((c) => c + 1)}
-                    className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep px-3 py-1.5 rounded-none"
-                  >
-                    RETRY
-                  </Button>
-                </CardContent>
-              </Card>
-            ) : (
-              <NoProjectsFound onClearFilters={handleClearFilters} />
-            )
-          ) : (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-2">
-              {filteredProjects.map((u) => (
-                <UnitCard key={u.id} {...u} onClick={() => setSelectedUnit(u)} />
-              ))}
-            </div>
-          )}
-        </section>
       </main>
 
       <footer className="panel mt-12">
@@ -435,16 +117,6 @@ const HomePage = () => {
           <span>POLKADOT · SUPERTEAM · HYPERBRIDGE · ARKIV</span>
         </div>
       </footer>
-
-      {selectedUnit && (
-        <Suspense fallback={null}>
-          <UnitDetailModal
-            open={!!selectedUnit}
-            onOpenChange={(open) => !open && setSelectedUnit(null)}
-            unit={selectedUnit}
-          />
-        </Suspense>
-      )}
     </div>
   );
 };

--- a/client/src/pages/ProgramDetailPage.tsx
+++ b/client/src/pages/ProgramDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useParams, Link, useNavigate } from "react-router-dom";
+import { useParams, Link } from "react-router-dom";
 import { Navigation } from "@/components/Navigation";
-import { UnitCard } from "@/components/unit-card";
+import { ProjectExplorer } from "@/components/ProjectExplorer";
 import { RotateCw } from "lucide-react";
 import { ChainPicker } from "@/components/auth/ChainPicker";
 import { getProvider } from "@/lib/auth/registry";
@@ -53,7 +53,6 @@ const ProgramDetailPage = () => {
   const [entries, setEntries] = useState<ApiProject[]>([]);
   const [modalOpen, setModalOpen] = useState(false);
   const [nonMemberOpen, setNonMemberOpen] = useState(false);
-  const navigate = useNavigate();
 
   // Admins can apply on behalf of any project (server-side `requireTeamMemberOrAdminByBodyProject`
   // accepts admins). Without this branch, the page would dead-end at "You need to be a team member"
@@ -445,34 +444,7 @@ const ProgramDetailPage = () => {
 
             {entries.length > 0 && (
               <div className="panel p-4 mb-4">
-                <div className="label-hw mb-3">·PROJECTS</div>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                  {entries.map((p, i) => {
-                    const isWinner = Array.isArray(p.bountyPrize) && p.bountyPrize.length > 0;
-                    const dateStr = p.completionDate || p.submittedDate || p.hackathon?.endDate;
-                    const date = dateStr
-                      ? new Date(dateStr).toLocaleDateString("en-US", { month: "short", day: "2-digit" }).toUpperCase()
-                      : undefined;
-                    return (
-                      <UnitCard
-                        key={p.id}
-                        unitNumber={String(i + 1).padStart(3, "0")}
-                        title={p.projectName}
-                        author={p.teamMembers?.[0]?.name || "Unknown"}
-                        description={p.description}
-                        track={p.bountyPrize?.[0]?.name || p.categories?.[0] || "Other"}
-                        isWinner={isWinner}
-                        isM2={p.m2Status === "completed"}
-                        date={date}
-                        prize={p.bountyPrize?.[0]?.amount ? `$${p.bountyPrize[0].amount.toLocaleString()}` : undefined}
-                        demoUrl={p.demoUrl}
-                        githubUrl={p.projectRepo}
-                        projectUrl={`/m2-program/${p.id}`}
-                        onClick={() => navigate(`/m2-program/${p.id}`)}
-                      />
-                    );
-                  })}
-                </div>
+                <ProjectExplorer projects={entries} />
               </div>
             )}
 

--- a/client/src/pages/ProgramsPage.tsx
+++ b/client/src/pages/ProgramsPage.tsx
@@ -60,7 +60,7 @@ const ProgramsPage = () => {
 
         <div className="flex items-center justify-between mb-3 pb-3 border-b border-hairline">
           <div className="label-hw text-display flex items-center gap-2">
-            <span className="led led-sm" aria-hidden="true" /> ·GRID
+            <span className="led led-sm" aria-hidden="true" /> ·ONGOING PROGRAMS
           </div>
           <div className="label-hw-dim">
             {loading ? "…" : `${openPrograms.length} ${openPrograms.length === 1 ? "PROGRAM" : "PROGRAMS"}`}

--- a/server/api/controllers/project.controller.js
+++ b/server/api/controllers/project.controller.js
@@ -80,7 +80,7 @@ class ProjectController {
             // Debug logging for incoming payload (safe fields only)
             try {
                 const preview = JSON.stringify(updateData)?.slice(0, 500);
-                console.log(`[ProjectController] updateProject payload for ${projectId}:`, preview);
+                logger.info(`[ProjectController] updateProject payload for ${projectId}:`, preview);
             } catch {}
 
             if (!updateData || typeof updateData !== 'object' || Object.keys(updateData).length === 0) {
@@ -193,7 +193,7 @@ class ProjectController {
                 return res.status(404).json({ status: "error", message: "Project not found" });
             }
 
-            console.log(`✅ M2 Agreement updated for project ${projectId}`);
+            logger.success(`✅ M2 Agreement updated for project ${projectId}`);
             res.status(200).json({ status: "success", data: updated });
         } catch (error) {
             console.error("❌ Error updating M2 agreement:", error);


### PR DESCRIPTION
Rolling draft for small bug fixes.

## Fixes

- **Audio mute on mobile** — the mute toggle relied on `widget.setVolume(0)`, which is a no-op on mobile (iOS controls volume in hardware), so tapping mute kept playing at full volume. Mute now pauses / unmute plays (`setVolume(100)` still applied on desktop). Needs a real-device check.

- **Stable React keys on editable team + M2-agreement lists** — the add/remove lists in `TeamPaymentSection` (editable members), `UpdateTeamModal`, and `M2AgreementModal` (core features / documentation / nice-to-have) keyed their controlled inputs by array index, so deleting a middle row reused the wrong DOM node and shifted focus/values onto a sibling row. Each row now carries a stable client-generated id (kept length-synced with its data) and is keyed by it.

- **TeamPaymentSection duplicate-key warning** — the read-only member card keyed by `member.walletAddress || index`. Wallet addresses are not unique across a team's members (mock data redacts several to one string), so keying by address alone collided and tripped React's "two children with the same key" warning. The key now folds in the index.

- **Two debug `console.log` -> logger (server)** — `project.controller.js` used raw `console.log` for the `updateProject` payload preview and the M2-agreement confirmation; both now route through the existing `logger` util (`info` / `success`) like the rest of the controller.

- **Landing page shows programs only** — removed the "Now Showing" featured unit and the whole project search/filter/grid from the landing page (`HomePage.tsx`). It now shows the hero, live stats, and the program cards, with the section heading reworded to "Explore past programs".

- **Project search view moved onto program pages** — the landing search view (search box, WINNERS/ALL toggle, category-filter sheet, grid + detail modal) is extracted into a reusable `ProjectExplorer` component. Each program's detail page (`ProgramDetailPage.tsx`) now renders it in place of the old static grid, scoped to that program's entries, so opening a program (e.g. sub0 hack 2025) gives the same browse/search experience.

- **"Ongoing programs" heading** — the Programs page open section was labelled `·GRID`; renamed to `·ONGOING PROGRAMS` (`ProgramsPage.tsx`).

## Out of scope (config, not code)

- **"Domain mismatch" when marking a team as paid** — this is a server env issue, not a bug in the diff. The first admin write triggers a SIWS session exchange (`POST /api/admin/session`) which enforces `parsed.domain === EXPECTED_DOMAIN` (`auth.middleware.js`). Fix operationally: set `EXPECTED_DOMAIN` on Railway to the exact production hostname (or `DISABLE_SIWS_DOMAIN_CHECK=true`). Already flagged in `docs/launch-checklist.md`.

## Test plan / report

- [x] `cd server && npm test` — 293/293 passing
- [x] `cd client && npm run build` — clean (tsc + vite)
- [x] `cd client && npm run lint` — clean (`--max-warnings 0`)
- [x] Desktop: mute toggle flips with no console errors

### stadium-tester — preview (mock mode), re-run for the landing/program changes

`stadium-git-fix-minor-bug-fixes` preview · commit `79ccc0d` · `window.__STADIUM_MOCK__ = true` · **0 console errors** · **5 scenarios: 5 pass, 0 fail**

| # | Scenario | Result | Notes |
|---|----------|--------|-------|
| 1 | `/` runs in mock mode | PASS | `__STADIUM_MOCK__ === true` |
| 2 | `/` surfaces programs only | PASS | "Explore past programs" + program cards visible; no `search entries…` input, no `·DIRECTORY / GRID` |
| 3 | `/programs` heading is "Ongoing programs", not "Grid" | PASS | `·ONGOING PROGRAMS` visible; `·GRID` count 0 |
| 4 | First program card opens cleanly | PASS | first card = M2 Incubator → `/m2-program`, renders, 0 errors |
| 4b | Hackathon program shows the search view | PASS | `/programs/symbiosis-2025`: `search entries…` + WINNERS/ALL + `·PROJECTS` render; 73 cards, non-matching query narrows to 0 (search functional) |

**Caveats:**
- Earlier-batch scenarios for the editable-list focus-retention fix (UpdateTeam / M2 Agreement modals) remain SIWS-gated and were not re-exercised here — they need a `VITE_USE_TEST_WALLET=true` build. The key-stability fix is covered by the green typecheck + diff.
- React's duplicate-key warning only fires in dev builds; the preview is a prod build, so a clean console there confirms a clean render but is not a strict regression check.

Owner TODO (needs hardware / harness):
- [ ] Mobile (real device): mute stops sound, unmute starts it
- [ ] (optional) Re-run the editable-list modal scenarios against a `VITE_USE_TEST_WALLET=true` build to exercise focus retention

Draft -> develop.
