### PR TITLE
fix(docker): retry apk add on transient Alpine mirror failures

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,8 +1,12 @@
 # Use Node.js LTS version
 FROM node:20-alpine
 
-# Install build dependencies for native modules
-RUN apk add --no-cache python3 make g++
+# Install build dependencies for native modules. Retry on transient Alpine
+# mirror/network failures (apk exit 15) so a flaky CDN can't break a deploy.
+RUN for i in 1 2 3 4 5; do \
+      apk add --no-cache python3 make g++ && break; \
+      echo "apk add failed (attempt $i), retrying in 5s..."; sleep 5; \
+    done
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
A flaky Alpine package mirror made `apk add --no-cache python3 make g++` fail with exit code 15, breaking a Railway deploy (which stranded a `RESEND_FROM_EMAIL` env change → all email stuck failing on the old build). Retries the apk step up to 5x with backoff so a transient CDN blip can't fail the build.

Infra-only; no app code touched. Takes effect on the next build after merge+deploy. The *immediate* fix for the stuck deploy is a Railway Redeploy.