### PR TITLE
Release: winner prize emails + email diagnostics + test-submit allowlist + defer-sign gate

### DIFF
--- a/client/src/pages/AdminProgramPage.tsx
+++ b/client/src/pages/AdminProgramPage.tsx
@@ -90,6 +90,11 @@ const AdminProgramPage = () => {
   const [filter, setFilter] = useState<Filter>("submitted");
   const [editOpen, setEditOpen] = useState(false);
   const [adminsReload, setAdminsReload] = useState(0);
+  // Viewing the program needs no signature. The wallet-admin sections each sign
+  // an admin-action message when they load their data, so we defer mounting them
+  // behind an explicit unlock — one click, one signature (the concurrent section
+  // loads dedup to a single wallet popup) — instead of prompting on page view.
+  const [adminUnlocked, setAdminUnlocked] = useState(false);
   const [errorData, setErrorData] = useState<{
     walletAddresses: string[];
     expectedAddresses: string[];
@@ -319,6 +324,23 @@ const AdminProgramPage = () => {
             )}
 
             {isAdminWallet ? (
+              !adminUnlocked ? (
+                <div className="panel px-4 py-10 text-center mb-3">
+                  <div className="label-hw text-display mb-2">·ADMIN DATA LOCKED</div>
+                  <p className="label-hw-dim mb-4 max-w-prose mx-auto">
+                    Viewing this program needs no signature. Load the admin data
+                    (guests, judging, stats) to manage it; this signs an admin-action
+                    message once.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => setAdminUnlocked(true)}
+                    className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim px-4 py-1.5"
+                  >
+                    LOAD ADMIN DATA ▸
+                  </button>
+                </div>
+              ) : (
               <>
                 <ProgramStatsHeader
                   programSlug={program.slug}
@@ -409,6 +431,7 @@ const AdminProgramPage = () => {
                   </>
                 )}
               </>
+              )
             ) : socialCanJudge || socialCanViewAdmin ? (
               <>
                 <div className="panel px-3 py-2.5 mb-3 flex flex-wrap items-center gap-2">

--- a/server/.env.example
+++ b/server/.env.example
@@ -48,6 +48,16 @@ RESEND_FROM_EMAIL=
 # comma-separated). Recipients never see it. Leave empty to disable.
 EMAIL_BCC=
 
+# Optional: reply-to address on the winner prize-award email, so winners can
+# reply to arrange collection. Defaults to RESEND_FROM_EMAIL if unset.
+PRIZE_CONTACT_EMAIL=
+
+# Optional: comma-separated email allowlist that bypasses the "checked-in guest"
+# (Luma signup) gate on the public submit form. For testing only — leave empty in
+# normal operation. Allowlisted submissions are still flagged eligible:false.
+#   SUBMIT_TEST_EMAILS=sacha@joinwebzero.com
+SUBMIT_TEST_EMAILS=
+
 # Public base URL of the client, used to build links in outbound email (e.g. the
 # program-admin onboarding link). Defaults to the prod URL if unset.
 FRONTEND_URL=https://stadium.joinwebzero.com

--- a/server/api/controllers/__tests__/submission.controller.test.js
+++ b/server/api/controllers/__tests__/submission.controller.test.js
@@ -31,6 +31,9 @@ vi.mock('../../repositories/program-judge-ballot.repository.js', () => ({
   default: { isSubmitted: vi.fn() },
 }));
 vi.mock('../../services/program-audit-log.service.js', () => ({ default: { logSafe: vi.fn() } }));
+vi.mock('../../services/prize-award.service.js', () => ({
+  default: { notifyWinners: vi.fn() },
+}));
 
 const programService = (await import('../../services/program.service.js')).default;
 const scoringService = (await import('../../services/scoring.service.js')).default;
@@ -40,6 +43,7 @@ const ballotRepo = (await import('../../repositories/program-judge-ballot.reposi
 const scoreRepo = (await import('../../repositories/submission-score.repository.js')).default;
 const signupRepo = (await import('../../repositories/program-signup.repository.js')).default;
 const confirmationService = (await import('../../services/submission-confirmation.service.js')).default;
+const prizeAwardService = (await import('../../services/prize-award.service.js')).default;
 const submissionController = (await import('../submission.controller.js')).default;
 
 const mockRes = () => {
@@ -96,6 +100,28 @@ describe('SubmissionController.submit (public)', () => {
     await submissionController.submit(req, res);
     expect(res.status).toHaveBeenCalledWith(403);
     expect(submissionRepo.create).not.toHaveBeenCalled();
+  });
+
+  it('lets a SUBMIT_TEST_EMAILS address bypass the checked-in gate', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    signupRepo.existsByEmail.mockResolvedValue(false); // NOT on the signup list
+    submissionRepo.findByEmail.mockResolvedValue(null);
+    submissionRepo.create.mockResolvedValue({
+      submission: { id: 'engine-ab12', lumaEmail: 'ada@example.com', submitterName: 'Ada', projectTitle: 'Engine' },
+      duplicate: false,
+    });
+    confirmationService.send.mockResolvedValue({ ok: true });
+    const prev = process.env.SUBMIT_TEST_EMAILS;
+    process.env.SUBMIT_TEST_EMAILS = 'ADA@example.com'; // case-insensitive match
+    try {
+      const req = { params: { slug: 'bitrefill' }, body: GOOD_BODY };
+      const res = mockRes();
+      await submissionController.submit(req, res);
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(submissionRepo.create).toHaveBeenCalled();
+    } finally {
+      process.env.SUBMIT_TEST_EMAILS = prev;
+    }
   });
 
   it('201s on a first submission and emails a confirmation', async () => {
@@ -427,9 +453,10 @@ describe('SubmissionController results publish (platform admin)', () => {
     expect(programRepo.setResultsPublished).not.toHaveBeenCalled();
   });
 
-  it('publish sets a timestamp', async () => {
+  it('publish sets a timestamp and notifies winners', async () => {
     programService.findBySlug.mockResolvedValue(PROGRAM);
     programRepo.setResultsPublished.mockResolvedValue({ resultsPublishedAt: '2026-06-11T00:00:00.000Z' });
+    prizeAwardService.notifyWinners.mockResolvedValue({ ok: true, sent: 0, failed: 0 });
     const req = { params: { slug: 'bitrefill' }, user: { address: '5Admin', isGlobalAdmin: true } };
     const res = mockRes();
     await submissionController.publishResults(req, res);
@@ -437,9 +464,10 @@ describe('SubmissionController results publish (platform admin)', () => {
     const [slug, publishedAt] = programRepo.setResultsPublished.mock.calls[0];
     expect(slug).toBe('bitrefill');
     expect(publishedAt).toBeTruthy(); // non-null timestamp
+    expect(prizeAwardService.notifyWinners).toHaveBeenCalledWith({ program: PROGRAM });
   });
 
-  it('unpublish clears the timestamp', async () => {
+  it('unpublish clears the timestamp and does NOT notify winners', async () => {
     programService.findBySlug.mockResolvedValue(PROGRAM);
     programRepo.setResultsPublished.mockResolvedValue({ resultsPublishedAt: null });
     const req = { params: { slug: 'bitrefill' }, user: { address: '5Admin', isGlobalAdmin: true } };
@@ -447,6 +475,7 @@ describe('SubmissionController results publish (platform admin)', () => {
     await submissionController.unpublishResults(req, res);
     expect(res.status).toHaveBeenCalledWith(200);
     expect(programRepo.setResultsPublished).toHaveBeenCalledWith('bitrefill', null);
+    expect(prizeAwardService.notifyWinners).not.toHaveBeenCalled();
   });
 });
 

--- a/server/api/controllers/program.controller.js
+++ b/server/api/controllers/program.controller.js
@@ -465,7 +465,9 @@ class ProgramController {
         emailSent = result.ok;
         emailReason = result.ok ? null : result.reason;
       } catch (err) {
-        emailReason = 'send_failed';
+        // Surface the real Resend reason (admin-only action) so a misconfigured
+        // sender domain / sandbox-mode key is diagnosable from the UI, not just logs.
+        emailReason = `send_failed: ${err?.message || 'unknown error'}`;
         logger.error('Program admin invite email failed:', err);
       }
 

--- a/server/api/controllers/submission.controller.js
+++ b/server/api/controllers/submission.controller.js
@@ -7,6 +7,7 @@ import submissionScoreRepository from '../repositories/submission-score.reposito
 import programJudgeBallotRepository from '../repositories/program-judge-ballot.repository.js';
 import { validateSubmission, validateScore, validatePrize, prizeTiersFor } from '../utils/submission.validator.js';
 import submissionConfirmationService from '../services/submission-confirmation.service.js';
+import prizeAwardService from '../services/prize-award.service.js';
 import auditLog from '../services/program-audit-log.service.js';
 
 // Winner selection + publishing are platform-admin only. After requireProgramAdmin,
@@ -38,6 +39,18 @@ async function setResultsPublished(req, res, publish) {
       targetId: program.id,
       metadata: null,
     });
+    // On publish, email each (not-yet-notified) winner about their prize.
+    // Fire-and-forget + best-effort: the response is already sent, and
+    // prize_notified_at makes a later unpublish/republish a no-op.
+    if (publish) {
+      prizeAwardService
+        .notifyWinners({ program })
+        .then((r) => {
+          if (r?.reason) console.warn(`Prize emails not sent (${r.reason}) for ${program.slug}`);
+          else console.log(`Prize emails for ${program.slug}: sent ${r.sent}, failed ${r.failed}`);
+        })
+        .catch((e) => console.error('❌ Prize-award notification failed:', e?.message || e));
+    }
   } catch (error) {
     console.error('❌ Error updating results publish state:', error);
     res.status(500).json({ status: 'error', message: 'Failed to update results' });
@@ -75,8 +88,21 @@ class SubmissionController {
         return res.status(400).json({ status: 'error', message: v.error });
       }
       // Only checked-in attendees may submit: the email must be on the program's
-      // imported Luma (checked-in / approved guest) list.
-      if (!(await programSignupRepository.existsByEmail(program.id, v.value.lumaEmail))) {
+      // imported Luma (checked-in / approved guest) list. SUBMIT_TEST_EMAILS is a
+      // comma-separated allowlist that bypasses this gate for testing (off by
+      // default; set per-deployment). Such submissions are still flagged
+      // eligible:false on the leaderboard since they're not in the Luma list.
+      const testEmails = new Set(
+        (process.env.SUBMIT_TEST_EMAILS || '')
+          .split(',')
+          .map((e) => e.trim().toLowerCase())
+          .filter(Boolean),
+      );
+      const submitterEmail = String(v.value.lumaEmail || '').trim().toLowerCase();
+      if (
+        !testEmails.has(submitterEmail) &&
+        !(await programSignupRepository.existsByEmail(program.id, v.value.lumaEmail))
+      ) {
         return res.status(403).json({
           status: 'error',
           message: 'Only checked-in attendees can submit. Use the email you checked in with on Luma.',

--- a/server/api/repositories/program-submission.repository.js
+++ b/server/api/repositories/program-submission.repository.js
@@ -27,6 +27,7 @@ const transform = (row) => {
     paid: row.paid ?? false,
     paidAt: row.paid_at ?? null,
     paidBy: row.paid_by ?? null,
+    prizeNotifiedAt: row.prize_notified_at ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -155,6 +156,31 @@ class ProgramSubmissionRepository {
         awarded_by: prize ? actor ?? null : null,
         updated_at: new Date().toISOString(),
       })
+      .eq('id', id)
+      .select('*')
+      .single();
+    if (error) throw error;
+    return transform(data);
+  }
+
+  // Winners (have a prize) not yet emailed about it. Drives the publish-time
+  // prize notification so each winner is mailed exactly once.
+  async listWinnersToNotify(programId) {
+    const { data, error } = await supabase
+      .from('program_submissions')
+      .select('*')
+      .eq('program_id', programId)
+      .not('prize_amount', 'is', null)
+      .is('prize_notified_at', null);
+    if (error) throw error;
+    return (data || []).map(transform);
+  }
+
+  // Stamp that a winner has been emailed about their prize (idempotency marker).
+  async setPrizeNotified(id) {
+    const { data, error } = await supabase
+      .from('program_submissions')
+      .update({ prize_notified_at: new Date().toISOString() })
       .eq('id', id)
       .select('*')
       .single();

--- a/server/api/services/__tests__/prize-award.service.test.js
+++ b/server/api/services/__tests__/prize-award.service.test.js
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../email-transport.js', () => ({ getEmailTransport: vi.fn() }));
+vi.mock('../../repositories/program-submission.repository.js', () => ({
+  default: { listWinnersToNotify: vi.fn(), setPrizeNotified: vi.fn() },
+}));
+
+const { getEmailTransport } = await import('../email-transport.js');
+const repo = (await import('../../repositories/program-submission.repository.js')).default;
+const service = (await import('../prize-award.service.js')).default;
+
+const PROGRAM = { id: 'prog-1', name: 'Bitrefill', slug: 'bitrefill-2026' };
+const WINNER = {
+  id: 's1',
+  lumaEmail: 'winner@x.com',
+  submitterName: 'Win',
+  projectTitle: 'PixelPay',
+  prizeAmount: 500,
+  prizeCurrency: 'EUR',
+  prizeLabel: 'Bitrefill giftcard',
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('prizeAwardService.notifyWinners', () => {
+  it('best-effort: provider_not_configured when the transport is null (no DB read)', async () => {
+    getEmailTransport.mockResolvedValue(null);
+    const r = await service.notifyWinners({ program: PROGRAM });
+    expect(r).toMatchObject({ ok: false, reason: 'provider_not_configured' });
+    expect(repo.listWinnersToNotify).not.toHaveBeenCalled();
+  });
+
+  it('emails each un-notified winner with prize details + results link, then stamps notified', async () => {
+    const send = vi.fn().mockResolvedValue({ id: 'res_1' });
+    getEmailTransport.mockResolvedValue({ send });
+    repo.listWinnersToNotify.mockResolvedValue([WINNER]);
+    repo.setPrizeNotified.mockResolvedValue({});
+
+    const r = await service.notifyWinners({ program: PROGRAM });
+    expect(r).toMatchObject({ ok: true, sent: 1, failed: 0 });
+
+    const arg = send.mock.calls[0][0];
+    expect(arg.to).toBe('winner@x.com');
+    expect(arg.subject).toContain('Bitrefill giftcard');
+    expect(arg.html).toContain('/programs/bitrefill-2026');
+    expect(repo.setPrizeNotified).toHaveBeenCalledWith('s1');
+  });
+
+  it('does NOT stamp notified when the send fails, so a later publish retries', async () => {
+    const send = vi.fn().mockRejectedValue(new Error('domain not verified'));
+    getEmailTransport.mockResolvedValue({ send });
+    repo.listWinnersToNotify.mockResolvedValue([WINNER]);
+
+    const r = await service.notifyWinners({ program: PROGRAM });
+    expect(r).toMatchObject({ ok: true, sent: 0, failed: 1 });
+    expect(repo.setPrizeNotified).not.toHaveBeenCalled();
+  });
+});

--- a/server/api/services/email-transport.js
+++ b/server/api/services/email-transport.js
@@ -22,7 +22,7 @@ export async function getEmailTransport() {
     .filter(Boolean);
 
   return {
-    async send({ from, to, cc, bcc, subject, html, text }) {
+    async send({ from, to, cc, bcc, replyTo, subject, html, text }) {
       const callerBcc = Array.isArray(bcc) ? bcc : bcc ? [bcc] : [];
       const allBcc = [...callerBcc, ...envBcc];
       const { data, error } = await resend.emails.send({
@@ -30,6 +30,7 @@ export async function getEmailTransport() {
         to,
         cc,
         bcc: allBcc.length ? allBcc : undefined,
+        replyTo: replyTo || undefined,
         subject,
         html,
         text,

--- a/server/api/services/notification-templates/index.js
+++ b/server/api/services/notification-templates/index.js
@@ -4,6 +4,7 @@ import * as m2Approved from './m2-approved.js';
 import * as m2ChangesRequested from './m2-changes-requested.js';
 import * as programAdminInvite from './program-admin-invite.js';
 import * as submissionConfirmation from './submission-confirmation.js';
+import * as prizeAward from './prize-award.js';
 
 const templates = {
   application_accepted: applicationAccepted,
@@ -12,6 +13,7 @@ const templates = {
   m2_changes_requested: m2ChangesRequested,
   program_admin_invite: programAdminInvite,
   submission_confirmation: submissionConfirmation,
+  prize_award: prizeAward,
 };
 
 export function renderEmail(eventType, payload) {

--- a/server/api/services/notification-templates/prize-award.js
+++ b/server/api/services/notification-templates/prize-award.js
@@ -1,0 +1,40 @@
+import { escapeHtml } from './escape.js';
+
+// Notifies a winning submitter that their project won a prize, with the prize
+// details, a link to the published results, and a note that the team will reach
+// out to arrange collection (Bitrefill prizes are off-chain giftcards).
+
+const prizeText = (payload) => {
+  const amount = payload.prizeAmount != null ? String(payload.prizeAmount) : '';
+  const currency = payload.prizeCurrency || '';
+  const money = `${amount} ${currency}`.trim();
+  const label = payload.prizeLabel || '';
+  if (label && money) return `${label} (${money})`;
+  return label || money || 'a prize';
+};
+
+export function subject(payload) {
+  return `You won ${prizeText(payload)} at ${payload.programName}`;
+}
+
+export function html(payload) {
+  const link = payload.link ?? 'https://stadium.joinwebzero.com';
+  const name = payload.submitterName ? `, ${escapeHtml(payload.submitterName)}` : '';
+  return `<p>Congratulations${name}!</p>
+<p>Your project <strong>${escapeHtml(payload.projectTitle)}</strong> won <strong>${escapeHtml(prizeText(payload))}</strong> at <strong>${escapeHtml(payload.programName)}</strong>.</p>
+<p>The WebZero team will reach out to arrange delivery of your prize. Just reply to this email if you have any questions or your contact details change.</p>
+<p><a href="${escapeHtml(link)}">See the published results</a></p>`;
+}
+
+export function text(payload) {
+  const link = payload.link ?? 'https://stadium.joinwebzero.com';
+  const name = payload.submitterName ? `, ${payload.submitterName}` : '';
+  return `Congratulations${name}!
+
+Your project "${payload.projectTitle}" won ${prizeText(payload)} at ${payload.programName}.
+
+The WebZero team will reach out to arrange delivery of your prize. Just reply to this email if you have any questions or your contact details change.
+
+See the published results:
+${link}`;
+}

--- a/server/api/services/prize-award.service.js
+++ b/server/api/services/prize-award.service.js
@@ -1,0 +1,58 @@
+import { getEmailTransport } from './email-transport.js';
+import { renderEmail } from './notification-templates/index.js';
+import programSubmissionRepository from '../repositories/program-submission.repository.js';
+
+const FRONTEND_URL = process.env.FRONTEND_URL || 'https://stadium.joinwebzero.com';
+
+class PrizeAwardService {
+  /**
+   * Email every winner of a program (a submission with a prize) that hasn't yet
+   * been notified, then stamp prize_notified_at so re-publishing never double-
+   * emails. Best-effort and transient (the notifications table is wallet-keyed;
+   * submitters are email-only), mirroring the invite + confirmation services.
+   *
+   * Returns { ok, reason?, sent, failed }. ok:false / reason:'provider_not_configured'
+   * when Resend is unset so the caller can log that winners weren't emailed.
+   */
+  async notifyWinners({ program }) {
+    const transport = await getEmailTransport();
+    if (!transport) return { ok: false, reason: 'provider_not_configured', sent: 0, failed: 0 };
+
+    const winners = await programSubmissionRepository.listWinnersToNotify(program.id);
+    const link = `${FRONTEND_URL}/programs/${encodeURIComponent(program.slug)}`;
+    const replyTo = process.env.PRIZE_CONTACT_EMAIL || process.env.RESEND_FROM_EMAIL;
+
+    let sent = 0;
+    let failed = 0;
+    for (const w of winners) {
+      try {
+        const { subject, html, text } = renderEmail('prize_award', {
+          submitterName: w.submitterName,
+          programName: program.name,
+          projectTitle: w.projectTitle,
+          prizeAmount: w.prizeAmount,
+          prizeCurrency: w.prizeCurrency,
+          prizeLabel: w.prizeLabel,
+          link,
+        });
+        await transport.send({
+          from: process.env.RESEND_FROM_EMAIL,
+          to: w.lumaEmail,
+          replyTo,
+          subject,
+          html,
+          text,
+        });
+        await programSubmissionRepository.setPrizeNotified(w.id);
+        sent += 1;
+      } catch (err) {
+        failed += 1;
+        // Leave prize_notified_at unset so a later publish retries this winner.
+        console.error(`❌ Prize-award email failed for ${w.lumaEmail}:`, err?.message || err);
+      }
+    }
+    return { ok: true, sent, failed };
+  }
+}
+
+export default new PrizeAwardService();

--- a/supabase/migrations/20260613000000_program_submission_prize_notified.sql
+++ b/supabase/migrations/20260613000000_program_submission_prize_notified.sql
@@ -1,0 +1,5 @@
+-- Track when a winning submission was emailed about its prize, so publishing
+-- results notifies each winner exactly once (unpublish/republish is a no-op for
+-- winners already notified). Nullable + additive; safe to apply on a live table.
+ALTER TABLE program_submissions
+  ADD COLUMN IF NOT EXISTS prize_notified_at TIMESTAMPTZ;


### PR DESCRIPTION
Promotes `develop` to `main` to deploy the post-launch judging fixes (PR #175 + the recovered defer-sign gate).

## Included
- **Winner prize emails:** publishing results emails each winner their prize + collection note (reply-to enabled). Deduped via `prize_notified_at` so republish never double-sends.
- **Email-error diagnostics:** the program-admin invite surfaces the real Resend reason (`send_failed: <reason>`) instead of a generic message.
- **`SUBMIT_TEST_EMAILS` allowlist:** lets specific emails bypass the checked-in (Luma) gate on the public submit form (off by default).
- **Defer-sign gate ("LOAD ADMIN DATA"):** recovered — it was stranded off #173 and never reached main.

## ⚠️ Deploy prerequisites (do with this merge)
- [ ] **Apply the migration to prod Supabase:** `supabase db push` (adds `prize_notified_at`). The winner-email query needs it.
- [ ] **Railway:** set `SUBMIT_TEST_EMAILS=sacha@joinwebzero.com`; optional `PRIZE_CONTACT_EMAIL`.
- [ ] **Resend:** `RESEND_FROM_EMAIL` must be `@stadium.joinwebzero.com` (DNS/DKIM verified ✓) and the domain shown Verified — the real unblock for all outbound email.

## Verification
Server `396 passed`; client build + lint clean. Email paths are unit-tested here and verified end-to-end on prod (mock previews can't send email).

🤖 Generated with [Claude Code](https://claude.com/claude-code)