### PR TITLE
fix(programs): restore UnitCard import — RESULTS section runtime crash

### DIFF
--- a/client/src/pages/ProgramDetailPage.tsx
+++ b/client/src/pages/ProgramDetailPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useParams, Link } from "react-router-dom";
 import { Navigation } from "@/components/Navigation";
 import { ProjectExplorer } from "@/components/ProjectExplorer";
+import { UnitCard } from "@/components/unit-card";
 import { RotateCw } from "lucide-react";
 import { ChainPicker } from "@/components/auth/ChainPicker";
 import { getProvider } from "@/lib/auth/registry";


### PR DESCRIPTION
## What
Re-add the dropped `import { UnitCard } from "@/components/unit-card"` in `ProgramDetailPage.tsx`.

## Why
When #168 swapped the projects grid to `<ProjectExplorer>`, it removed the `UnitCard` import — but the `·RESULTS` (winners) section at `ProgramDetailPage.tsx:520` still renders `<UnitCard>`. Because `client/tsconfig.app.json` runs `strict: false`, tsc never flagged the bare identifier; the client built clean and threw **`UnitCard is not defined`** at runtime the moment a program with **published results** rendered.

This is live on `develop` (independent of the in-flight #171). One-line fix.

## Verification
- `cd client && npm run build` ✓ (tsc now type-checks the 9 props against `UnitCardProps` — all match; build passes)
- `cd client && npm run lint` ✓ (clean, `--max-warnings 0`)
- The runtime `ReferenceError` is structurally eliminated: `UnitCard` is now in scope. No behavior change beyond the section now rendering instead of throwing.

## Scope
Single import line. No logic, styling, or API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)