### PR TITLE
fix(results-panel): guard Recharts 0-width canvas crash on admin panel open

### DIFF
--- a/client/src/components/admin/ProgramResultsSummarySection.tsx
+++ b/client/src/components/admin/ProgramResultsSummarySection.tsx
@@ -163,9 +163,11 @@ function FeedbackChart({
   const maxVal = Math.max(...data.map((d) => d.value));
 
   return (
-    <div className="min-w-0">
+    // min-w-[1px] + debounce prevents Recharts creating a 0-dim canvas pattern
+    // when the admin panel first opens (layout still in flight).
+    <div className="min-w-0" style={{ minWidth: 1 }}>
       <div className="label-hw-dim mb-1">{title.toUpperCase()}</div>
-      <ResponsiveContainer width="100%" height={data.length * 28 + 10}>
+      <ResponsiveContainer width="100%" height={data.length * 28 + 10} debounce={50}>
         <BarChart
           data={data}
           layout="vertical"


### PR DESCRIPTION
## Summary

- Adds `debounce={50}` to `ResponsiveContainer` in `FeedbackChart`
- Adds `style={{ minWidth: 1 }}` to the container div

## Root cause

Recharts fires its first `ResizeObserver` measurement synchronously on mount, before the admin panel layout has settled. When the wallet unlocks and the admin section expands, the chart container is still in a CSS transition and reports width=0. Recharts then tries to create a Canvas gradient pattern on a 0×0 canvas, throwing `InvalidStateError: Failed to execute 'createPattern' on 'CanvasRenderingContext2D': The image argument is a canvas element with a width or height of 0`.

`debounce={50}` defers the first measurement by 50ms, giving the layout time to settle. `minWidth: 1` is a belt-and-suspenders guard so Recharts never receives a literal 0 even if the debounce doesn't fire in time.

## Why it didn't catch in testing

- The `stadium-tester` runs in mock mode where the admin panel is immediately visible (no layout transition) — the chart always gets a non-zero width on first render
- The `consoleErrors` gate in the test spec catches errors that appear during test steps, but the Canvas error fires during mount before the wallet-unlock action completes, so it doesn't fail a specific `expect()`
- No post-deploy smoke test runs against production after Railway swaps containers

## Companion CORS error

The console also showed a CORS block on `GET /api/programs/bitrefill-2026`. That was transient — the Railway container swap caused a brief gap between old container going down and new container serving. Server is healthy; `stadium.joinwebzero.com` is explicitly in the CORS allowlist. No code change needed.

## Test plan
- [ ] Unlock admin panel on bitrefill-2026 in production, open the completed program → feedback charts render without console errors
- [ ] `cd client && npm run build` — passes