### PR TITLE
feat(programs): fresh-signature gate on payouts/results + PAID toggle; relax program edit

### DIFF
--- a/client/src/components/admin/ProgramFormModal.tsx
+++ b/client/src/components/admin/ProgramFormModal.tsx
@@ -18,9 +18,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Loader2, Plus, X } from "lucide-react";
-import { web3Enable, web3Accounts, web3FromSource } from "@polkadot/extension-dapp";
-import { SiwsMessage } from "@talismn/siws";
-import { generateSiwsStatement } from "@/lib/siwsUtils";
 import { api, type ApiProgram } from "@/lib/api";
 import { DEFAULT_PRIZE_TIERS } from "@/lib/constants";
 import { useToast } from "@/hooks/use-toast";
@@ -73,7 +70,6 @@ export function ProgramFormModal({
   open,
   onOpenChange,
   program,
-  connectedAddress,
   onSaved,
   signAuthHeader,
   isGlobalAdmin = false,
@@ -82,13 +78,15 @@ export function ProgramFormModal({
   onOpenChange: (v: boolean) => void;
   /** When provided, the modal is in edit mode for this program. Otherwise create mode. */
   program: ApiProgram | null;
-  connectedAddress: string;
   onSaved: (program: ApiProgram) => void;
-  /** When provided + isGlobalAdmin, the modal hosts the admins/judges management UI. */
+  /**
+   * Authorizes the save. Wallet admins pass the cached admin-action bearer,
+   * email admins their Supabase session — the save rides the cached session
+   * either way (no fresh per-save signature). Also gates the hosted
+   * admins/judges management UI when combined with isGlobalAdmin.
+   */
   signAuthHeader?: () => Promise<import("@/lib/api").AdminAuthArg>;
   isGlobalAdmin?: boolean;
-  /** Email-admin session (no wallet): save via signAuthHeader instead of a SIWS signature. */
-  emailMode?: boolean;
 }) {
   const editing = Boolean(program);
 
@@ -188,37 +186,12 @@ export function ProgramFormModal({
     if (!validate()) return;
     setSubmitting(true);
     try {
-      // Email admins (no wallet) authorize the save with their Supabase session;
-      // wallet admins sign a SIWS message. The server's requireProgramAdmin accepts
-      // an admin-role email session for program edits.
-      let authHeader: import("@/lib/api").AdminAuthArg;
-      if (emailMode && signAuthHeader) {
-        authHeader = await signAuthHeader();
-      } else {
-        await web3Enable("Stadium");
-        const accounts = await web3Accounts();
-        const account = accounts.find((a) => a.address === connectedAddress) || accounts[0];
-        if (!account) throw new Error("No wallet account found");
-
-        const siws = new SiwsMessage({
-          domain: window.location.hostname,
-          uri: window.location.origin,
-          address: account.address,
-          nonce: Math.random().toString(36).slice(2),
-          statement: generateSiwsStatement({
-            action: editing ? "update-program" : "create-program",
-          }),
-        });
-        const injector = await web3FromSource(account.meta.source);
-        const signed = (await siws.sign(injector)) as unknown as { signature: string; message?: string };
-        const messageStr =
-          typeof signed.message === "string" && signed.message
-            ? signed.message
-            : (siws as unknown as { toString: () => string }).toString();
-        authHeader = btoa(
-          JSON.stringify({ message: messageStr, signature: signed.signature, address: account.address }),
-        );
-      }
+      // Program edit is a low-stakes action: it rides the cached admin session
+      // rather than popping a fresh signature every save. Wallet admins pass the
+      // cached admin-action bearer, email admins their Supabase session — both
+      // through signAuthHeader. The server's requireProgramAdmin accepts either.
+      if (!signAuthHeader) throw new Error("No admin auth available");
+      const authHeader = await signAuthHeader();
 
       const payload: Partial<ApiProgram> & {
         name: string;

--- a/client/src/components/admin/ProgramFormModal.tsx
+++ b/client/src/components/admin/ProgramFormModal.tsx
@@ -148,8 +148,12 @@ export function ProgramFormModal({
   }, [open, program]);
 
   useEffect(() => {
-    if (!slugEdited) setSlug(slugify(name));
-  }, [name, slugEdited]);
+    // Only auto-derive the slug from the name in CREATE mode. In edit mode the
+    // slug is fixed (field disabled); without the `!editing` guard this effect's
+    // stale `slugEdited` closure races the hydrate effect on open and clobbers
+    // the loaded slug to "", which fails validation and blocks every edit save.
+    if (!slugEdited && !editing) setSlug(slugify(name));
+  }, [name, slugEdited, editing]);
 
   const validate = (): boolean => {
     const e: Record<string, string> = {};

--- a/client/src/components/admin/ProgramJudgingSection.tsx
+++ b/client/src/components/admin/ProgramJudgingSection.tsx
@@ -39,6 +39,7 @@ const prizeText = (amount?: number | null, currency?: string | null) =>
 export function ProgramJudgingSection({
   programSlug,
   getAuth,
+  signWinnerAction,
   canSelectWinners = false,
   prizeTiers,
   resultsPublishedAt = null,
@@ -46,6 +47,14 @@ export function ProgramJudgingSection({
 }: {
   programSlug: string;
   getAuth: () => Promise<AdminAuthArg>;
+  /**
+   * Fresh-signature source for the high-stakes winner/payout actions
+   * (award prize, publish results, mark paid). When provided, these actions
+   * pop a wallet signature every time instead of riding the cached admin
+   * session — a deliberate human confirmation. Reads still use `getAuth`.
+   * Only wired on the wallet-admin path (`canSelectWinners`).
+   */
+  signWinnerAction?: (action: "mark-paid" | "award-prize" | "publish-results") => Promise<string>;
   canSelectWinners?: boolean;
   prizeTiers?: ApiPrizeTier[] | null;
   resultsPublishedAt?: string | null;
@@ -60,6 +69,7 @@ export function ProgramJudgingSection({
   const [claiming, setClaiming] = useState(false);
   const [savingBatch, setSavingBatch] = useState<number | null>(null);
   const [awardingId, setAwardingId] = useState<string | null>(null);
+  const [paidId, setPaidId] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [publishedAt, setPublishedAt] = useState<string | null>(resultsPublishedAt);
   const [publishing, setPublishing] = useState(false);
@@ -206,12 +216,17 @@ export function ProgramJudgingSection({
     }
   };
 
+  // Auth for the high-stakes winner/payout actions: a fresh signature each
+  // time when wired (wallet admins), else the cached admin session.
+  const winnerAuth = (action: "mark-paid" | "award-prize" | "publish-results") =>
+    signWinnerAction ? signWinnerAction(action) : getAuth();
+
   // Platform admin: assign a prize tier (winner) to a submission, or clear it.
   const award = async (submissionId: string, amountRaw: string) => {
     const tier = amountRaw === "" ? null : tiers.find((t) => t.amount === Number(amountRaw)) ?? null;
     setAwardingId(submissionId);
     try {
-      const auth = await getAuth();
+      const auth = await winnerAuth("award-prize");
       await api.awardPrize(programSlug, submissionId, tier, auth);
       setBoard((prev) =>
         prev && !prev.locked
@@ -237,10 +252,33 @@ export function ProgramJudgingSection({
     }
   };
 
+  // Platform admin: toggle payout-sent tracking on a submission.
+  const markPaid = async (submissionId: string, paid: boolean) => {
+    setPaidId(submissionId);
+    try {
+      const auth = await winnerAuth("mark-paid");
+      await api.setSubmissionPaid(programSlug, submissionId, paid, auth);
+      setBoard((prev) =>
+        prev && !prev.locked
+          ? { ...prev, rows: prev.rows.map((r) => (r.submissionId === submissionId ? { ...r, paid } : r)) }
+          : prev,
+      );
+      toast({ title: paid ? "Marked paid" : "Marked unpaid" });
+    } catch (e) {
+      toast({
+        title: "Couldn't update payout status",
+        description: (e as Error)?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setPaidId(null);
+    }
+  };
+
   const togglePublish = async () => {
     setPublishing(true);
     try {
-      const auth = await getAuth();
+      const auth = await winnerAuth("publish-results");
       const res = await api.publishResults(programSlug, !publishedAt, auth);
       setPublishedAt(res.data.resultsPublishedAt);
       onPublishedChange?.(res.data.resultsPublishedAt);
@@ -539,6 +577,7 @@ export function ProgramJudgingSection({
                   <th className="py-2 pr-2">INNOV</th>
                   <th className="py-2 pr-2">JUDGES</th>
                   <th className="py-2 pr-2">PRIZE</th>
+                  <th className="py-2 pr-2">PAID</th>
                 </tr>
               </thead>
               <tbody>
@@ -591,11 +630,29 @@ export function ProgramJudgingSection({
                             <span className="label-hw-dim">—</span>
                           )}
                         </td>
+                        <td className="py-2 pr-2" onClick={(e) => e.stopPropagation()}>
+                          {canSelectWinners ? (
+                            <label className="inline-flex items-center gap-1.5 cursor-pointer label-hw-dim">
+                              <input
+                                type="checkbox"
+                                checked={!!r.paid}
+                                disabled={paidId === r.submissionId}
+                                onChange={(e) => markPaid(r.submissionId, e.target.checked)}
+                                className="accent-display disabled:opacity-50"
+                              />
+                              {r.paid ? <span className="text-display">PAID</span> : "MARK"}
+                            </label>
+                          ) : r.paid ? (
+                            <span className="label-hw text-display">·PAID</span>
+                          ) : (
+                            <span className="label-hw-dim">—</span>
+                          )}
+                        </td>
                       </tr>
                       {isOpen && (
                         <tr className="border-b border-hairline/50 bg-panel-deep/20">
                           <td></td>
-                          <td colSpan={8} className="py-2 pr-2">
+                          <td colSpan={9} className="py-2 pr-2">
                             <div className="label-hw-dim mb-1">·SCORES PER JUDGE</div>
                             {(r.judgeScores ?? []).length === 0 ? (
                               <span className="label-hw-dim">No individual scores.</span>

--- a/client/src/components/admin/WinnersTable.tsx
+++ b/client/src/components/admin/WinnersTable.tsx
@@ -93,11 +93,17 @@ interface WinnersTableProps {
    * write below to share the cache.
    */
   signAdminAction: () => Promise<import("@/lib/api").AdminAuthArg>;
+  /**
+   * Auth for the payout action specifically. Pops a FRESH signature every
+   * time (never the cached session) so confirming a payout is a deliberate,
+   * separately-signed step. Falls back to signAdminAction if not provided.
+   */
+  signPaymentAction?: () => Promise<import("@/lib/api").AdminAuthArg>;
 }
 
 type WinnerFilter = "all" | "main-track" | "bounty";
 
-export function WinnersTable({ projects, onRefresh, connectedAddress, signAdminAction }: WinnersTableProps) {
+export function WinnersTable({ projects, onRefresh, connectedAddress, signAdminAction, signPaymentAction }: WinnersTableProps) {
   const { toast } = useToast();
   const [saving, setSaving] = useState<string | null>(null);
   const [winnerFilter, setWinnerFilter] = useState<WinnerFilter>("all");
@@ -364,10 +370,11 @@ export function WinnersTable({ projects, onRefresh, connectedAddress, signAdminA
   const savePayment = async () => {
     if (!manageModal) return;
     setSaving("payment");
-    
+
     try {
-      const authHeader = await signAdminAction();
-      
+      // Confirming a payout re-signs fresh every time (not the cached session).
+      const authHeader = await (signPaymentAction ?? signAdminAction)();
+
       // Validate
       if (!manageModal.paymentAmount || manageModal.paymentAmount <= 0) {
         throw new Error("Payment amount must be greater than 0");

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -305,6 +305,8 @@ export type ApiLeaderboardRow = {
   prizeAmount?: number | null;
   prizeCurrency?: string | null;
   prizeLabel?: string | null;
+  /** Payout tracking: true once an admin marks the submission paid. */
+  paid?: boolean;
 };
 
 export type ApiLeaderboard =

--- a/client/src/lib/mockJudging.ts
+++ b/client/src/lib/mockJudging.ts
@@ -398,6 +398,7 @@ export const mockJudging = {
     const youSubmitted = ballotSubmitted();
     const mine = readScores();
     const prizes = readPrizes();
+    const paidMap = readPaid();
     const addedEmails = new Set(readAdded().map((s) => s.lumaEmail));
     const all = allSubmissions();
 
@@ -456,6 +457,7 @@ export const mockJudging = {
           prizeAmount: prize ? prize.amount : null,
           prizeCurrency: prize ? prize.currency : null,
           prizeLabel: prize ? prize.label : null,
+          paid: paidMap[s.id] ?? false,
         };
       })
       .sort((x, y) => y.avgTotal - x.avgTotal || y.avgInnovation - x.avgInnovation)

--- a/client/src/lib/siwsUtils.ts
+++ b/client/src/lib/siwsUtils.ts
@@ -3,7 +3,7 @@
  */
 
 export interface SiwsContext {
-  action: 'update-team' | 'submit-deliverable' | 'update-project' | 'register-address' | 'admin-action' | 'create-project' | 'delete-project' | 'review-project' | 'approve-project' | 'reject-project' | 'post-update' | 'update-funding-signal' | 'apply-to-program' | 'create-program' | 'update-program' | 'review-application' | 'update-program-sponsors' | 'import-program-signups' | 'submit-continuation' | 'update-notifications';
+  action: 'update-team' | 'submit-deliverable' | 'update-project' | 'register-address' | 'admin-action' | 'create-project' | 'delete-project' | 'review-project' | 'approve-project' | 'reject-project' | 'post-update' | 'update-funding-signal' | 'apply-to-program' | 'create-program' | 'update-program' | 'review-application' | 'update-program-sponsors' | 'import-program-signups' | 'submit-continuation' | 'update-notifications' | 'mark-paid' | 'award-prize' | 'publish-results' | 'confirm-payment';
   projectId?: string;
   projectTitle?: string;
   programTitle?: string;
@@ -76,6 +76,17 @@ export function generateSiwsStatement(context: SiwsContext): string {
     // Phase 2 revamp (#71): notification preferences
     case 'update-notifications':
       return `Update notification preferences for wallet on Stadium`;
+
+    // High-stakes payout/results actions: each re-signs fresh (never the
+    // cached admin session) so the human deliberately confirms it.
+    case 'mark-paid':
+      return `Mark a payout as sent on ${baseDomain}`;
+    case 'award-prize':
+      return `Select a winner on ${baseDomain}`;
+    case 'publish-results':
+      return `Publish results on ${baseDomain}`;
+    case 'confirm-payment':
+      return `Confirm a milestone payout on ${baseDomain}`;
 
     default:
       return `Sign in to ${baseDomain}`;

--- a/client/src/pages/AdminPage.tsx
+++ b/client/src/pages/AdminPage.tsx
@@ -109,7 +109,9 @@ const AdminPage = () => {
   const handleConfirmM1Payout = async (data: any) => {
     if (!selectedProject) return;
     try {
-      const authHeaders = await auth.getAdminBearerHeaders();
+      // Payout confirmation moves real funds — re-sign fresh every time
+      // (never the cached admin session) so the human deliberately approves it.
+      const authHeaders = { "x-siws-auth": await auth.signAction("confirm-payment") };
       const response = await fetch(`/api/m2-program/${selectedProject.id}/confirm-payment`, {
         method: "POST",
         headers: { "Content-Type": "application/json", ...authHeaders },
@@ -146,7 +148,9 @@ const AdminPage = () => {
   const handleConfirmPayment = async (data: any) => {
     if (!selectedProject) return;
     try {
-      const authHeaders = await auth.getAdminBearerHeaders();
+      // Payout confirmation moves real funds — re-sign fresh every time
+      // (never the cached admin session) so the human deliberately approves it.
+      const authHeaders = { "x-siws-auth": await auth.signAction("confirm-payment") };
       const response = await fetch(`/api/m2-program/${selectedProject.id}/confirm-payment`, {
         method: "POST",
         headers: { "Content-Type": "application/json", ...authHeaders },
@@ -499,6 +503,7 @@ const AdminPage = () => {
             onRefresh={loadData}
             connectedAddress={BYPASS_ADMIN_CHECK ? ADMIN_ADDRESSES[0]?.address : auth.account?.address}
             signAdminAction={auth.getAdminBearerHeaders}
+            signPaymentAction={() => auth.signAction("confirm-payment")}
           />
         </section>
 

--- a/client/src/pages/AdminProgramPage.tsx
+++ b/client/src/pages/AdminProgramPage.tsx
@@ -312,11 +312,9 @@ const AdminProgramPage = () => {
                   if (!v) setAdminsReload((n) => n + 1); // refresh the read-only list
                 }}
                 program={program}
-                connectedAddress={connectedAddress ?? ""}
                 onSaved={(p) => setProgram(p)}
                 signAuthHeader={isAdminWallet ? getAdminAuth : getJudgeAuth}
                 isGlobalAdmin={isAdminWallet && isGlobalAdmin}
-                emailMode={!isAdminWallet}
               />
             )}
 
@@ -337,6 +335,7 @@ const AdminProgramPage = () => {
                 <ProgramJudgingSection
                   programSlug={program.slug}
                   getAuth={getAdminAuth}
+                  signWinnerAction={(a) => auth.signAction(a)}
                   canSelectWinners={isGlobalAdmin}
                   prizeTiers={program.prizeTiers}
                   resultsPublishedAt={program.resultsPublishedAt}

--- a/docs/improvement-backlog.md
+++ b/docs/improvement-backlog.md
@@ -199,3 +199,9 @@ Do **not** manually edit `- **Promoted**` lines.
 - **Observed during**: hardening CSV export (#122) for formula injection
 - **Suggestion**: #122 sanitises the inbox EXPORT. The Luma CSV IMPORT reads attacker-controllable rows from a third-party file and persists them. The values aren't re-emitted to a spreadsheet from a different surface (yet), so import-side sanitisation isn't urgent — but if any future feature exports a CSV that includes signup names/emails from this table, the same defense must run. Either: apply the prefix at import time (defense in depth, alters stored data), or factor `csvCell` from `program-inbox.service.js` into a shared `csv.util.js` and call it everywhere CSV is generated.
 - **Promoted**: #134
+
+## [2026-06-12] Canonical stadium-tester spec drifted from ProgramJudgingSection
+- **Severity**: minor
+- **File(s)**: `.claude/skills/stadium-tester/flows/client-journey.spec.mjs`
+- **Observed during**: testing the must-sign payouts/results PR
+- **Suggestion**: The committed canonical wallet-gated suite (added in #171, labeled "validated green") targets a `LEADERBOARD` tab, an `ADD TO STADIUM`/promote button, and a score-view `MARK PAID` button that no longer exist in `client/src/components/admin/ProgramJudgingSection.tsx` — the component now has `SCORE`/`RESULTS` tabs, award-via-dropdown, `PUBLISH RESULTS`, and (as of this PR) a PAID toggle in the RESULTS table. The spec would fail if run verbatim, so it can't be trusted as a regression gate. Rewrite the judging portion to the current SCORE/RESULTS surface (claim → score → submit → RESULTS tab → award/PAID/publish).

--- a/server/api/services/__tests__/scoring.service.test.js
+++ b/server/api/services/__tests__/scoring.service.test.js
@@ -110,6 +110,24 @@ describe('scoringService.leaderboard — tally + per-judge breakdown', () => {
     expect(r.rows[0].submissionId).toBe('s2');
     expect(r.rows[1].submissionId).toBe('s1');
   });
+
+  it('surfaces each submission\'s paid flag (payout tracking)', async () => {
+    emailRepo.listJudges.mockResolvedValue([{ email: 'a@x.com' }]);
+    ballotRepo.listSubmitted.mockResolvedValue([{ judgeEmail: 'a@x.com' }]);
+    submissionRepo.listByProgramId.mockResolvedValue([
+      { id: 's1', projectTitle: 'Alpha', paid: true },
+      { id: 's2', projectTitle: 'Beta' }, // no paid field -> defaults false
+    ]);
+    scoreRepo.listByProgramId.mockResolvedValue([
+      score('s1', 'a@x.com', 2, 5, 5),
+      score('s2', 'a@x.com', 1, 1, 1),
+    ]);
+
+    const r = await scoringService.leaderboard('prog-1');
+    const byId = Object.fromEntries(r.rows.map((row) => [row.submissionId, row]));
+    expect(byId.s1.paid).toBe(true);
+    expect(byId.s2.paid).toBe(false);
+  });
 });
 
 describe('scoringService.submitBallot — scoped to claimed batches', () => {

--- a/server/api/services/scoring.service.js
+++ b/server/api/services/scoring.service.js
@@ -275,6 +275,8 @@ class ScoringService {
           prizeAmount: s.prizeAmount ?? null,
           prizeCurrency: s.prizeCurrency ?? null,
           prizeLabel: s.prizeLabel ?? null,
+          // Payout tracking, so the results table can show + toggle PAID.
+          paid: s.paid ?? false,
         };
       })
       .sort(


### PR DESCRIPTION
## What

Flips the signing friction to match the stakes:

- **High-stakes actions now re-sign a fresh wallet signature every time** (never the cached 15-min admin session), so each is a deliberate human confirmation:
  - **Award prize** and **publish results** (`ProgramJudgingSection`) via a new `signWinnerAction` prop.
  - **Mark paid** — *new* PAID toggle in the RESULTS table (global wallet admin only), wired to `setSubmissionPaid`. The API + route already existed (`b5bcb25`) but had no UI; this adds it. Leaderboard now surfaces each submission's `paid` flag so the toggle reflects state.
  - **m2 confirm-payment** (AdminPage M1/M2 payout handlers + `WinnersTable` payout) now re-signs via `signAction('confirm-payment')`. `WinnersTable` gets a dedicated `signPaymentAction` so its other admin writes keep the shared cache.
- **Low-stakes program edit moves the other way — onto the cached session.** `ProgramFormModal` drops the manual `@talismn/siws` block; create/edit now ride `signAuthHeader` (cached bearer for wallet, Supabase for email). No more signature popup on every save. Removed the now-dead `connectedAddress`/`emailMode` props.
- New SIWS statements (`mark-paid` / `award-prize` / `publish-results` / `confirm-payment`) so each popup says exactly what's being signed.

Email / per-program admins remain blocked from payouts/winners/publish — server-side (`isPlatformAdmin` → `isGlobalAdmin`) and in the UI (`canSelectWinners`). Unchanged; the new PAID toggle inherits the same gate.

### Bundled fix (separate commit `e683a20`)
While verifying the relaxed edit flow, found a **pre-existing bug that blocked _every_ program edit**: the auto-slug effect's stale `slugEdited` closure raced the hydrate effect on open and clobbered the loaded slug to `""`, failing validation before any save. One-line guard (`!editing`) — surfaced and fixed because "relax program edit" is meaningless if edit can't save.

## Decisions (from the author)
Must-sign set = mark-paid + award + publish + m2 confirm-payment · email admins blocked (already enforced) · program edit → cached session · build the PAID toggle · slug fix included here.

## Test plan
- `cd server && npm test` → **392 passed**.
- `cd client && npm run build` (typecheck) + `npm run lint --max-warnings 0` → clean.
- Added: `scoring.service.test.js` asserts the leaderboard surfaces `paid`.
- `stadium-tester` against `dev:harness` (mock + //Alice test wallet) — report below.

## stadium-tester report

```
## Stadium UI verification — http://localhost:8081 (dev:harness, mock + test wallet)

Scenarios: 7 total, 7 pass, 0 fail, 0 skipped

| # | Scenario | Result | Notes |
|---|----------|--------|-------|
| 1 | preview-mode + test-wallet sanity                              | PASS | __STADIUM_MOCK__ && __TEST_WALLET_ENABLED__ |
| 2 | RESULTS tab renders a PAID column alongside PRIZE              | PASS | both column headers visible |
| 3 | toggling a row PAID marks it paid                              | PASS | 'Marked paid' toast + row shows PAID |
| 4 | selecting a prize tier awards a winner                         | PASS | 'Awarded' toast |
| 5 | PUBLISH RESULTS publishes                                      | PASS | panel shows ·PUBLISHED |
| 6 | editing the program saves (no signature prompt)               | PASS | 'Program updated' toast — passes *because of* the slug fix |
| 7 | no unexpected console errors during the run                   | PASS | 0 (ERR_CONNECTION_REFUSED for non-mocked endpoints filtered) |

Preview mode: window.__STADIUM_MOCK__ = true
Console errors during run: 0
Recommended next action: continue to PR
```

**Verification caveat:** the //Alice test wallet auto-signs silently, so the suite proves these flows are *functionally* complete — it can NOT observe the wallet popup itself. The core UX of this PR (routine action = no popup vs. high-stakes = fresh popup) needs a one-time manual pass with a real Polkadot wallet before relying on it.

## Out of scope / logged to backlog
- The committed canonical tester spec (`flows/client-journey.spec.mjs`, from #171) has drifted from the current `ProgramJudgingSection` (references a `LEADERBOARD` tab / promote / score-view MARK PAID that no longer exist) — logged to `docs/improvement-backlog.md`.
- Server still accepts the cached bearer on these endpoints; "must sign" is a deliberate client-side human-confirmation gate, not a server bearer-rejection.
- `M2BuildingProjectsTable` (dead code, rendered nowhere) has a no-auth confirm-payment; left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)