### PR TITLE
feat(judging): batch overview + decimal scores + delete submission

### DIFF
--- a/client/src/components/admin/ProgramJudgingSection.tsx
+++ b/client/src/components/admin/ProgramJudgingSection.tsx
@@ -616,29 +616,48 @@ export function ProgramJudgingSection({
                             {subs.length === 0 ? (
                               <p className="label-hw-dim">No submissions in this batch.</p>
                             ) : (
-                              subs.map((s) => (
-                                <div key={s.id} className="flex items-center justify-between gap-2">
-                                  <span className="min-w-0 truncate font-mono text-[11px] text-body">
-                                    {s.projectTitle} <span className="label-hw-dim">· {s.submitterName}</span>
-                                  </span>
-                                  <span className="flex items-center gap-2 flex-shrink-0">
-                                    <span className="label-hw-dim" title={s.scoredBy?.join(", ")}>
-                                      {s.scoredBy && s.scoredBy.length > 0 ? `${s.scoredBy.length} SCORED` : "—"}
-                                    </span>
-                                    {canSelectWinners && (
-                                      <button
-                                        type="button"
-                                        onClick={() => deleteSub(s)}
-                                        disabled={deletingId === s.id}
-                                        title="Delete this submission (admin)"
-                                        className="label-hw-dim hover:text-destructive disabled:opacity-50"
-                                      >
-                                        {deletingId === s.id ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
-                                      </button>
-                                    )}
-                                  </span>
-                                </div>
-                              ))
+                              subs.map((s) => {
+                                const scs = s.scores ?? [];
+                                const avg = scs.length ? round1(scs.reduce((acc, x) => acc + x.total, 0) / scs.length) : null;
+                                const breakdown = scs.map((x) => `${judgeLabel(x.judgeEmail)}: ${round1(x.total)}/12`).join(", ");
+                                return (
+                                  <div key={s.id} className="py-1 border-b border-hairline-subtle last:border-0">
+                                    <div className="flex items-center justify-between gap-2">
+                                      <span className="min-w-0 truncate font-mono text-[11px] text-display">
+                                        {s.projectTitle} <span className="label-hw-dim">· {s.submitterName}</span>
+                                      </span>
+                                      <span className="flex items-center gap-2 flex-shrink-0 label-hw-dim">
+                                        <button
+                                          type="button"
+                                          onClick={() => setReview({ url: s.videoUrl, title: s.projectTitle })}
+                                          className="hover:text-display inline-flex items-center gap-1"
+                                        >
+                                          VIDEO <Play className="h-3 w-3" />
+                                        </button>
+                                        <a href={s.githubUrl} target="_blank" rel="noreferrer" className="hover:text-display inline-flex items-center gap-1">
+                                          GIT <ExternalLink className="h-3 w-3" />
+                                        </a>
+                                        {canSelectWinners && (
+                                          <button
+                                            type="button"
+                                            onClick={() => deleteSub(s)}
+                                            disabled={deletingId === s.id}
+                                            title="Delete this submission (admin)"
+                                            className="hover:text-destructive disabled:opacity-50"
+                                          >
+                                            {deletingId === s.id ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
+                                          </button>
+                                        )}
+                                      </span>
+                                    </div>
+                                    <div className="label-hw-dim mt-0.5" title={breakdown || undefined}>
+                                      {avg != null
+                                        ? `SCORE ${avg}/12 AVG · ${scs.length} judge${scs.length === 1 ? "" : "s"}: ${judgesText(s.scoredBy)}`
+                                        : "NOT SCORED YET"}
+                                    </div>
+                                  </div>
+                                );
+                              })
                             )}
                           </div>
                         )}

--- a/client/src/components/admin/ProgramJudgingSection.tsx
+++ b/client/src/components/admin/ProgramJudgingSection.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
-import { Loader2, ExternalLink, Lock, Trophy, Plus, ChevronRight, ChevronDown, Play } from "lucide-react";
+import { Loader2, ExternalLink, Lock, Trophy, Plus, ChevronRight, ChevronDown, Play, Trash2 } from "lucide-react";
 import {
   api,
   type AdminAuthArg,
@@ -26,8 +26,12 @@ const draftFromRow = (row: ApiSubmissionRow): Draft => ({
 });
 
 const fmt = (n: number) => (Number.isInteger(n) ? String(n) : n.toFixed(2));
+const round1 = (n: number) => Math.round(n * 10) / 10;
 const prizeText = (amount?: number | null, currency?: string | null) =>
   amount != null ? `${amount} ${currency ?? ""}`.trim() : null;
+// Short, readable judge label (local-part of the email) for "who's working on this".
+const judgeLabel = (email: string) => email.split("@")[0];
+const judgesText = (emails?: string[]) => (emails && emails.length ? emails.map(judgeLabel).join(", ") : "");
 
 /**
  * Judge/admin scoring surface. Judging is split into fixed batches of 10; a
@@ -77,6 +81,11 @@ export function ProgramJudgingSection({
   const [publishing, setPublishing] = useState(false);
   const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const [exporting, setExporting] = useState(false);
+  // Batch overview: which unclaimed batches are checked for multi-claim, which
+  // batch is expanded to preview its submissions, and an in-flight delete.
+  const [selectedBatches, setSelectedBatches] = useState<Set<number>>(new Set());
+  const [openBatch, setOpenBatch] = useState<number | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
 
   const handleExportCsv = async () => {
     setExporting(true);
@@ -177,7 +186,8 @@ export function ProgramJudgingSection({
       const cur = prev[id] ?? { requirements: 0, techStack: 0, innovation: 0, notes: "" };
       if (field === "notes") return { ...prev, [id]: { ...cur, notes: raw } };
       const max = BOUNDS[field];
-      const n = Math.max(0, Math.min(max, Math.round(Number(raw) || 0)));
+      // One decimal place (e.g. 4.3), clamped to [0, max].
+      const n = Math.max(0, Math.min(max, round1(Number(raw) || 0)));
       return { ...prev, [id]: { ...cur, [field]: n } };
     });
   };
@@ -199,6 +209,63 @@ export function ProgramJudgingSection({
       });
     } finally {
       setClaiming(false);
+    }
+  };
+
+  const toggleSelect = (batchNumber: number) =>
+    setSelectedBatches((prev) => {
+      const next = new Set(prev);
+      if (next.has(batchNumber)) next.delete(batchNumber);
+      else next.add(batchNumber);
+      return next;
+    });
+
+  // Claim several batches at once (sequential idempotent claims; last view wins).
+  const claimSelected = async () => {
+    const nums = [...selectedBatches].sort((a, b) => a - b);
+    if (nums.length === 0) return;
+    setClaiming(true);
+    try {
+      const auth = await getAuth();
+      let last: Awaited<ReturnType<typeof api.claimBatch>> | undefined;
+      for (const n of nums) {
+        last = await api.claimBatch(programSlug, n, auth);
+      }
+      if (last) {
+        setView(last.data);
+        seedDrafts(last.data.submissions);
+      }
+      setSelectedBatches(new Set());
+      toast({ title: `Claimed ${nums.length} batch${nums.length === 1 ? "" : "es"}` });
+    } catch (e) {
+      toast({
+        title: "Couldn't claim batches",
+        description: (e as Error)?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setClaiming(false);
+    }
+  };
+
+  // Admin: delete a submission (e.g. a test entry). Reloads so batch membership
+  // (which shifts when a submission is removed) stays correct.
+  const deleteSub = async (s: ApiSubmissionRow) => {
+    if (!window.confirm(`Delete "${s.projectTitle}" by ${s.submitterName}? This removes the submission and any scores, and can't be undone.`)) return;
+    setDeletingId(s.id);
+    try {
+      const auth = await getAuth();
+      await api.deleteSubmission(programSlug, s.id, auth);
+      toast({ title: "Submission deleted" });
+      await loadSubmissions();
+    } catch (e) {
+      toast({
+        title: "Couldn't delete submission",
+        description: (e as Error)?.message || "Unknown error",
+        variant: "destructive",
+      });
+    } finally {
+      setDeletingId(null);
     }
   };
 
@@ -375,6 +442,17 @@ export function ProgramJudgingSection({
             <a href={s.githubUrl} target="_blank" rel="noreferrer" className="label-hw-dim hover:text-display inline-flex items-center gap-1">
               GITHUB <ExternalLink className="h-3 w-3" />
             </a>
+            {canSelectWinners && (
+              <button
+                type="button"
+                onClick={() => deleteSub(s)}
+                disabled={deletingId === s.id}
+                title="Delete this submission (admin)"
+                className="label-hw-dim hover:text-destructive inline-flex items-center gap-1 disabled:opacity-50"
+              >
+                {deletingId === s.id ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
+              </button>
+            )}
           </div>
         </div>
         {s.projectBrief && (
@@ -390,13 +468,14 @@ export function ProgramJudgingSection({
                 type="number"
                 min={0}
                 max={BOUNDS[field]}
+                step={0.1}
                 value={d[field]}
                 onChange={(e) => setField(s.id, field, e.target.value)}
                 className="w-full font-mono text-[13px] bg-panel-deep border border-hairline text-display px-2 py-1.5 focus:outline-none focus:border-display disabled:opacity-50"
               />
             </label>
           ))}
-          <div className="label-hw text-display self-center">TOTAL {total} / 12</div>
+          <div className="label-hw text-display self-center">TOTAL {round1(total)} / 12</div>
         </div>
         <textarea
           rows={2}
@@ -405,7 +484,14 @@ export function ProgramJudgingSection({
           onChange={(e) => setField(s.id, "notes", e.target.value)}
           className="mt-2 w-full font-mono text-[12px] bg-panel-deep border border-hairline text-display px-2 py-1.5 focus:outline-none focus:border-display disabled:opacity-50"
         />
-        <div className="mt-2 label-hw-dim">{s.myScore ? "SAVED" : "NOT SCORED"}</div>
+        <div className="mt-2 flex flex-wrap items-center justify-between gap-2 label-hw-dim">
+          <span>{s.myScore ? "·YOU: SAVED" : "·YOU: NOT SCORED"}</span>
+          {s.scoredBy && s.scoredBy.length > 0 && (
+            <span title={s.scoredBy.join(", ")}>
+              SCORED BY {s.scoredBy.length}: {judgesText(s.scoredBy)}
+            </span>
+          )}
+        </div>
       </div>
     );
   };
@@ -465,38 +551,100 @@ export function ProgramJudgingSection({
               </div>
             )}
 
-            {/* Batch coverage strip + claim controls. */}
+            {/* Batch overview: preview each batch's submissions, see who's working
+                on it, and claim one or several. */}
             {!locked && view.batches && view.batches.length > 0 && (
               <div className="lcd p-3 mb-3">
                 <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
                   <span className="label-hw text-display">·BATCHES ({view.batchSize ?? 10} EACH)</span>
-                  <button
-                    type="button"
-                    onClick={() => claimBatch()}
-                    disabled={claiming || view.batches.every((b) => b.claimedByMe)}
-                    className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-3 py-1 inline-flex items-center gap-1"
-                  >
-                    <Plus className="h-3 w-3" aria-hidden="true" /> {claiming ? "CLAIMING…" : `CLAIM NEXT ${view.batchSize ?? 10} ▸`}
-                  </button>
-                </div>
-                <div className="flex flex-wrap gap-1.5">
-                  {view.batches.map((b) => (
+                  <div className="flex items-center gap-2">
+                    {selectedBatches.size > 0 && (
+                      <button
+                        type="button"
+                        onClick={claimSelected}
+                        disabled={claiming}
+                        className="font-mono text-[10px] tracking-[0.14em] border border-display bg-display text-shell hover:bg-display-dim disabled:opacity-50 px-3 py-1 inline-flex items-center gap-1"
+                      >
+                        <Plus className="h-3 w-3" aria-hidden="true" /> {claiming ? "CLAIMING…" : `CLAIM SELECTED (${selectedBatches.size}) ▸`}
+                      </button>
+                    )}
                     <button
-                      key={b.batchNumber}
                       type="button"
-                      onClick={() => !b.claimedByMe && claimBatch(b.batchNumber)}
-                      disabled={claiming || b.claimedByMe}
-                      title={`${b.size} projects · ${b.claimCount} judge${b.claimCount === 1 ? "" : "s"} claimed`}
-                      className={cn(
-                        "font-mono text-[10px] tracking-[0.12em] border px-2 py-1",
-                        b.claimedByMe
-                          ? "border-display bg-display text-shell"
-                          : "border-hairline text-display hover:bg-panel-deep",
-                      )}
+                      onClick={() => claimBatch()}
+                      disabled={claiming || view.batches.every((b) => b.claimedByMe)}
+                      className="font-mono text-[10px] tracking-[0.14em] border border-hairline text-display hover:bg-panel-deep disabled:opacity-50 px-3 py-1 inline-flex items-center gap-1"
                     >
-                      B{b.batchNumber} · {b.size}p · {b.claimCount}j{b.claimedByMe ? " · MINE" : ""}
+                      {claiming ? "CLAIMING…" : `CLAIM NEXT ${view.batchSize ?? 10} ▸`}
                     </button>
-                  ))}
+                  </div>
+                </div>
+                <div className="space-y-1.5">
+                  {view.batches.map((b) => {
+                    const subs = view.submissions.filter((s) => s.batchNumber === b.batchNumber);
+                    const open = openBatch === b.batchNumber;
+                    return (
+                      <div key={b.batchNumber} className={cn("border", b.claimedByMe ? "border-display" : "border-hairline")}>
+                        <div className="flex items-center gap-2 px-2 py-1.5">
+                          {!b.claimedByMe && (
+                            <input
+                              type="checkbox"
+                              aria-label={`Select batch ${b.batchNumber}`}
+                              checked={selectedBatches.has(b.batchNumber)}
+                              onChange={() => toggleSelect(b.batchNumber)}
+                              className="accent-display"
+                            />
+                          )}
+                          <button
+                            type="button"
+                            onClick={() => setOpenBatch(open ? null : b.batchNumber)}
+                            className="min-w-0 flex-1 inline-flex items-center gap-1.5 text-left"
+                          >
+                            {open ? <ChevronDown className="h-3 w-3 flex-shrink-0" /> : <ChevronRight className="h-3 w-3 flex-shrink-0" />}
+                            <span className="font-mono text-[11px] text-display">BATCH {b.batchNumber}</span>
+                            <span className="label-hw-dim">· {b.size}p</span>
+                            {b.claimedByMe && <span className="label-hw text-led">· MINE</span>}
+                          </button>
+                          <span
+                            className="label-hw-dim truncate max-w-[45%] text-right"
+                            title={b.claimedBy && b.claimedBy.length ? b.claimedBy.join(", ") : "Unclaimed"}
+                          >
+                            {b.claimCount === 0 ? "UNCLAIMED" : `WORKING: ${judgesText(b.claimedBy)}`}
+                          </span>
+                        </div>
+                        {open && (
+                          <div className="border-t border-hairline-subtle px-2 py-1.5 space-y-1">
+                            {subs.length === 0 ? (
+                              <p className="label-hw-dim">No submissions in this batch.</p>
+                            ) : (
+                              subs.map((s) => (
+                                <div key={s.id} className="flex items-center justify-between gap-2">
+                                  <span className="min-w-0 truncate font-mono text-[11px] text-body">
+                                    {s.projectTitle} <span className="label-hw-dim">· {s.submitterName}</span>
+                                  </span>
+                                  <span className="flex items-center gap-2 flex-shrink-0">
+                                    <span className="label-hw-dim" title={s.scoredBy?.join(", ")}>
+                                      {s.scoredBy && s.scoredBy.length > 0 ? `${s.scoredBy.length} SCORED` : "—"}
+                                    </span>
+                                    {canSelectWinners && (
+                                      <button
+                                        type="button"
+                                        onClick={() => deleteSub(s)}
+                                        disabled={deletingId === s.id}
+                                        title="Delete this submission (admin)"
+                                        className="label-hw-dim hover:text-destructive disabled:opacity-50"
+                                      >
+                                        {deletingId === s.id ? <Loader2 className="h-3 w-3 animate-spin" /> : <Trash2 className="h-3 w-3" />}
+                                      </button>
+                                    )}
+                                  </span>
+                                </div>
+                              ))
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
                 </div>
               </div>
             )}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -263,6 +263,8 @@ export type ApiSubmissionRow = ApiSubmission & {
   batchNumber?: number;
   /** Emails of judges who have saved a score for this submission. */
   scoredBy?: string[];
+  /** Every judge's score for this submission so far (for the live overview). */
+  scores?: Array<{ judgeEmail: string; requirements: number; techStack: number; innovation: number; total: number }>;
 };
 
 /** Coverage of one batch: how many judges claimed it + whether this judge has. */

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -261,6 +261,8 @@ export type ApiSubmissionRow = ApiSubmission & {
   myScore: ApiScore | null;
   /** Which batch (of batchSize) this submission falls in. */
   batchNumber?: number;
+  /** Emails of judges who have saved a score for this submission. */
+  scoredBy?: string[];
 };
 
 /** Coverage of one batch: how many judges claimed it + whether this judge has. */
@@ -269,6 +271,8 @@ export type ApiBatchInfo = {
   size: number;
   claimCount: number;
   claimedByMe: boolean;
+  /** Emails of judges currently working on (claimed) this batch. */
+  claimedBy?: string[];
 };
 
 export type ApiJudgeView = {
@@ -2057,6 +2061,24 @@ export const api = {
       headers: { ...adminAuthHeaders(authHeader), "Content-Type": "application/json" },
       body: JSON.stringify({ scores }),
     });
+  },
+
+  /** Admin: delete a submission (e.g. a test entry). Scores cascade. */
+  deleteSubmission: async (
+    slug: string,
+    submissionId: string,
+    authHeader: AdminAuthArg,
+  ): Promise<{ status: string }> => {
+    if (USE_MOCK_DATA) {
+      const { mockJudging } = await import("./mockJudging");
+      mockJudging.deleteSubmission?.(submissionId);
+      return { status: "success" };
+    }
+    await request(`/programs/${encodeURIComponent(slug)}/submissions/${encodeURIComponent(submissionId)}`, {
+      method: "DELETE",
+      headers: adminAuthHeaders(authHeader),
+    });
+    return { status: "success" };
   },
 
   /** Judge/admin: finalize the ballot (requires every submission scored). */

--- a/server/api/controllers/__tests__/submission.controller.test.js
+++ b/server/api/controllers/__tests__/submission.controller.test.js
@@ -16,7 +16,7 @@ vi.mock('../../repositories/program.repository.js', () => ({
   default: { setResultsPublished: vi.fn() },
 }));
 vi.mock('../../repositories/program-submission.repository.js', () => ({
-  default: { create: vi.fn(), findById: vi.fn(), findByEmail: vi.fn(), updateSubmission: vi.fn(), setPaid: vi.fn(), setPrize: vi.fn(), listByProgramId: vi.fn(), countByProgramId: vi.fn() },
+  default: { create: vi.fn(), findById: vi.fn(), findByEmail: vi.fn(), updateSubmission: vi.fn(), setPaid: vi.fn(), setPrize: vi.fn(), listByProgramId: vi.fn(), countByProgramId: vi.fn(), delete: vi.fn() },
 }));
 vi.mock('../../services/submission-confirmation.service.js', () => ({
   default: { send: vi.fn() },
@@ -587,5 +587,40 @@ describe('SubmissionController.publicResults (public)', () => {
     await submissionController.publicResults(req, res);
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({ status: 'success', data: { published: false, submissions: [] } });
+  });
+});
+
+describe('SubmissionController.deleteSubmission (admin)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('204s and deletes a submission that belongs to the program', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    submissionRepo.findById.mockResolvedValue({ id: 's1', programId: 'bitrefill', lumaEmail: 'x@y.com', projectTitle: 'T' });
+    submissionRepo.delete.mockResolvedValue();
+    const req = { params: { slug: 'bitrefill', submissionId: 's1' }, user: { address: 'admin' } };
+    const res = mockRes();
+    await submissionController.deleteSubmission(req, res);
+    expect(submissionRepo.delete).toHaveBeenCalledWith('s1');
+    expect(res.status).toHaveBeenCalledWith(204);
+  });
+
+  it('404s (no delete) when the submission belongs to a DIFFERENT program (IDOR)', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM); // id: 'bitrefill'
+    submissionRepo.findById.mockResolvedValue({ id: 'other', programId: 'another-prog' });
+    const req = { params: { slug: 'bitrefill', submissionId: 'other' }, user: { address: 'admin' } };
+    const res = mockRes();
+    await submissionController.deleteSubmission(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(submissionRepo.delete).not.toHaveBeenCalled();
+  });
+
+  it('404s when the submission does not exist', async () => {
+    programService.findBySlug.mockResolvedValue(PROGRAM);
+    submissionRepo.findById.mockResolvedValue(null);
+    const req = { params: { slug: 'bitrefill', submissionId: 'ghost' }, user: { address: 'admin' } };
+    const res = mockRes();
+    await submissionController.deleteSubmission(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(submissionRepo.delete).not.toHaveBeenCalled();
   });
 });

--- a/server/api/controllers/submission.controller.js
+++ b/server/api/controllers/submission.controller.js
@@ -221,6 +221,38 @@ class SubmissionController {
     }
   }
 
+  // Admin: hard-delete a submission (e.g. a test entry). Scores cascade.
+  // Route-gated by requireProgramAdmin. Intended for cleanup BEFORE judging —
+  // deleting after scoring starts shifts batch membership (created_at order).
+  async deleteSubmission(req, res) {
+    try {
+      const { slug, submissionId } = req.params;
+      const program = await programService.findBySlug(slug);
+      if (!program) {
+        return res.status(404).json({ status: 'error', message: 'Program not found' });
+      }
+      // Program-scope check (IDOR): a submission from program B must not be
+      // deletable via program A's slug.
+      const existing = await programSubmissionRepository.findById(submissionId);
+      if (!existing || existing.programId !== program.id) {
+        return res.status(404).json({ status: 'error', message: 'Submission not found' });
+      }
+      await programSubmissionRepository.delete(submissionId);
+      res.status(204).end();
+      auditLog.logSafe({
+        programId: program.id,
+        actor: { chain: req.user?.chain, wallet: req.user?.address, email: req.user?.email },
+        action: 'submission.delete',
+        targetType: 'submission',
+        targetId: submissionId,
+        metadata: { lumaEmail: existing.lumaEmail, projectTitle: existing.projectTitle },
+      });
+    } catch (error) {
+      console.error('❌ Error deleting submission:', error);
+      res.status(500).json({ status: 'error', message: 'Failed to delete submission' });
+    }
+  }
+
   // Judge/admin: upsert this judge's score for one submission (draft save).
   async upsertScore(req, res) {
     try {

--- a/server/api/repositories/program-submission.repository.js
+++ b/server/api/repositories/program-submission.repository.js
@@ -206,6 +206,12 @@ class ProgramSubmissionRepository {
     if (error) throw error;
     return count ?? 0;
   }
+
+  // Hard-delete a submission. submission_scores rows cascade (ON DELETE CASCADE).
+  async delete(id) {
+    const { error } = await supabase.from('program_submissions').delete().eq('id', id);
+    if (error) throw error;
+  }
 }
 
 export default new ProgramSubmissionRepository();

--- a/server/api/repositories/submission-score.repository.js
+++ b/server/api/repositories/submission-score.repository.js
@@ -10,9 +10,11 @@ const transform = (row) => {
     submissionId: row.submission_id,
     programId: row.program_id,
     judgeEmail: row.judge_email,
-    requirements: row.requirements_score,
-    techStack: row.tech_stack_score,
-    innovation: row.innovation_score,
+    // NUMERIC columns come back from PostgREST as strings ("4.3"); coerce so all
+    // score arithmetic (totals, averages) stays numeric, not string-concat.
+    requirements: Number(row.requirements_score),
+    techStack: Number(row.tech_stack_score),
+    innovation: Number(row.innovation_score),
     notes: row.notes,
     createdAt: row.created_at,
     updatedAt: row.updated_at,

--- a/server/api/routes/program.routes.js
+++ b/server/api/routes/program.routes.js
@@ -180,6 +180,12 @@ router.post('/:slug/submissions', submissionLimiter, submissionController.submit
 router.get('/:slug/submissions', requireProgramJudge('slug'), submissionController.list);
 // Download all submissions + their feedback survey as CSV (judge/admin).
 router.get('/:slug/submissions.csv', requireProgramJudge('slug'), submissionController.exportCsv);
+// Admin-only: delete a submission (e.g. a test entry). Judges (requireProgramJudge) cannot.
+router.delete(
+  '/:slug/submissions/:submissionId',
+  requireProgramAdmin('slug'),
+  submissionController.deleteSubmission,
+);
 router.put(
   '/:slug/submissions/:submissionId/score',
   requireProgramJudge('slug'),

--- a/server/api/services/scoring.service.js
+++ b/server/api/services/scoring.service.js
@@ -28,7 +28,7 @@ class ScoringService {
   // `eligible` is advisory: a submission whose email isn't in program_signups is
   // flagged but still scoreable.
   async listForJudge(programId, judgeEmail) {
-    const [submissions, myScores, signupEmails, registeredJudges, submittedBallots, ballot, myBatches, allClaims] =
+    const [submissions, myScores, signupEmails, registeredJudges, submittedBallots, ballot, myBatches, allClaims, allScores] =
       await Promise.all([
         programSubmissionRepository.listByProgramId(programId),
         submissionScoreRepository.listByJudge(programId, judgeEmail),
@@ -38,6 +38,7 @@ class ScoringService {
         programJudgeBallotRepository.find(programId, judgeEmail),
         programJudgeBatchRepository.listByJudge(programId, judgeEmail),
         programJudgeBatchRepository.listByProgram(programId),
+        submissionScoreRepository.listByProgramId(programId),
       ]);
 
     // listEmailsByProgramId returns a Set of raw signup emails; lowercase for a
@@ -60,17 +61,30 @@ class ScoringService {
     // Batch coverage overview: how many judges have claimed each batch + whether
     // this judge has. Lets the panel show "Claim next 10" and per-batch coverage.
     const claimedSet = new Set(myBatches);
-    const claimCounts = new Map();
-    for (const c of allClaims) claimCounts.set(c.batchNumber, (claimCounts.get(c.batchNumber) || 0) + 1);
+    // Who has claimed each batch (judges shown as "working on" it) and who has
+    // saved a score for each submission. Both additive — the write path is
+    // unchanged.
+    const claimedByBatch = new Map();
+    for (const c of allClaims) {
+      if (!claimedByBatch.has(c.batchNumber)) claimedByBatch.set(c.batchNumber, []);
+      claimedByBatch.get(c.batchNumber).push(c.judgeEmail);
+    }
+    const scoredBySubmission = new Map();
+    for (const sc of allScores) {
+      if (!scoredBySubmission.has(sc.submissionId)) scoredBySubmission.set(sc.submissionId, []);
+      scoredBySubmission.get(sc.submissionId).push(sc.judgeEmail);
+    }
     const count = batchCountFor(submissions.length);
     const batches = [];
     for (let n = 1; n <= count; n += 1) {
       const start = (n - 1) * BATCH_SIZE;
+      const claimedBy = claimedByBatch.get(n) || [];
       batches.push({
         batchNumber: n,
         size: Math.min(BATCH_SIZE, submissions.length - start),
-        claimCount: claimCounts.get(n) || 0,
+        claimCount: claimedBy.length,
         claimedByMe: claimedSet.has(n),
+        claimedBy,
       });
     }
 
@@ -86,6 +100,7 @@ class ScoringService {
         eligible: eligibleSet.has(normalizeEmail(s.lumaEmail)),
         myScore: scoreBySubmission.get(s.id) || null,
         batchNumber: byBatch.get(s.id),
+        scoredBy: scoredBySubmission.get(s.id) || [],
       })),
     };
   }

--- a/server/api/services/scoring.service.js
+++ b/server/api/services/scoring.service.js
@@ -70,9 +70,18 @@ class ScoringService {
       claimedByBatch.get(c.batchNumber).push(c.judgeEmail);
     }
     const scoredBySubmission = new Map();
+    const scoresBySubmission = new Map();
     for (const sc of allScores) {
       if (!scoredBySubmission.has(sc.submissionId)) scoredBySubmission.set(sc.submissionId, []);
       scoredBySubmission.get(sc.submissionId).push(sc.judgeEmail);
+      if (!scoresBySubmission.has(sc.submissionId)) scoresBySubmission.set(sc.submissionId, []);
+      scoresBySubmission.get(sc.submissionId).push({
+        judgeEmail: sc.judgeEmail,
+        requirements: sc.requirements,
+        techStack: sc.techStack,
+        innovation: sc.innovation,
+        total: Math.round((sc.requirements + sc.techStack + sc.innovation) * 10) / 10,
+      });
     }
     const count = batchCountFor(submissions.length);
     const batches = [];
@@ -101,6 +110,7 @@ class ScoringService {
         myScore: scoreBySubmission.get(s.id) || null,
         batchNumber: byBatch.get(s.id),
         scoredBy: scoredBySubmission.get(s.id) || [],
+        scores: scoresBySubmission.get(s.id) || [],
       })),
     };
   }

--- a/server/api/utils/__tests__/submission.validator.test.js
+++ b/server/api/utils/__tests__/submission.validator.test.js
@@ -179,9 +179,18 @@ describe('validateScore', () => {
     expect(validateScore({ requirements: 2, techStack: 5, innovation: -1 }).ok).toBe(false);
   });
 
-  it('rejects non-integer values', () => {
-    expect(validateScore({ requirements: 1.5, techStack: 5, innovation: 5 }).ok).toBe(false);
+  it('accepts in-range decimal scores, rounded to 1 decimal place', () => {
+    const r = validateScore({ requirements: 1.5, techStack: 4.3, innovation: 5 });
+    expect(r.ok).toBe(true);
+    expect(r.value).toMatchObject({ requirements: 1.5, techStack: 4.3, innovation: 5 });
+    // 4.34 rounds to 4.3 (matches NUMERIC(3,1) storage)
+    expect(validateScore({ requirements: 0, techStack: 4.34, innovation: 0 }).value.techStack).toBe(4.3);
+  });
+
+  it('rejects non-numeric values', () => {
     expect(validateScore({ requirements: '2', techStack: 5, innovation: 5 }).ok).toBe(false);
+    expect(validateScore({ requirements: NaN, techStack: 5, innovation: 5 }).ok).toBe(false);
+    expect(validateScore({ techStack: 5, innovation: 5 }).ok).toBe(false); // missing requirements
   });
 
   it('rejects overly long notes', () => {

--- a/server/api/utils/submission.validator.js
+++ b/server/api/utils/submission.validator.js
@@ -181,20 +181,26 @@ export const SCORE_BOUNDS = {
 export const MAX_TOTAL_SCORE =
   SCORE_BOUNDS.requirements.max + SCORE_BOUNDS.techStack.max + SCORE_BOUNDS.innovation.max;
 
-const isIntInRange = (v, { min, max }) =>
-  typeof v === 'number' && Number.isInteger(v) && v >= min && v <= max;
+const isNumInRange = (v, { min, max }) =>
+  typeof v === 'number' && Number.isFinite(v) && v >= min && v <= max;
+
+// Scores accept one decimal place (e.g. 4.3). Round half-up to 1dp so the
+// validator and the NUMERIC(3,1) column agree on the stored value.
+const roundTo1dp = (v) => Math.round(v * 10) / 10;
 
 export function validateScore(body = {}) {
-  const { requirements, techStack, innovation } = body;
-  for (const [key, value] of Object.entries({ requirements, techStack, innovation })) {
-    if (!isIntInRange(value, SCORE_BOUNDS[key])) {
+  const out = {};
+  for (const key of ['requirements', 'techStack', 'innovation']) {
+    const value = body[key];
+    if (!isNumInRange(value, SCORE_BOUNDS[key])) {
       const { min, max } = SCORE_BOUNDS[key];
-      return { ok: false, error: `${key} must be an integer between ${min} and ${max}` };
+      return { ok: false, error: `${key} must be a number between ${min} and ${max}` };
     }
+    out[key] = roundTo1dp(value);
   }
   const notes = typeof body.notes === 'string' ? body.notes.trim() : '';
   if (notes.length > 5000) {
     return { ok: false, error: 'Notes must be 5000 characters or fewer' };
   }
-  return { ok: true, value: { requirements, techStack, innovation, notes } };
+  return { ok: true, value: { ...out, notes } };
 }

--- a/supabase/migrations/20260617000000_submission_scores_decimal.sql
+++ b/supabase/migrations/20260617000000_submission_scores_decimal.sql
@@ -1,0 +1,14 @@
+-- Allow decimal judge scores (e.g. 4.3/5).
+--
+-- Widen the three score columns from INTEGER to NUMERIC(3,1) (one decimal place).
+-- This is non-destructive and backward-compatible: existing integer scores are
+-- preserved (5 -> 5.0), the BETWEEN range CHECK constraints stay valid for
+-- numerics, and the previously-deployed integer-only code keeps writing fine.
+-- Safe to run while the old build is still serving.
+--
+-- Idempotent-ish: re-running ALTER TYPE to the same type is a cheap no-op.
+
+ALTER TABLE submission_scores
+  ALTER COLUMN requirements_score TYPE NUMERIC(3,1),
+  ALTER COLUMN tech_stack_score   TYPE NUMERIC(3,1),
+  ALTER COLUMN innovation_score   TYPE NUMERIC(3,1);


### PR DESCRIPTION
Bundles the judging-batch UX, decimal scores, and an admin delete. **Built to not disrupt live judging** — server changes are additive and the scoring write-path + ballot gate are untouched.

## What's new
**Batch overview** (replaces the flat batch chips)
- Expand any batch to **preview its submissions** (title + submitter) before claiming.
- See **who's working on each batch** (`claimedBy` judges) + a `· MINE` marker.
- **Multi-select** unclaimed batches → **Claim selected (N)**; "Claim next 10" stays.
- Per submission, shows **which judges have saved a score** (`scoredBy`), in the overview and on the scoring card.

**Decimal scores (e.g. 4.3/5)**
- Migration widens the 3 score columns `INTEGER → NUMERIC(3,1)` — non-destructive, existing scores preserved (`5 → 5.0`), `CHECK` ranges still valid, and **backward-compatible** (old build keeps writing integers fine, so the migration can run first).
- Validator accepts 1 decimal place (rounds to match storage); inputs use `step="0.1"`.

**Admin delete submission** (for test entries)
- `DELETE /:slug/submissions/:submissionId` (`requireProgramAdmin`, IDOR-guarded, scores cascade) + a trash button (admin-only) in the batch overview and scoring card. Reloads after delete so batch membership stays correct.

## Safety
- Additive server fields (`claimedBy`, `scoredBy`); claim/score/ballot logic unchanged.
- **438 server tests** pass (decimal validator, claimedBy/scoredBy, delete authorized/IDOR/not-found); client build + lint clean.
- Two judges can already score the same batch concurrently (claims aren't exclusive; scores are per-judge-unique) — now they *see* each other working on it.

## Rollout (live-safe)
1. Run migration `20260617000000_submission_scores_decimal.sql` — backward-compatible, can go anytime.
2. Deploy code during a scoring lull (scoring hasn't started yet, so low risk now).
3. Delete-after-scoring shifts batch membership — intended for **pre-scoring** cleanup (noted in the confirm + code).
