### PR TITLE
fix(results-panel): guard Recharts 0-width canvas crash on admin panel open

### DIFF
--- a/client/src/components/admin/ProgramResultsSummarySection.tsx
+++ b/client/src/components/admin/ProgramResultsSummarySection.tsx
@@ -163,9 +163,11 @@ function FeedbackChart({
   const maxVal = Math.max(...data.map((d) => d.value));
 
   return (
-    <div className="min-w-0">
+    // min-w-[1px] + debounce prevents Recharts creating a 0-dim canvas pattern
+    // when the admin panel first opens (layout still in flight).
+    <div className="min-w-0" style={{ minWidth: 1 }}>
       <div className="label-hw-dim mb-1">{title.toUpperCase()}</div>
-      <ResponsiveContainer width="100%" height={data.length * 28 + 10}>
+      <ResponsiveContainer width="100%" height={data.length * 28 + 10} debounce={50}>
         <BarChart
           data={data}
           layout="vertical"


### PR DESCRIPTION
## Summary

- Adds `debounce={50}` and `style={{ minWidth: 1 }}` to `ResponsiveContainer` in `FeedbackChart` inside `ProgramResultsSummarySection`

## Root cause

When the admin wallet unlocks and the completed-program results panel expands, the CSS layout transition means `ResponsiveContainer` fires its first `ResizeObserver` tick with `width=0`. Recharts then attempts to create a Canvas gradient pattern on a 0×0 canvas:

```
Uncaught InvalidStateError: Failed to execute 'createPattern' on
'CanvasRenderingContext2D': The image argument is a canvas element
with a width or height of 0.
```

`debounce={50}` defers the first measurement by 50ms so the layout settles first. `minWidth: 1` is a belt-and-suspenders guard.

## Why it didn't catch in testing

- `stadium-tester` runs in mock mode — admin panel is already visible before data loads, no layout transition, chart always gets non-zero width on first render
- Console error gate in the Playwright spec only fails when an `expect()` assertion fails; this error fires during mount, not tied to any UI state assertion
- No post-deploy smoke test catches JS exceptions on the production build

## Companion CORS error (no code change needed)

The console also showed `No 'Access-Control-Allow-Origin' header` on `GET /api/programs/bitrefill-2026`. That was a transient Railway container-swap gap during deploy — old container down before new one was serving. Server is healthy; `stadium.joinwebzero.com` is in the explicit CORS allowlist.

## Test plan
- [ ] Unlock admin wallet on bitrefill-2026 in production, open the completed program → feedback charts render with no console errors
- [ ] `cd client && npm run build` passes ✓ (verified pre-PR)

Fixes prod regression introduced by #195.